### PR TITLE
fix(security): remove unused imports from test files

### DIFF
--- a/apps/api/tests/unit/core/test_errors.py
+++ b/apps/api/tests/unit/core/test_errors.py
@@ -4,7 +4,7 @@ Tests for API exceptions, error responses, and exception handlers
 """
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 from fastapi import status
 from fastapi.exceptions import RequestValidationError
 

--- a/apps/api/tests/unit/services/test_jwt_service_comprehensive.py
+++ b/apps/api/tests/unit/services/test_jwt_service_comprehensive.py
@@ -3,7 +3,6 @@ Enhanced JWT Service Test Suite
 Comprehensive coverage for JWT token management
 """
 
-from datetime import timedelta
 from unittest.mock import AsyncMock
 
 import pytest

--- a/apps/api/tests/unit/services/test_webhooks_service.py
+++ b/apps/api/tests/unit/services/test_webhooks_service.py
@@ -6,7 +6,6 @@ Tests for webhook event notifications and delivery
 import hashlib
 import hmac
 from datetime import datetime
-from unittest.mock import AsyncMock
 
 import pytest
 


### PR DESCRIPTION
## Summary
- Remove unused `AsyncMock` import from `test_webhooks_service.py` (Alert #2293)
- Remove unused `timedelta` import from `test_jwt_service_comprehensive.py` (Alert #2292)
- Remove unused `AsyncMock` import from `test_errors.py` (Alert #2291)

## Test plan
- [x] Verified all imports work: `python -c "import tests.unit.services.test_webhooks_service; import tests.unit.services.test_jwt_service_comprehensive; import tests.unit.core.test_errors; print('All imports OK')"`
- [x] All 129 affected tests pass: `pytest tests/unit/services/test_webhooks_service.py tests/unit/services/test_jwt_service_comprehensive.py tests/unit/core/test_errors.py -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)