### PR TITLE
docs(drift-check): document expected image tag drift behavior

### DIFF
--- a/scripts/drift-check.sh
+++ b/scripts/drift-check.sh
@@ -90,6 +90,9 @@ extract_deployment_image() {
 
 # ============================================================================
 # Deployment Image Comparison
+# NOTE: Image tag drift is EXPECTED when CI/CD uses commit-specific tags
+# (e.g., main-3ee48f8) instead of :latest for production traceability.
+# See: .github/workflows/docker-publish.yml:92
 # ============================================================================
 echo "## Deployment Images"
 echo ""
@@ -177,8 +180,9 @@ if [[ $DRIFT_FOUND -eq 1 ]]; then
     echo "STATUS: DRIFT DETECTED"
     echo ""
     echo "Resolution options:"
-    echo "  1. If cluster state is correct: Update k8s/ manifests in Git"
-    echo "  2. If Git state is correct: Re-apply manifests with kubectl apply -k k8s/overlays/prod"
+    echo "  1. Image tag drift only? This is EXPECTED - CI/CD uses commit-specific tags for traceability"
+    echo "  2. If cluster state is correct: Update k8s/ manifests in Git"
+    echo "  3. If Git state is correct: Re-apply manifests with kubectl apply -k k8s/overlays/prod"
     exit 1
 else
     echo "STATUS: NO DRIFT - Configuration in sync"


### PR DESCRIPTION
## Summary
- Documents that image tag drift is **expected behavior** when CI/CD uses commit-specific tags
- Updates resolution options to clarify image tag drift is intentional
- References `.github/workflows/docker-publish.yml:92` for context

## Context
This addresses Issue #173 which flagged configuration drift for `janua-api`. The drift (`:latest` in manifests vs `main-3ee48f8` in cluster) is intentional - our CI/CD pipeline uses commit-specific tags for traceability.

## Changes
1. Added documentation comment explaining expected image tag drift behavior
2. Updated resolution options to list image tag drift as expected (option 1)

## Test plan
- [x] Script syntax valid (shellcheck passes)
- [x] Changes are documentation-only, no functional impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)