### PR TITLE
feat(ci): pp.3c janua promote-to-prod + rollback-prod workflows (pattern b)

### DIFF
--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -1,0 +1,286 @@
+# PP.3c (RFC 0001 Phase 2) — promote staging -> prod.
+#
+# Promotes a staging image digest to production. Does NOT rebuild —
+# promotion is strictly a pointer update. This is the single most
+# important invariant of the pipeline.
+#
+# Janua is RFC 0001 Pattern B (manual gate) because it is the ecosystem
+# auth floor — every other MADFAM service depends on Janua's JWTs.
+# A wrong promote breaks every downstream login. The scheduled
+# auto-promote job is present in the template but gated off via the
+# repo variable AUTO_PROMOTE_ENABLED — enclii.yaml declares
+# `promotion.pattern: manual`, and AUTO_PROMOTE_ENABLED defaults to
+# "false". To enable auto-promote in the future, flip the repo
+# variable + update enclii.yaml.
+#
+# Janua-specific operator note:
+#   Promotes MUST serialize with key rotation (JWT RSA keypair in
+#   janua-secrets) and OAuth-client-registry changes (Google / GitHub /
+#   Microsoft client IDs). The `prod-promote` concurrency group below
+#   serializes promotes against each other; coordination with rotation
+#   jobs is a human discipline — if a rotation is in flight, wait for
+#   it to complete + its audit row to land before promoting. A
+#   simultaneous key rotation + image promote is the single most likely
+#   way to brick downstream logins ecosystem-wide.
+#
+# Target file note:
+#   This workflow writes to k8s/overlays/production/kustomization.yaml,
+#   which is the canonical prod manifest path AFTER PP.3b lands (PP.3b
+#   renames k8s/overlays/prod -> k8s/overlays/production and migrates
+#   digests out of k8s/base/deployments). Until PP.3b ships, the
+#   workflow will fail with a helpful error — that's intentional, you
+#   cannot promote to a target that does not exist yet.
+
+name: Promote staging -> prod
+
+on:
+  workflow_dispatch:
+    inputs:
+      component:
+        description: "Which image to promote"
+        required: true
+        type: choice
+        options:
+          - api
+          - admin
+          - dashboard
+          - docs
+          - website
+          - all
+      digest:
+        description: "Staging image digest to promote (sha256:...). Leave blank to read current staging overlay digest for the chosen component."
+        required: false
+        type: string
+      reason:
+        description: "Why are you promoting now? (shown in audit log; required)"
+        required: true
+        type: string
+
+  # Auto-promote is gated — Janua is Pattern B, so this job exits early
+  # unless the repo variable AUTO_PROMOTE_ENABLED == "true".
+  schedule:
+    - cron: "*/15 * * * *"
+
+concurrency:
+  # Serialize all prod-touching operations (promote + rollback share
+  # this group). See operator note above re: key rotation coordination.
+  group: prod-promote
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate promotion candidate(s)
+    runs-on: ubuntu-latest
+    outputs:
+      should_promote: ${{ steps.resolve.outputs.should_promote }}
+      api_digest: ${{ steps.resolve.outputs.api_digest }}
+      admin_digest: ${{ steps.resolve.outputs.admin_digest }}
+      dashboard_digest: ${{ steps.resolve.outputs.dashboard_digest }}
+      docs_digest: ${{ steps.resolve.outputs.docs_digest }}
+      website_digest: ${{ steps.resolve.outputs.website_digest }}
+      short: ${{ steps.resolve.outputs.short }}
+      reason: ${{ steps.resolve.outputs.reason }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 100
+
+      - id: resolve
+        name: Resolve digest(s) per component
+        env:
+          AUTO_ENABLED: ${{ vars.AUTO_PROMOTE_ENABLED || 'false' }}
+          MIN_SOAK_MIN: ${{ vars.MIN_SOAK_MINUTES || '30' }}
+          COMPONENT: ${{ inputs.component }}
+          INPUT_DIGEST: ${{ inputs.digest }}
+          INPUT_REASON: ${{ inputs.reason }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EVENT" == "schedule" ]]; then
+            if [[ "$AUTO_ENABLED" != "true" ]]; then
+              echo "Auto-promote disabled for Janua (Pattern B — manual gate)."
+              echo "should_promote=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            COMPONENT="all"
+            REASON="auto:scheduled"
+          else
+            REASON="manual:$INPUT_REASON"
+          fi
+
+          STAGING_FILE="k8s/overlays/staging/kustomization.yaml"
+          if [[ ! -f "$STAGING_FILE" ]]; then
+            echo "::error::$STAGING_FILE does not exist. PP.3b (staging overlay) must land before PP.3c promotes can succeed."
+            exit 1
+          fi
+
+          read_staging_digest() {
+            local image="$1"
+            python3 - "$image" <<'PY'
+          import re, pathlib, sys
+          image = sys.argv[1]
+          text = pathlib.Path("k8s/overlays/staging/kustomization.yaml").read_text()
+          # Match either "name: <img>\n  digest: sha256:..."
+          # or the alt order "digest: sha256:...\n  name: <img>"
+          pat = r'name:\s+' + re.escape(image) + r'\s*\n\s+digest:\s+(sha256:[a-f0-9]+)'
+          m = re.search(pat, text)
+          if not m:
+              alt = r'digest:\s+(sha256:[a-f0-9]+)\s*\n\s+name:\s+' + re.escape(image)
+              m = re.search(alt, text)
+          if not m:
+              sys.exit(1)
+          print(m.group(1))
+          PY
+          }
+
+          resolve_one() {
+            local comp="$1"
+            local image="ghcr.io/madfam-org/janua-$comp"
+            local d
+            if [[ -n "$INPUT_DIGEST" && "$COMPONENT" != "all" ]]; then
+              d="$INPUT_DIGEST"
+            else
+              d=$(read_staging_digest "$image") || {
+                echo "::error::Could not read staging digest for $comp ($image) from $STAGING_FILE"
+                exit 1
+              }
+            fi
+            if [[ ! "$d" =~ ^sha256:[a-f0-9]+$ ]]; then
+              echo "::error::Invalid $comp digest: $d"
+              exit 1
+            fi
+            # Placeholder check — never promote the zero-digest
+            if [[ "$d" == "sha256:0000000000000000000000000000000000000000000000000000000000000000" ]]; then
+              echo "::error::$comp staging digest is the placeholder — staging has never deployed this image. Refusing to promote."
+              exit 1
+            fi
+            # Soak check: find the commit that wrote this digest to staging overlay
+            STAGING_COMMIT=$(git log --all -n 50 --format="%H" -- "$STAGING_FILE" \
+              | while read sha; do
+                  if git show "$sha:$STAGING_FILE" 2>/dev/null | grep -q "$d"; then
+                    echo "$sha"; break
+                  fi
+                done)
+            if [[ -z "$STAGING_COMMIT" ]]; then
+              echo "::error::$comp digest $d has no recent staging commit — refusing to promote."
+              exit 1
+            fi
+            STAGING_TIME=$(git show -s --format=%ct "$STAGING_COMMIT")
+            NOW=$(date +%s)
+            AGE_MIN=$(( (NOW - STAGING_TIME) / 60 ))
+            if [[ "$AGE_MIN" -lt "$MIN_SOAK_MIN" ]]; then
+              echo "::error::$comp digest soaked ${AGE_MIN}min; required ${MIN_SOAK_MIN}min."
+              exit 1
+            fi
+            echo "$d"
+          }
+
+          API_D=""
+          ADMIN_D=""
+          DASHBOARD_D=""
+          DOCS_D=""
+          WEBSITE_D=""
+          case "$COMPONENT" in
+            api)       API_D=$(resolve_one api) ;;
+            admin)     ADMIN_D=$(resolve_one admin) ;;
+            dashboard) DASHBOARD_D=$(resolve_one dashboard) ;;
+            docs)      DOCS_D=$(resolve_one docs) ;;
+            website)   WEBSITE_D=$(resolve_one website) ;;
+            all)
+              API_D=$(resolve_one api)
+              ADMIN_D=$(resolve_one admin)
+              DASHBOARD_D=$(resolve_one dashboard)
+              DOCS_D=$(resolve_one docs)
+              WEBSITE_D=$(resolve_one website)
+              ;;
+            *)
+              echo "::error::Unknown component $COMPONENT"; exit 1 ;;
+          esac
+
+          SHORT="$(git rev-parse --short HEAD)"
+          {
+            echo "api_digest=$API_D"
+            echo "admin_digest=$ADMIN_D"
+            echo "dashboard_digest=$DASHBOARD_D"
+            echo "docs_digest=$DOCS_D"
+            echo "website_digest=$WEBSITE_D"
+            echo "short=$SHORT"
+            echo "reason=$REASON"
+            echo "should_promote=true"
+          } >> "$GITHUB_OUTPUT"
+
+  promote:
+    name: Write prod kustomization
+    needs: validate
+    if: needs.validate.outputs.should_promote == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.MADFAM_BOT_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Patch prod kustomization digests
+        env:
+          API_DIGEST: ${{ needs.validate.outputs.api_digest }}
+          ADMIN_DIGEST: ${{ needs.validate.outputs.admin_digest }}
+          DASHBOARD_DIGEST: ${{ needs.validate.outputs.dashboard_digest }}
+          DOCS_DIGEST: ${{ needs.validate.outputs.docs_digest }}
+          WEBSITE_DIGEST: ${{ needs.validate.outputs.website_digest }}
+          SHORT: ${{ needs.validate.outputs.short }}
+          REASON: ${{ needs.validate.outputs.reason }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          FILE="k8s/overlays/production/kustomization.yaml"
+          if [[ ! -f "$FILE" ]]; then
+            echo "::error::$FILE does not exist. PP.3b must land first — it renames k8s/overlays/prod -> k8s/overlays/production and migrates digests out of k8s/base/deployments."
+            exit 1
+          fi
+
+          python3 <<'PY'
+          import os, re, pathlib
+          path = pathlib.Path("k8s/overlays/production/kustomization.yaml")
+          text = path.read_text()
+
+          # Janua prod kustomization uses long-form image keys:
+          #   - name: ghcr.io/madfam-org/janua-<comp>
+          #     digest: sha256:...
+          # (or the alt order seen in base/).
+          def patch(text, image, digest):
+              if not digest:
+                  return text
+              pat = (
+                  r'(name:\s+' + re.escape(image)
+                  + r'\s*\n\s+(?:newName:\s+' + re.escape(image) + r'\s*\n\s+)?digest:\s+)sha256:[a-f0-9]+'
+              )
+              alt = (
+                  r'(digest:\s+)sha256:[a-f0-9]+(\s*\n\s+name:\s+' + re.escape(image) + r')'
+              )
+              if re.search(pat, text):
+                  return re.sub(pat, lambda m: m.group(1) + digest, text)
+              if re.search(alt, text):
+                  return re.sub(alt, lambda m: m.group(1) + digest + m.group(2), text)
+              return text
+
+          text = patch(text, "ghcr.io/madfam-org/janua-api",       os.environ["API_DIGEST"])
+          text = patch(text, "ghcr.io/madfam-org/janua-admin",     os.environ["ADMIN_DIGEST"])
+          text = patch(text, "ghcr.io/madfam-org/janua-dashboard", os.environ["DASHBOARD_DIGEST"])
+          text = patch(text, "ghcr.io/madfam-org/janua-docs",      os.environ["DOCS_DIGEST"])
+          text = patch(text, "ghcr.io/madfam-org/janua-website",   os.environ["WEBSITE_DIGEST"])
+          path.write_text(text)
+          PY
+
+          git config user.name "madfam-deploy-bot"
+          git config user.email "deploy-bot@madfam.io"
+          git add "$FILE"
+          git commit -m "deploy(prod): promote $SHORT
+
+          Reason: $REASON
+          Promoted-by: $ACTOR" || {
+            echo "No digest change — already at target"
+            exit 0
+          }
+          git push

--- a/.github/workflows/rollback-prod.yml
+++ b/.github/workflows/rollback-prod.yml
@@ -1,0 +1,171 @@
+# PP.3c (RFC 0001 Phase 2) — emergency prod rollback.
+#
+# Writes a target digest into k8s/overlays/production/kustomization.yaml
+# and commits. ArgoCD reconciles within ~3 min. Intended RTO <5 min.
+#
+# There is no auto-trigger — rollbacks are always a human call. Per
+# RFC 0001, leaving `digest` blank rolls back to the previous prod
+# digest for the chosen component by reading git history.
+#
+# Janua-specific operator note:
+#   Rollbacks share the `prod-promote` concurrency group with promotes
+#   to serialize prod-touching writes. If a JWT keypair rotation is in
+#   flight when you need to roll back, the safer path is: let the
+#   rotation complete (its commit lands), THEN roll back to the target
+#   digest. Rolling back across a key-rotation boundary can orphan
+#   in-flight tokens — coordinate via the #incident channel.
+#
+# Target file note:
+#   Rolls back via k8s/overlays/production/kustomization.yaml (post
+#   PP.3b canonical path). Until PP.3b lands, this workflow fails fast
+#   with a helpful error.
+
+name: Rollback prod
+
+on:
+  workflow_dispatch:
+    inputs:
+      component:
+        description: "Which image to roll back"
+        required: true
+        type: choice
+        options:
+          - api
+          - admin
+          - dashboard
+          - docs
+          - website
+      digest:
+        description: "Digest to roll back to (sha256:...). Leave blank to use the previous prod digest from git history."
+        required: false
+        type: string
+      reason:
+        description: "Why are you rolling back? (shown in audit log; required)"
+        required: true
+        type: string
+
+concurrency:
+  group: prod-promote
+  cancel-in-progress: false
+
+jobs:
+  rollback:
+    name: Write target digest
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.MADFAM_BOT_PAT || secrets.GITHUB_TOKEN }}
+          fetch-depth: 100
+
+      - name: Resolve target digest
+        id: target
+        env:
+          COMPONENT: ${{ inputs.component }}
+          INPUT_DIGEST: ${{ inputs.digest }}
+        run: |
+          set -euo pipefail
+          FILE="k8s/overlays/production/kustomization.yaml"
+          if [[ ! -f "$FILE" ]]; then
+            echo "::error::$FILE does not exist. PP.3b must land first — rollback target path is the post-PP.3b canonical overlay."
+            exit 1
+          fi
+          IMAGE="ghcr.io/madfam-org/janua-$COMPONENT"
+
+          if [[ -n "$INPUT_DIGEST" ]]; then
+            TARGET="$INPUT_DIGEST"
+          else
+            CURRENT_DIGEST=$(python3 - "$IMAGE" <<'PY'
+          import re, pathlib, sys
+          image = sys.argv[1]
+          t = pathlib.Path("k8s/overlays/production/kustomization.yaml").read_text()
+          pat = r'name:\s+' + re.escape(image) + r'\s*\n(?:\s+newName:[^\n]+\n)?\s+digest:\s+(sha256:[a-f0-9]+)'
+          m = re.search(pat, t)
+          if not m:
+              alt = r'digest:\s+(sha256:[a-f0-9]+)\s*\n\s+name:\s+' + re.escape(image)
+              m = re.search(alt, t)
+          if m: print(m.group(1))
+          PY
+          )
+            if [[ -z "$CURRENT_DIGEST" ]]; then
+              echo "::error::Could not read current prod digest for $COMPONENT ($IMAGE)"; exit 1
+            fi
+            # Walk git log; find first historical version where the digest
+            # for this component differed from current.
+            TARGET=""
+            for sha in $(git log -n 40 --format=%H -- "$FILE"); do
+              HIST=$(git show "$sha:$FILE" 2>/dev/null | python3 - "$IMAGE" <<'PY'
+          import re, sys
+          image = sys.argv[1]
+          t = sys.stdin.read()
+          pat = r'name:\s+' + re.escape(image) + r'\s*\n(?:\s+newName:[^\n]+\n)?\s+digest:\s+(sha256:[a-f0-9]+)'
+          m = re.search(pat, t)
+          if not m:
+              alt = r'digest:\s+(sha256:[a-f0-9]+)\s*\n\s+name:\s+' + re.escape(image)
+              m = re.search(alt, t)
+          if m: print(m.group(1))
+          PY
+          )
+              if [[ -n "$HIST" && "$HIST" != "$CURRENT_DIGEST" ]]; then
+                TARGET="$HIST"
+                break
+              fi
+            done
+            if [[ -z "$TARGET" ]]; then
+              echo "::error::Cannot find previous $COMPONENT digest. Pass one explicitly."; exit 1
+            fi
+          fi
+
+          if [[ ! "$TARGET" =~ ^sha256:[a-f0-9]+$ ]]; then
+            echo "::error::Invalid digest: $TARGET"; exit 1
+          fi
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+          echo "Rolling back $COMPONENT to $TARGET"
+
+      - name: Patch prod kustomization
+        env:
+          TARGET: ${{ steps.target.outputs.target }}
+          COMPONENT: ${{ inputs.component }}
+          REASON: ${{ inputs.reason }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          FILE="k8s/overlays/production/kustomization.yaml"
+          python3 <<'PY'
+          import os, re, pathlib
+          p = pathlib.Path("k8s/overlays/production/kustomization.yaml")
+          t = p.read_text()
+          target = os.environ["TARGET"]
+          comp = os.environ["COMPONENT"]
+          image = f"ghcr.io/madfam-org/janua-{comp}"
+          pat = (
+              r'(name:\s+' + re.escape(image)
+              + r'\s*\n\s+(?:newName:\s+' + re.escape(image) + r'\s*\n\s+)?digest:\s+)sha256:[a-f0-9]+'
+          )
+          alt = (
+              r'(digest:\s+)sha256:[a-f0-9]+(\s*\n\s+name:\s+' + re.escape(image) + r')'
+          )
+          if re.search(pat, t):
+              t = re.sub(pat, lambda m: m.group(1) + target, t)
+          elif re.search(alt, t):
+              t = re.sub(alt, lambda m: m.group(1) + target + m.group(2), t)
+          else:
+              raise SystemExit(f"Could not locate {image} digest entry")
+          p.write_text(t)
+          PY
+          SHORT="${TARGET:7:15}"
+          git config user.name "madfam-deploy-bot"
+          git config user.email "deploy-bot@madfam.io"
+          git add "$FILE"
+          git commit -m "rollback(prod): restore $COMPONENT $SHORT
+
+          Reason: $REASON
+          Rolled-back-by: $ACTOR"
+          git push
+
+      - name: Notify
+        if: always()
+        run: |
+          echo "::notice::Janua ${{ inputs.component }} rolled back to ${{ steps.target.outputs.target }}. Monitor ArgoCD (janua Application) for reconcile completion. RTO target <5min."

--- a/enclii.yaml
+++ b/enclii.yaml
@@ -3,6 +3,19 @@ kind: Service
 metadata:
   name: janua
   project: janua
+
+# RFC 0001 promotion policy — Janua is Pattern B (manual gate) because
+# it is the ecosystem auth floor. Every other MADFAM service depends on
+# Janua's JWTs; a wrong promote breaks every downstream login. Blast
+# radius is maximum. The promote-to-prod.yml workflow's scheduled
+# auto-promote job is disabled via the repo variable AUTO_PROMOTE_ENABLED
+# (default: unset -> evaluated as "false"); leaving this value "manual"
+# here is the policy record.
+promotion:
+  pattern: manual
+  min_soak_minutes: 30
+  require_smoke_pass: true
+
 spec:
   runtime:
     port: 8080


### PR DESCRIPTION
## Summary

Ships workflow-level plumbing for **RFC 0001 Phase 2** on Janua. Janua is **Pattern B (manual gate)** — the ecosystem auth floor, maximum blast radius.

- `.github/workflows/promote-to-prod.yml` — `workflow_dispatch` + gated cron; per-component or `all` promotion across Janua's 5 images (api, admin, dashboard, docs, website); validates `min_soak_minutes` (default 30) against the commit that wrote the digest into the staging overlay; writes to `k8s/overlays/production/kustomization.yaml`.
- `.github/workflows/rollback-prod.yml` — `workflow_dispatch` only; reads previous prod digest from git history when no explicit digest supplied; shares `prod-promote` concurrency group with promote to serialize prod-touching writes; RTO target <5 min.
- `enclii.yaml` — adds `promotion: { pattern: manual, min_soak_minutes: 30, require_smoke_pass: true }`.

Workflows call out in comments that promotes MUST serialize with JWT keypair rotations and OAuth-client-registry changes (operator discipline, no code-level enforcement).

## Audit rows closed

Refs `docs/PP_3_STAGING_AUDIT.md` rows **8** (promote workflow), **9** (rollback workflow), **10** (soak period), **20** (`.enclii.yml` promotion key). Row **21** (direct-to-prod bypass removal) is **intentionally deferred** to a post-soak cleanup PR per the audit — see "Not in this PR" below.

## Not in this PR (by design)

- **PP.3b structural work** — staging overlay, ArgoCD staging app, `janua-staging` namespace, staging secrets, rename `k8s/overlays/prod` → `k8s/overlays/production`, move digests out of `k8s/base/deployments`. Separate PR, gated on the ops prerequisite of provisioning a separate staging Janua tenant (distinct JWT RSA keypair, distinct Fernet key, staging OAuth client registrations). These workflows will error fast with a helpful message (`k8s/overlays/production/kustomization.yaml does not exist...`) until PP.3b lands, which is the correct contract.
- **Trimming `docker-publish.yml` direct-to-prod commits** — per the audit, this requires a 14-day no-rollback soak with `promote-to-prod.yml` in active use. Follow-up PR after soak.

## Precedent

Templates copied from **dhanam#296 (PP.2c)** which landed 2026-04-16. Differences from Dhanam:
- 5 components instead of 3 (api, admin, dashboard, docs, website)
- Long-form image keys (`ghcr.io/madfam-org/janua-<comp>`) match Janua's current `k8s/base/deployments/kustomization.yaml` format; Dhanam prod uses short-names (`dhanam-<comp>`). Regex handles both orderings (`name` → `digest` and alt `digest` → `name`).
- Concurrency-group comment flags the key-rotation + OAuth-registry serialization requirement specific to Janua.

## Test plan

- [ ] Verify workflows appear in the Actions tab after merge
- [ ] Verify both fail fast with `::error::... does not exist` when invoked before PP.3b lands (negative test — this is the intended contract)
- [ ] After PP.3b merges: dry-run `promote-to-prod.yml` with `component: docs` (lowest-risk) and a real staging digest; confirm soak check enforces 30 min; confirm commit lands on `k8s/overlays/production/kustomization.yaml`
- [ ] Confirm scheduled cron run exits early with "Auto-promote disabled for Janua (Pattern B — manual gate)" message when `AUTO_PROMOTE_ENABLED` is unset
- [ ] After a real promote: dry-run `rollback-prod.yml` with `component: docs`, no explicit digest — confirm it resolves the previous prod digest from git history

🤖 Generated with [Claude Code](https://claude.com/claude-code)