### PR TITLE
fix(ci): wire NPM_MADFAM_TOKEN into pr-quality.yml

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -9,6 +9,11 @@ on:
 env:
   NODE_VERSION: "20"
   PYTHON_VERSION: "3.11"
+  # Required by .npmrc to resolve @janua/* packages from npm.madfam.io.
+  # Without this, pnpm install falls back to the public registry and 404s
+  # on @janua/typescript-sdk (and any other private scope). Matches the
+  # pattern in ci.yml / tests.yml / docs-validation.yml.
+  NPM_MADFAM_TOKEN: ${{ secrets.NPM_MADFAM_TOKEN }}
 
 jobs:
   code-quality:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,6 +13,9 @@ on:
 env:
   PYTHON_VERSION: '3.11'
   NODE_VERSION: '20'
+  # Required by .npmrc to resolve @janua/* packages from npm.madfam.io.
+  # Without this, pnpm install falls back to the public registry.
+  NPM_MADFAM_TOKEN: ${{ secrets.NPM_MADFAM_TOKEN }}
 
 jobs:
   # Static Application Security Testing (SAST)


### PR DESCRIPTION
## Summary

`pr-quality.yml` runs `pnpm install --frozen-lockfile` but never exports `NPM_MADFAM_TOKEN`. The `.npmrc` `${NPM_MADFAM_TOKEN}` substitution becomes the literal string, pnpm falls back to `registry.npmjs.org` without auth, and the install 404s on `@janua/typescript-sdk` (and any other private scope).

All other Janua workflows (ci.yml, tests.yml, docs-validation.yml, maintenance.yml, publish-sdks.yml, etc.) set the token at workflow env level. This change brings pr-quality.yml into alignment.

This is currently blocking every security audit PR's CI on Code Quality + Frontend Tests & Build — notably [PR #326](https://github.com/madfam-org/janua/pull/326) (edge-verify CORS allowlist).

## Test plan
- [ ] CI green on this PR (proves install step now succeeds)
- [ ] After merge, re-run CI on PR #326 and verify Code Quality + Frontend Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)