### PR TITLE
fix(edge-verify): replace wildcard CORS with allowlist [AUDIT H5]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -987,3 +987,13 @@ This section defines the operating protocol for AI agents (Claude Code, GitHub C
 ---
 
 *Janua - The Gatekeeper | One key for the whole city*
+
+## Known Issues — Audit 2026-04-23
+
+See `/Users/aldoruizluna/labspace/claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md` for the full ecosystem audit.
+
+- ~~**🟠 H5: Wildcard CORS on edge-verify**~~ — Fixed 2026-04-23: `resolveCors` now reflects Origin only when it matches an allowlist (configurable via `CORS_ALLOWED_ORIGINS` env; defaults to `https://*.madfam.io` + known MADFAM product domains). Never emits `*`.
+- **🟠 H9: `ENABLE_DOCS=true` in base K8s deployment** — `k8s/base/deployments/janua-api.yaml:128`. Verify overlay overrides in prod with `enclii service describe janua-api`; otherwise `/docs` + `/openapi.json` enumerate all auth endpoints on auth.madfam.io.
+- **🟠 M2: `ast.literal_eval` on Redis-stored email token** — `apps/api/app/services/email_service.py:106`. Swap for `json.loads` + schema validation.
+- **🔴 T2: 5 core auth e2e tests skipped** — `tests/e2e/auth-flows.spec.ts:94, 106, 122, 139, 150` (login invalid creds, password reset, MFA enrollment, session persistence, logout/redirect). Un-skip and wire to CI.
+- **🟢 positive**: Correct RS256 usage, good webhook signature verification pattern.

--- a/apps/edge-verify/src/index.ts
+++ b/apps/edge-verify/src/index.ts
@@ -14,6 +14,66 @@ export interface Env {
   JWKS_URL: string
   JWT_AUDIENCE: string
   JWT_ISSUER: string
+  // Comma-separated list of origins or wildcard patterns
+  // (e.g. "https://app.madfam.io,https://*.madfam.io,https://partner.com").
+  // When unset, falls back to a conservative *.madfam.io allowlist.
+  CORS_ALLOWED_ORIGINS?: string
+}
+
+// Default allowlist used when CORS_ALLOWED_ORIGINS is not provided. Keep this
+// in sync with Enclii ingress and known MADFAM product domains.
+const DEFAULT_ALLOWED_ORIGINS: readonly string[] = [
+  'https://*.madfam.io',
+  'https://*.janua.dev',
+  // Ecosystem partner domains that talk to the edge verifier from the browser.
+  'https://*.enclii.dev',
+  'https://*.rondel.io',
+  'https://*.forgesight.quest',
+  'https://*.dhan.am',
+  'https://*.karafiel.mx',
+  'https://*.tezca.mx',
+  'https://*.selva.town',
+  'https://*.routecraft.app',
+]
+
+function parseAllowlist(env: Env): readonly string[] {
+  const raw = (env.CORS_ALLOWED_ORIGINS ?? '').trim()
+  if (!raw) return DEFAULT_ALLOWED_ORIGINS
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+}
+
+function matchesPattern(origin: string, pattern: string): boolean {
+  // Exact match covers "https://app.madfam.io" style entries.
+  if (pattern === origin) return true
+  // Wildcard host support, e.g. "https://*.madfam.io" matches
+  // "https://admin.madfam.io" but NOT "https://evil-madfam.io".
+  if (pattern.includes('*')) {
+    const escaped = pattern
+      .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+      .replace(/\*/g, '[A-Za-z0-9-]+')
+    return new RegExp(`^${escaped}$`).test(origin)
+  }
+  return false
+}
+
+function resolveCors(env: Env, origin: string | null): Record<string, string> {
+  const base: Record<string, string> = {
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+    'Access-Control-Max-Age': '86400',
+    Vary: 'Origin',
+  }
+  if (!origin) return base
+  const allowlist = parseAllowlist(env)
+  const allowed = allowlist.some((p) => matchesPattern(origin, p))
+  if (!allowed) return base
+  return {
+    ...base,
+    'Access-Control-Allow-Origin': origin,
+  }
 }
 
 export default {
@@ -25,13 +85,9 @@ export default {
     // Start timing
     const startTime = Date.now()
 
-    // CORS headers
-    const corsHeaders = {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-      'Access-Control-Allow-Headers': 'Authorization, Content-Type',
-      'Access-Control-Max-Age': '86400',
-    }
+    // CORS headers (audit 2026-04-23 H5: no wildcards on the edge verifier).
+    const origin = request.headers.get('Origin')
+    const corsHeaders = resolveCors(env, origin)
 
     // Handle OPTIONS
     if (request.method === 'OPTIONS') {


### PR DESCRIPTION
Audit 2026-04-23 finding H5. The edge verifier sat at the CORS edge
of the entire ecosystem and was emitting Access-Control-Allow-Origin: *
unconditionally. Any third-party page could have its users' browsers
call the verifier with their cookies/credentials.

Changes:
- New Env field CORS_ALLOWED_ORIGINS (comma-separated list, supports
  wildcard patterns like "https://*.madfam.io"). Empty/unset falls back
  to DEFAULT_ALLOWED_ORIGINS — the MADFAM ecosystem domains
  (madfam.io, janua.dev, enclii.dev, rondel.io, forgesight.quest,
  dhan.am, karafiel.mx, tezca.mx, selva.town, routecraft.app).
- resolveCors(env, origin) returns Allow-Origin only when the request
  Origin matches the allowlist. Otherwise the header is omitted and
  browsers block the credentialed request.
- matchesPattern:
  * exact match ("https://app.madfam.io")
  * wildcard subdomain ("https://*.madfam.io") — uses [A-Za-z0-9-]+
    so evil-madfam.io, sub.sub.madfam.io, and scheme mismatches are
    all rejected
- Vary: Origin added so caches key per-origin.

Sanity-checked the pattern matcher against 11 cases (apex, hyphenated
subdomain, scheme mismatch, look-alike domain, multi-segment subdomain)
— all green.



## Test plan
- [ ] Local smoke — reproduce the audit scenario and confirm it's blocked.
- [ ] CI green on the branch.
- [ ] Review the audit file-line anchors in `claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md`.

Full audit: `claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
