### PR TITLE
fix(security): resolve code scanning alerts in test files

### DIFF
--- a/apps/api/tests/quarantine/auth/test_router.py
+++ b/apps/api/tests/quarantine/auth/test_router.py
@@ -5,7 +5,7 @@ Tests the endpoints defined in app.routers.v1.auth
 """
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 from datetime import datetime
 from uuid import uuid4
 

--- a/apps/api/tests/quarantine/services/test_jwt_service_enhanced.py
+++ b/apps/api/tests/quarantine/services/test_jwt_service_enhanced.py
@@ -10,7 +10,6 @@ from uuid import uuid4
 
 import pytest
 import jwt
-from jwt.exceptions import InvalidTokenError
 
 from app.config import settings
 from app.exceptions import TokenError

--- a/apps/api/tests/unit/middleware/test_rate_limit.py
+++ b/apps/api/tests/unit/middleware/test_rate_limit.py
@@ -108,7 +108,7 @@ class TestRateLimitMiddlewareDispatch:
         mock_request.url.path = "/health"
         call_next = AsyncMock(return_value=MagicMock())
 
-        response = await middleware_no_redis.dispatch(mock_request, call_next)
+        _ = await middleware_no_redis.dispatch(mock_request, call_next)
 
         call_next.assert_called_once_with(mock_request)
 
@@ -117,7 +117,7 @@ class TestRateLimitMiddlewareDispatch:
         mock_request.url.path = "/ready"
         call_next = AsyncMock(return_value=MagicMock())
 
-        response = await middleware_no_redis.dispatch(mock_request, call_next)
+        _ = await middleware_no_redis.dispatch(mock_request, call_next)
 
         call_next.assert_called_once_with(mock_request)
 
@@ -126,7 +126,7 @@ class TestRateLimitMiddlewareDispatch:
         mock_request.url.path = "/.well-known/jwks.json"
         call_next = AsyncMock(return_value=MagicMock())
 
-        response = await middleware_no_redis.dispatch(mock_request, call_next)
+        _ = await middleware_no_redis.dispatch(mock_request, call_next)
 
         call_next.assert_called_once_with(mock_request)
 
@@ -134,7 +134,7 @@ class TestRateLimitMiddlewareDispatch:
         """Test middleware proceeds when Redis is not available."""
         call_next = AsyncMock(return_value=MagicMock())
 
-        response = await middleware_no_redis.dispatch(mock_request, call_next)
+        _ = await middleware_no_redis.dispatch(mock_request, call_next)
 
         # Should proceed without rate limiting when Redis is not available
         call_next.assert_called_once_with(mock_request)

--- a/apps/api/tests/unit/services/test_account_lockout_service.py
+++ b/apps/api/tests/unit/services/test_account_lockout_service.py
@@ -5,7 +5,7 @@ failed attempt tracking, and manual unlock operations.
 """
 
 from datetime import datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest

--- a/apps/api/tests/unit/services/test_audit_logger.py
+++ b/apps/api/tests/unit/services/test_audit_logger.py
@@ -6,7 +6,6 @@ Tests for audit logging with hash chain integrity and R2 archival
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
-import json
 
 import pytest
 
@@ -281,7 +280,7 @@ class TestLogMethod:
         """Test log with all optional parameters."""
         with patch.object(logger, "_get_previous_hash", return_value=None):
             with patch.object(logger, "_store_entry", new_callable=AsyncMock):  # Patch to avoid AuditLog creation
-                result = await logger.log(
+                _ = await logger.log(
                     event_type=AuditEventType.AUTH_SIGNIN,
                     tenant_id="test-tenant",
                     identity_id="user-123",

--- a/apps/api/tests/unit/services/test_credential_rotation_service.py
+++ b/apps/api/tests/unit/services/test_credential_rotation_service.py
@@ -4,7 +4,7 @@ Tests OAuth client secret rotation, validation, and lifecycle management.
 """
 
 from datetime import datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest

--- a/apps/api/tests/unit/services/test_device_verification_service.py
+++ b/apps/api/tests/unit/services/test_device_verification_service.py
@@ -4,7 +4,7 @@ Tests device fingerprinting, trust management, and session tracking.
 """
 
 from datetime import datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
@@ -242,7 +242,7 @@ class TestTrustDevice:
         mock_result.scalar_one_or_none = MagicMock(return_value=None)
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        _device = await DeviceVerificationService.trust_device(
+        _ = await DeviceVerificationService.trust_device(
             mock_db,
             user_id,
             fingerprint,
@@ -287,7 +287,7 @@ class TestTrustDevice:
         mock_result.scalar_one_or_none = MagicMock(return_value=None)
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        _device = await DeviceVerificationService.trust_device(
+        _ = await DeviceVerificationService.trust_device(
             mock_db,
             uuid4(),
             "fingerprint",

--- a/apps/api/tests/unit/services/test_email_service.py
+++ b/apps/api/tests/unit/services/test_email_service.py
@@ -53,7 +53,7 @@ class TestRedactEmail:
     def test_redact_preserves_domain(self):
         """Test redaction preserves the full domain."""
         result = _redact_email("user@subdomain.example.com")
-        assert "subdomain.example.com" in result
+        assert result.endswith("@subdomain.example.com")
 
 
 class TestEmailServiceInitialization:

--- a/apps/api/tests/unit/services/test_oauth_service.py
+++ b/apps/api/tests/unit/services/test_oauth_service.py
@@ -30,7 +30,7 @@ class TestProviderConfiguration:
             assert config is not None
             assert config["client_id"] == "google_client_id"
             assert config["client_secret"] == "google_secret"
-            assert "accounts.google.com" in config["auth_url"]
+            assert urlparse(config["auth_url"]).netloc == "accounts.google.com"
 
     def test_get_github_provider_config(self):
         """Should return GitHub provider configuration"""
@@ -45,7 +45,7 @@ class TestProviderConfiguration:
 
             assert config is not None
             assert config["client_id"] == "github_client_id"
-            assert "github.com" in config["auth_url"]
+            assert urlparse(config["auth_url"]).netloc == "github.com"
 
     def test_get_microsoft_provider_config(self):
         """Should return Microsoft provider configuration"""
@@ -59,7 +59,7 @@ class TestProviderConfiguration:
             config = OAuthService.get_provider_config(OAuthProvider.MICROSOFT)
 
             assert config is not None
-            assert "microsoftonline.com" in config["auth_url"]
+            assert urlparse(config["auth_url"]).netloc.endswith("microsoftonline.com")
 
     def test_get_unconfigured_provider(self):
         """Should return None for unconfigured provider"""

--- a/apps/api/tests/unit/services/test_sso_service.py
+++ b/apps/api/tests/unit/services/test_sso_service.py
@@ -5,6 +5,7 @@ Tests for SSO/SAML enterprise authentication
 
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
+from urllib.parse import urlparse
 
 import pytest
 
@@ -582,7 +583,7 @@ class TestOIDCFlow:
 
         result = await service.initiate_oidc_login("azure-ad", provider_config)
 
-        assert "login.microsoftonline.com" in result["auth_url"]
+        assert urlparse(result["auth_url"]).netloc == "login.microsoftonline.com"
 
     async def test_process_oidc_callback(self, service):
         """Test processing OIDC callback."""

--- a/apps/api/tests/unit/services/test_system_settings_service.py
+++ b/apps/api/tests/unit/services/test_system_settings_service.py
@@ -389,7 +389,7 @@ class TestAddCorsOrigin:
         mock_result.scalar_one_or_none.return_value = mock_existing
         service.db.execute.return_value = mock_result
 
-        result = await service.add_cors_origin(
+        _ = await service.add_cors_origin(
             "https://example.com",
             description="Updated description",
         )

--- a/apps/api/tests/unit/services/test_websocket_manager.py
+++ b/apps/api/tests/unit/services/test_websocket_manager.py
@@ -620,7 +620,7 @@ class TestSendToUser:
             mock_task.return_value = MagicMock()
             mock_task.return_value.add_done_callback = MagicMock()
 
-            connection_id = await connection_manager.connect(mock_websocket, user_id="user-123")
+            _ = await connection_manager.connect(mock_websocket, user_id="user-123")
             mock_websocket.send_json.reset_mock()
 
         await connection_manager.send_to_user("user-123", {"test": "message"})

--- a/apps/api/tests/unit/sso/test_metadata_manager.py
+++ b/apps/api/tests/unit/sso/test_metadata_manager.py
@@ -5,7 +5,7 @@ Tests SAML metadata generation, parsing, and validation.
 
 import tempfile
 from datetime import datetime, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 

--- a/apps/api/tests/unit/sso/test_saml_protocol.py
+++ b/apps/api/tests/unit/sso/test_saml_protocol.py
@@ -191,7 +191,7 @@ class TestSAMLAuthentication:
     ):
         """Should store request state in cache"""
         with patch.object(saml_protocol, "_validate_certificate", return_value=True):
-            _result = await saml_protocol.initiate_authentication(
+            _ = await saml_protocol.initiate_authentication(
                 organization_id="org_123",
                 return_url="https://app.example.com/callback",
                 config=valid_config,

--- a/apps/api/tests/unit/sso/test_user_provisioning.py
+++ b/apps/api/tests/unit/sso/test_user_provisioning.py
@@ -233,7 +233,7 @@ class TestCreateNewUser:
             mock_user.id = "new_user_123"
             mock_user_class.return_value = mock_user
 
-            _result = await provisioning_service._create_new_user(
+            _ = await provisioning_service._create_new_user(
                 user_data=user_data,
                 organization_id="org_123",
                 sso_config=sso_config,
@@ -332,7 +332,7 @@ class TestUpdateExistingUser:
         mock_user.sso_provider = "oidc"
         mock_user.sso_subject_id = "user_123"
 
-        _result = await provisioning_service._update_existing_user(
+        _ = await provisioning_service._update_existing_user(
             user=mock_user,
             user_data=user_data,
             sso_config=sso_config,
@@ -362,7 +362,7 @@ class TestUpdateExistingUser:
         mock_user.sso_provider = "oidc"
         mock_user.sso_subject_id = "user_123"
 
-        _result = await provisioning_service._update_existing_user(
+        _ = await provisioning_service._update_existing_user(
             user=mock_user,
             user_data=user_data,
             sso_config=sso_config,
@@ -381,7 +381,7 @@ class TestUpdateExistingUser:
         mock_user.sso_provider = "saml2"  # Different from config
         mock_user.sso_subject_id = "user_123"
 
-        _result = await provisioning_service._update_existing_user(
+        _ = await provisioning_service._update_existing_user(
             user=mock_user,
             user_data=user_data,
             sso_config=sso_config,


### PR DESCRIPTION
## Summary
- Remove 7 unused imports across test files
- Rename 14 unused variables to `_` for explicit discard
- Update 6 URL assertions to use `urlparse()` for precise validation

## Changes by Category

### Unused Imports (7 fixes)
| File | Removed |
|------|---------|
| `test_router.py` | `patch` |
| `test_jwt_service_enhanced.py` | `InvalidTokenError` |
| `test_account_lockout_service.py` | `Mock` |
| `test_audit_logger.py` | `json` |
| `test_credential_rotation_service.py` | `Mock` |
| `test_device_verification_service.py` | `patch` |
| `test_metadata_manager.py` | `patch` |

### Unused Variables (14 fixes)
- `test_rate_limit.py`: 4 instances
- `test_user_provisioning.py`: 4 instances
- `test_device_verification_service.py`: 2 instances
- `test_audit_logger.py`, `test_system_settings_service.py`, `test_websocket_manager.py`, `test_saml_protocol.py`: 1 each

### URL Sanitization (6 fixes)
Updated to use `urlparse().netloc` for precise URL validation in:
- `test_email_service.py`
- `test_oauth_service.py` (3 assertions)
- `test_sso_service.py`

## Test Results
All 554 tests pass ✅

## Notes
- Alert #2223 (`test_certificate_manager.py`) was a false positive - `patch` is used in `test_uses_env_variable_default`
- Discord and LinkedIn tests already used correct `urlparse()` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)