### PR TITLE
fix: Add missing os import in oauth_provider.py

### DIFF
--- a/apps/api/app/routers/v1/oauth_provider.py
+++ b/apps/api/app/routers/v1/oauth_provider.py
@@ -14,6 +14,7 @@ Based on RFC 6749 (OAuth 2.0) and OpenID Connect Core 1.0
 
 import hashlib
 import json
+import os
 import secrets
 import time
 from datetime import datetime, timedelta, timezone


### PR DESCRIPTION
## Summary
- Adds missing `import os` statement to `oauth_provider.py`

## Problem
The `_generate_id_token` function was using `os.getenv("JANUA_CUSTOM_DOMAIN")` but `os` was never imported, causing:
```
NameError: name 'os' is not defined
```

This caused all OIDC token exchanges to fail with a 500 error, breaking SSO login for apps like Enclii.

## Test plan
- [x] SSO login flow via Playwright
- [x] Token exchange completes without NameError

🤖 Generated with [Claude Code](https://claude.com/claude-code)