### PR TITLE
fix(csp): add explicit api_host to form-action directive

### DIFF
--- a/apps/api/app/middleware/security_headers.py
+++ b/apps/api/app/middleware/security_headers.py
@@ -43,7 +43,7 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             f"connect-src 'self' https://{self.api_host} https://cloudflareinsights.com",
             "frame-ancestors 'none'",
             "base-uri 'self'",
-            "form-action 'self'",
+            f"form-action 'self' https://{self.api_host}",
             "upgrade-insecure-requests",
         ]
 

--- a/apps/api/tests/unit/middleware/test_security_headers.py
+++ b/apps/api/tests/unit/middleware/test_security_headers.py
@@ -242,8 +242,8 @@ class TestContentSecurityPolicy:
         csp = result.headers["Content-Security-Policy"]
         assert "connect-src 'self' https://api.janua.dev https://cloudflareinsights.com" in csp
 
-    async def test_csp_form_action_self_only(self, middleware, mock_response):
-        """Test CSP form-action directive is 'self' only (no explicit URLs)."""
+    async def test_csp_form_action_includes_api_host(self, middleware, mock_response):
+        """Test CSP form-action directive includes 'self' and explicit api_host."""
         request = MagicMock(spec=Request)
         request.url.scheme = "https"
         request.url.path = "/api/users"
@@ -253,7 +253,7 @@ class TestContentSecurityPolicy:
         result = await middleware.dispatch(request, call_next)
 
         csp = result.headers["Content-Security-Policy"]
-        assert "form-action 'self'" in csp
+        assert "form-action 'self' https://api.janua.dev" in csp
 
 
 class TestCSPDynamicApiHost:
@@ -297,8 +297,8 @@ class TestCSPDynamicApiHost:
         assert "connect-src 'self' https://auth.madfam.io https://cloudflareinsights.com" in csp
         assert "api.janua.dev" not in csp
 
-    async def test_csp_form_action_self_only_custom_host(self, mock_response):
-        """Test CSP form-action is 'self' only regardless of custom api_host."""
+    async def test_csp_form_action_includes_custom_host(self, mock_response):
+        """Test CSP form-action includes custom api_host."""
         app = MagicMock()
         middleware = SecurityHeadersMiddleware(app, strict=True, api_host="auth.madfam.io")
 
@@ -310,7 +310,7 @@ class TestCSPDynamicApiHost:
         result = await middleware.dispatch(request, call_next)
 
         csp = result.headers["Content-Security-Policy"]
-        assert "form-action 'self'" in csp
+        assert "form-action 'self' https://auth.madfam.io" in csp
 
     async def test_csp_swagger_cdn_allowed(self, mock_response):
         """Test CSP allows CDN resources needed by Swagger UI."""


### PR DESCRIPTION
## Summary
- Add explicit `https://{api_host}` to CSP `form-action` directive alongside `'self'`
- Fixes Chromium edge case where Cloudflare tunnel modifies origin context, blocking the login form POST from `/api/v1/auth/login` to `/api/v1/auth/login-form`
- Matches existing pattern used for `connect-src` on line 43
- Updates 2 tests to expect the new `form-action` value

## Test plan
- [ ] Run `pytest tests/unit/middleware/test_security_headers.py` — all 25 tests pass
- [ ] Deploy to production, verify admin.tezca.mx SSO login form POST is not blocked by CSP
- [ ] Verify Swagger docs still load at auth.madfam.io/docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)