### PR TITLE
security: fix CVE-2025-29927 - upgrade Next.js to 14.2.25

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -30,7 +30,7 @@
     "clsx": "^2.1.0",
     "date-fns": "^3.0.0",
     "lucide-react": "^0.303.0",
-    "next": "14.0.4",
+    "next": "14.2.25",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.48.0",
@@ -45,7 +45,7 @@
     "@types/react-dom": "^18.2.0",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.56.0",
-    "eslint-config-next": "14.0.4",
+    "eslint-config-next": "14.2.25",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.3.0"

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -29,7 +29,7 @@
     "clsx": "^2.1.0",
     "date-fns": "^3.0.0",
     "lucide-react": "^0.303.0",
-    "next": "14.0.4",
+    "next": "14.2.25",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.48.0",
@@ -44,7 +44,7 @@
     "@types/react-dom": "^18.2.0",
     "autoprefixer": "^10.4.16",
     "eslint": "^8.56.0",
-    "eslint-config-next": "14.0.4",
+    "eslint-config-next": "14.2.25",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.3.0"

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -20,7 +20,7 @@
     "framer-motion": "^10.16.0",
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.294.0",
-    "next": "14.0.4",
+    "next": "14.2.25",
     "next-mdx-remote": "^4.4.1",
     "next-themes": "^0.2.1",
     "prismjs": "^1.29.0",
@@ -41,7 +41,7 @@
     "@types/react-dom": "^18",
     "autoprefixer": "^10.0.1",
     "eslint": "^8",
-    "eslint-config-next": "14.0.4",
+    "eslint-config-next": "14.2.25",
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
     "typescript": "^5.3.0"


### PR DESCRIPTION
CRITICAL SECURITY PATCH

Fixed CVE-2025-29927: Authorization Bypass in Next.js Middleware

- Severity: CRITICAL
- Impact: Authorization bypass vulnerability in Next.js middleware
- Previous version: 14.0.4 (vulnerable)
- Patched version: 14.2.25

Changes:
- apps/admin: Next.js 14.0.4 → 14.2.25
- apps/dashboard: Next.js 14.0.4 → 14.2.25
- apps/docs: Next.js 14.0.4 → 14.2.25
- Updated eslint-config-next to match Next.js version

This fix prevents potential authorization bypass attacks that could allow attackers to circumvent authentication/authorization checks and access protected routes.

Reference: https://github.com/advisories/GHSA-[CVE-2025-29927]
Detection: Trivy security scanner (GitHub Code Scanning)