### PR TITLE
chore: replace all MIT license references with AGPL v3

### DIFF
--- a/.serena/memories/phase_3_critical_findings.md
+++ b/.serena/memories/phase_3_critical_findings.md
@@ -93,7 +93,7 @@ Lines 622-626 - Same GitHub repository URL issue
 
 ### Package Metadata
 - ✅ All SDKs at version 0.1.0-beta.1
-- ✅ All have MIT license
+- ✅ All have AGPL v3 license
 - ✅ All have proper keywords
 - ✅ All have publishConfig.access: "public"
 - ✅ All have correct main/module/types entries

--- a/.serena/memories/phase_3_validation_plan.md
+++ b/.serena/memories/phase_3_validation_plan.md
@@ -54,7 +54,7 @@
 2. ✅ Vue SDK package name - Renamed from @janua/vue to @janua/vue-sdk
 3. ✅ **React SDK TypeScript definitions** - Fixed 6 code errors, types now generated successfully
 4. ✅ README repository links - Fixed in typescript-sdk and react-sdk
-5. ✅ Next.js LICENSE file - MIT license added
+5. ✅ Next.js LICENSE file - AGPL v3 license added
 
 ### React SDK TypeScript Fix (COMPLETED)
 **Files Fixed**: 

--- a/.serena/memories/week1_sdk_build_completion.md
+++ b/.serena/memories/week1_sdk_build_completion.md
@@ -17,7 +17,7 @@
 
 ### 2. Python SDK Build System ✅
 **Modernized pyproject.toml**:
-- Changed license from table to SPDX string `"MIT"`
+- Changed license from table to SPDX string `"AGPL-3.0"`
 - Removed deprecated license classifier
 - Fixed setuptools deprecation warnings
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 **Open-source authentication for developers who want to own their auth infrastructure.**
 
-MIT licensed. No features locked behind paid tiers. No SaaS required.
+AGPL v3 licensed. No features locked behind paid tiers. No SaaS required.
 
-[![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/Python-3.11+-3776AB.svg)](https://python.org)
 [![FastAPI](https://img.shields.io/badge/FastAPI-0.104+-009688.svg)](https://fastapi.tiangolo.com)
 
@@ -42,7 +42,7 @@ A self-hosted authentication platform built with FastAPI and modern web technolo
 
 **Our take:** Authentication features shouldn't cost enterprise prices. Self-hosting shouldn't mean suffering through Keycloak's Java-era UI.
 
-So we built this. All features are free and open source. MIT licensed.
+So we built this. All features are free and open source. AGPL v3 licensed.
 
 ---
 
@@ -366,7 +366,7 @@ See [LICENSE](LICENSE) for details.
 - **Stars:** Just getting started (star us if you find this useful!)
 - **Production users:** Unknown (tell us if you're using it!)
 - **Contributors:** Looking for more
-- **Funding:** None (bootstrapped, MIT licensed)
+- **Funding:** None (bootstrapped, AGPL v3 licensed)
 
 **We're building this in public.** The good, the bad, and the bugs.
 

--- a/apps/api/app/__init__.py
+++ b/apps/api/app/__init__.py
@@ -8,7 +8,7 @@ and enterprise security features for modern applications.
 __version__ = "0.1.0-beta.1"
 __author__ = "Janua Team"
 __email__ = "team@janua.dev"
-__license__ = "MIT"
+__license__ = "AGPL-3.0"
 __url__ = "https://janua.dev"
 
 # Core API exports for package consumers

--- a/apps/api/docs/project-docs/TYPESCRIPT_SDK_IMPLEMENTATION.md
+++ b/apps/api/docs/project-docs/TYPESCRIPT_SDK_IMPLEMENTATION.md
@@ -108,7 +108,7 @@ sdks/typescript/
 ├── tsconfig.json                 # TypeScript configuration
 ├── README.md                     # Comprehensive documentation
 ├── CHANGELOG.md                  # Version history
-├── LICENSE                       # MIT license
+├── LICENSE                       # AGPL v3 license
 └── .github/workflows/ci.yml      # CI/CD pipeline
 ```
 

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -7,7 +7,7 @@ name = "janua"
 dynamic = ["version"]
 description = "Enterprise-grade authentication and user management platform"
 readme = "README.md"
-license = {text = "MIT"}
+license = {text = "AGPL-3.0"}
 authors = [
     {name = "Janua Team", email = "team@janua.dev"},
 ]

--- a/apps/api/sdks/typescript/README.md
+++ b/apps/api/sdks/typescript/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/@janua%2Ftypescript-sdk.svg)](https://badge.fury.io/js/@janua%2Ftypescript-sdk)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.2+-blue.svg)](https://www.typescriptlang.org/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
 Official TypeScript SDK for [Janua](https://janua.dev) - Enterprise-grade authentication and user management platform.
 

--- a/docs/BETA_ONBOARDING_GUIDE.md
+++ b/docs/BETA_ONBOARDING_GUIDE.md
@@ -428,7 +428,7 @@ Please share feedback on:
 ### Post-Beta Pricing (Locked for Beta Users)
 - **Starter**: $0.005/MAU (vs $0.02 for Clerk)
 - **Pro**: Custom enterprise pricing
-- **Self-Hosted**: Free (MIT license)
+- **Self-Hosted**: Free (AGPL v3 license)
 
 Beta users get 12 months at beta pricing.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -467,7 +467,7 @@ This roadmap prioritizes features and improvements based on competitive differen
 ## 🎯 Strategic Priorities
 
 ### Must-Have (Non-Negotiable)
-1. **100% features free in OSS** (MIT license, no gates)
+1. **100% features free in OSS** (AGPL v3 license, no gates)
 2. **Anti-lock-in guarantee** (migration path documented)
 3. **Synchronous database writes** (no webhook sync)
 4. **Production-ready quality** (comprehensive testing, documentation)

--- a/docs/archive/2025-11/session-notes/strategic-positioning-session-summary-2025-11-16.md
+++ b/docs/archive/2025-11/session-notes/strategic-positioning-session-summary-2025-11-16.md
@@ -93,7 +93,7 @@ This session focused on validating and correcting Janua's "blue-ocean" market po
 - ✅ MFA - ALL TYPES (TOTP, SMS, WebAuthn/Passkeys, backup codes)
 - ✅ Multi-Tenancy (unlimited organizations, RBAC, custom roles)
 - ✅ Enterprise SSO (SAML 2.0, OIDC)
-- ✅ Self-hosting (MIT license, Docker, K8s)
+- ✅ Self-hosting (AGPL v3 license, Docker, K8s)
 
 ### 💼 Professional (Managed Cloud) - $99/mo
 - Everything in Community +

--- a/docs/business/MARKETING_CLAIMS_CORRECTIONS.md
+++ b/docs/business/MARKETING_CLAIMS_CORRECTIONS.md
@@ -42,7 +42,7 @@ Paid tiers provide managed hosting, enterprise support, compliance, and scale.
 - ✅ Multi-Tenancy (unlimited organizations, RBAC, custom roles)
 - ✅ Enterprise SSO (SAML 2.0, OIDC)
 - ✅ Unlimited webhooks, API keys, developer tools
-- ✅ Self-hosting (MIT license, Docker, K8s)
+- ✅ Self-hosting (AGPL v3 license, Docker, K8s)
 
 ### 💼 Professional (Managed Cloud) - $99/mo
 - Everything in Community +

--- a/docs/guides/LOCAL_DEMO_GUIDE.md
+++ b/docs/guides/LOCAL_DEMO_GUIDE.md
@@ -518,7 +518,7 @@ Use this script to demonstrate Janua's capabilities:
 **Talking Points**:
 - "These features cost $2,000-5,000/month in Auth0"
 - "Clerk charges $1,000+/month for SSO"
-- "In Janua? Free forever in our MIT-licensed OSS"
+- "In Janua? Free forever in our AGPL v3-licensed OSS"
 - "We charge for managed hosting convenience, not capabilities"
 
 ### Minute 11-13: Migration Path (Anti-Lock-In)

--- a/docs/internal/claude-sessions/implementation-reports/strategic-market-positioning-audit-nov17-2025.md
+++ b/docs/internal/claude-sessions/implementation-reports/strategic-market-positioning-audit-nov17-2025.md
@@ -1092,7 +1092,7 @@ Janua successfully delivers on its blue-ocean market positioning:
 1. **Only OSS authentication with free enterprise SSO and SCIM 2.0**
    - Auth0: $24,000-60,000/year
    - Clerk: $12,000+/year
-   - Janua: $0/year (MIT license)
+   - Janua: $0/year (AGPL v3 license)
 
 2. **Better-Auth control + Clerk DX**
    - Unique combination in market

--- a/docs/internal/reports/PACKAGE_PUBLISHABILITY_ASSESSMENT.md
+++ b/docs/internal/reports/PACKAGE_PUBLISHABILITY_ASSESSMENT.md
@@ -48,7 +48,7 @@
 - **Complete exports**: ESM/CJS dual builds
 - **Type definitions**: Full TypeScript support
 - **Peer dependencies**: Proper framework integration
-- **License**: MIT (developer-friendly)
+- **License**: AGPL v3 (copyleft open source)
 
 #### ✅ **Documentation Quality**:
 - Comprehensive READMEs with examples

--- a/docs/internal/reports/packages-remediation-strategy.md
+++ b/docs/internal/reports/packages-remediation-strategy.md
@@ -872,7 +872,7 @@ Use the standard template from `scripts/readme-template.md`
   },
   "keywords": ["janua", "relevant", "keywords"],
   "author": "Janua Team",
-  "license": "MIT"
+  "license": "AGPL-3.0"
 }
 ```
 

--- a/docs/reference/openapi.yaml
+++ b/docs/reference/openapi.yaml
@@ -21,8 +21,8 @@ info:
     email: support@janua.dev
     url: https://docs.janua.dev
   license:
-    name: MIT
-    url: https://opensource.org/licenses/MIT
+    name: AGPL-3.0
+    url: https://www.gnu.org/licenses/agpl-3.0
 
 servers:
   - url: https://api.janua.dev

--- a/examples/nextjs-app/README.md
+++ b/examples/nextjs-app/README.md
@@ -238,4 +238,4 @@ npm run test:e2e
 
 ## License
 
-MIT - See [LICENSE](../../LICENSE) for details
+AGPL-3.0 - See [LICENSE](../../LICENSE) for details

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0b1"
 description = "Python SDK for Janua Authentication Platform"
 readme = "README.md"
 requires-python = ">=3.8"
-license = "MIT"
+license = "AGPL-3.0"
 authors = [
     {name = "Janua Team", email = "support@janua.dev"},
 ]

--- a/packages/typescript-sdk/README.md
+++ b/packages/typescript-sdk/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/@janua/typescript-sdk.svg)](https://www.npmjs.com/package/@janua/typescript-sdk)
 [![TypeScript](https://img.shields.io/badge/TypeScript-Ready-blue.svg)](https://www.typescriptlang.org)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
 Official TypeScript/JavaScript SDK for the Janua authentication API. This SDK provides a complete interface for user authentication, organization management, webhooks, and administrative operations.
 

--- a/packages/ui/AUTH_COMPONENTS.md
+++ b/packages/ui/AUTH_COMPONENTS.md
@@ -824,7 +824,7 @@ function VerifyPhonePage() {
 ## 📦 Package Info
 
 **Current Version:** 1.0.0
-**License:** MIT
+**License:** AGPL-3.0
 **Bundle Size:** ~45KB (gzipped)
 
 ## 🤝 Contributing
@@ -833,4 +833,4 @@ We welcome contributions! Please see our contributing guidelines for more inform
 
 ## 📄 License
 
-MIT © Janua
+AGPL-3.0 © Janua

--- a/tests/e2e/validation/content-validator.spec.ts
+++ b/tests/e2e/validation/content-validator.spec.ts
@@ -23,7 +23,7 @@ test.describe('Content Validation', () => {
     // Check trust indicators
     const trustIndicators = await page.locator('.text-3xl.font-bold.text-primary-600').allTextContents();
     
-    // "100% Open Source" - verify repo is public and MIT licensed
+    // "100% Open Source" - verify repo is public and AGPL v3 licensed
     expect(trustIndicators).toContain('100%');
     
     // "6 SDKs" - verify we have exactly 6 SDKs


### PR DESCRIPTION
Updated license references across the entire codebase to accurately reflect the AGPL-3.0 license. This ensures consistency in all documentation, package metadata, and code files.

Changes:
- Updated README.md with AGPL v3 badges and references
- Updated all documentation files with MIT references
- Updated package metadata in pyproject.toml files
- Updated OpenAPI specification license field
- Updated SDK README files and badges
- Updated test file comments
- Updated UI component documentation
- Updated internal documentation and reports

This change affects documentation and metadata only, with no changes to actual functionality.