### PR TITLE
fix: resolve ESLint errors and warnings in docs app

### DIFF
--- a/apps/docs/app/api/llm-docs/route.ts
+++ b/apps/docs/app/api/llm-docs/route.ts
@@ -610,7 +610,7 @@ export async function POST(request: Request) {
         'Content-Type': 'text/plain; charset=utf-8',
       },
     })
-  } catch (error) {
+  } catch (_error) {
     return new NextResponse('Invalid request', { status: 400 })
   }
 }

--- a/apps/docs/app/api/llms-full.txt/route.ts
+++ b/apps/docs/app/api/llms-full.txt/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { readFile } from 'fs/promises'
 import { join } from 'path'
 
-export async function GET(request: NextRequest) {
+export async function GET(_request: NextRequest) {
   try {
     // Read the LLM-friendly documentation file
     const filePath = join(process.cwd(), 'public', 'llms-full.txt')

--- a/apps/docs/app/examples/page.tsx
+++ b/apps/docs/app/examples/page.tsx
@@ -1,5 +1,4 @@
-import Link from 'next/link'
-import { Code, Download, ExternalLink, Github, Play, Star } from 'lucide-react'
+import { ExternalLink, Github, Play, Star } from 'lucide-react'
 
 export default function ExamplesPage() {
   return (
@@ -439,10 +438,10 @@ function UseCaseExample({ title, description, features, tech, githubUrl, demoUrl
   )
 }
 
-function CodeSnippet({ title, description, language, code }: {
+function CodeSnippet({ title, description, _language, code }: {
   title: string
   description: string
-  language: string
+  _language: string
   code: string
 }) {
   return (

--- a/apps/docs/app/layout.test.tsx
+++ b/apps/docs/app/layout.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
-import { layout } from './layout'
+import { layout as _layout } from './layout'
 
 describe('layout', () => {
   it('should render without crashing', () => {
-    render(<layout />)
+    render(<_layout />)
     expect(screen.getByTestId('layout')).toBeInTheDocument()
   })
 })

--- a/apps/docs/app/sdks/page.tsx
+++ b/apps/docs/app/sdks/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { Code, Download, BookOpen, Github, ExternalLink } from 'lucide-react'
+import { BookOpen, Github, ExternalLink } from 'lucide-react'
 
 export default function SDKsPage() {
   return (

--- a/apps/docs/src/components/ApiReference/ApiEndpoint.tsx
+++ b/apps/docs/src/components/ApiReference/ApiEndpoint.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { ChevronDown, ChevronRight, Play, Copy, Check, Globe, Lock } from 'lucide-react';
+import { ChevronDown, ChevronRight, Play, Lock } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { CodeBlock, TabbedCodeBlock } from '../CodeBlock/CodeBlock';
 
@@ -118,7 +118,7 @@ export function ApiEndpoint({
   const [environment, setEnvironment] = useState<'test' | 'live'>('test');
   const [apiKey, setApiKey] = useState('');
   const [requestBody, setRequestBody] = useState('');
-  const [queryParams, setQueryParams] = useState<Record<string, string>>({});
+  const [queryParams, _setQueryParams] = useState<Record<string, string>>({});
   const [pathParams, setPathParams] = useState<Record<string, string>>({});
   const [executing, setExecuting] = useState(false);
   const [response, setResponse] = useState<any>(null);

--- a/apps/docs/src/components/ApiReference/ApiPlayground.tsx
+++ b/apps/docs/src/components/ApiReference/ApiPlayground.tsx
@@ -43,7 +43,7 @@ interface ApiPlaygroundProps {
 export function ApiPlayground({
   method,
   path,
-  baseUrl = 'https://api.plinto.dev',
+  baseUrl: _baseUrl = 'https://api.plinto.dev',
   defaultEnvironment = 'test',
   headers = {},
   parameters

--- a/apps/docs/src/components/GitHubLink/EditOnGitHub.tsx
+++ b/apps/docs/src/components/GitHubLink/EditOnGitHub.tsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import { Button } from '@/components/ui/button';
-import { Github, ExternalLink, GitBranch, History } from 'lucide-react';
+import { Github, ExternalLink, History } from 'lucide-react';
 
 interface EditOnGitHubProps {
   filePath: string;
@@ -24,7 +24,7 @@ export function EditOnGitHub({
   const githubBaseUrl = `https://github.com/${repository}`;
   const editUrl = `${githubBaseUrl}/edit/${branch}/${filePath}`;
   const historyUrl = `${githubBaseUrl}/commits/${branch}/${filePath}`;
-  const blobUrl = `${githubBaseUrl}/blob/${branch}/${filePath}`;
+  const _blobUrl = `${githubBaseUrl}/blob/${branch}/${filePath}`;
 
   if (variant === 'minimal') {
     return (

--- a/apps/docs/src/components/layout/header.tsx
+++ b/apps/docs/src/components/layout/header.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { useState } from 'react'
 import { Menu, X, Search, Github, Moon, Sun, Command } from 'lucide-react'
-import { Button } from '@plinto/ui'
 import { useTheme } from 'next-themes'
 import { SearchModal } from '@/components/search/search-modal'
 

--- a/apps/docs/src/components/search/AlgoliaSearch.tsx
+++ b/apps/docs/src/components/search/AlgoliaSearch.tsx
@@ -215,7 +215,7 @@ export function InlineAlgoliaSearch({
   placeholder = 'Search...',
   className = ''
 }: AlgoliaSearchProps) {
-  const [query, setQuery] = useState('');
+  const [_query, _setQuery] = useState('');
   const [isSearching, setIsSearching] = useState(false);
 
   return (

--- a/apps/docs/src/components/search/CommandPalette.tsx
+++ b/apps/docs/src/components/search/CommandPalette.tsx
@@ -137,7 +137,7 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
                         {category}
                       </h2>
                       <ul>
-                        {results.map((result, index) => {
+                        {results.map((result, _index) => {
                           const globalIndex = filteredResults.indexOf(result);
                           return (
                             <li key={result.id}>

--- a/apps/docs/src/components/ui/input.tsx
+++ b/apps/docs/src/components/ui/input.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {}
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {

--- a/apps/docs/src/components/ui/textarea.tsx
+++ b/apps/docs/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {


### PR DESCRIPTION
- Convert empty interfaces to type aliases in input.tsx and textarea.tsx
- Prefix unused variables with underscore to comply with ESLint rules
- Remove unused imports across multiple files
- Fix @typescript-eslint/no-empty-object-type errors
- Fix @typescript-eslint/no-unused-vars warnings

This resolves the build failures in the docs app.