### PR TITLE
fix(oauth): use JANUA_CUSTOM_DOMAIN for ID token issuer

### DIFF
--- a/apps/api/app/routers/v1/oauth_provider.py
+++ b/apps/api/app/routers/v1/oauth_provider.py
@@ -346,7 +346,15 @@ def _generate_id_token(
 ) -> str:
     """Generate an OpenID Connect ID Token."""
     now = datetime.now(timezone.utc)
-    issuer = settings.BASE_URL or os.getenv("DEFAULT_ISSUER", "https://api.janua.dev")
+    # Use JANUA_CUSTOM_DOMAIN as issuer if set (for white-label deployments like auth.madfam.io)
+    # This must match the issuer in /.well-known/openid-configuration
+    custom_domain_issuer = os.getenv("JANUA_CUSTOM_DOMAIN")
+    if custom_domain_issuer:
+        issuer = f"https://{custom_domain_issuer}".rstrip("/")
+    elif settings.API_BASE_URL:
+        issuer = settings.API_BASE_URL.rstrip("/")
+    else:
+        issuer = settings.BASE_URL or "https://api.janua.dev"
 
     claims = {
         "iss": issuer,


### PR DESCRIPTION
## Summary
- Fix OIDC issuer mismatch between discovery endpoint and ID tokens
- Ensures ID tokens use JANUA_CUSTOM_DOMAIN when set (for white-label deployments)

## Problem
The OIDC discovery endpoint `/.well-known/openid-configuration` correctly used `JANUA_CUSTOM_DOMAIN` for the issuer, but `_generate_id_token` was using `settings.BASE_URL` which caused a mismatch.

This caused Enclii OAuth callbacks to fail with:
```
oidc: id token issued by a different provider, expected "https://auth.madfam.io" got "https://api.janua.dev"
```

## Solution
Updated `_generate_id_token` in oauth_provider.py to use the same issuer logic as the OIDC discovery endpoint:
1. If `JANUA_CUSTOM_DOMAIN` is set, use `https://{JANUA_CUSTOM_DOMAIN}`
2. Otherwise fall back to `API_BASE_URL` or `BASE_URL`

## Test plan
- [ ] Deploy to production with `JANUA_CUSTOM_DOMAIN=auth.madfam.io`
- [ ] Test Enclii OAuth flow via Playwright
- [ ] Verify ID token issuer matches OIDC discovery issuer

🤖 Generated with [Claude Code](https://claude.com/claude-code)