### PR TITLE
fix(security): disable /docs in production by default (H9)

### DIFF
--- a/k8s/base/deployments/janua-api.yaml
+++ b/k8s/base/deployments/janua-api.yaml
@@ -125,8 +125,11 @@ spec:
             - name: COOKIE_DOMAIN
               value: ".madfam.io"
             # Features
+            # ENABLE_DOCS: prod-safe default (false). Dev overlay flips this on.
+            # Audit 2026-04-23 H9: /docs, /redoc, /openapi.json must NOT be public
+            # in prod (would enumerate all auth endpoints on auth.madfam.io).
             - name: ENABLE_DOCS
-              value: "true"
+              value: "false"
             - name: ENABLE_SIGNUPS
               value: "true"
             - name: ENABLE_OAUTH

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -28,6 +28,25 @@ patches:
     target:
       kind: Deployment
       name: janua-api
+  # H9 (2026-04-23): re-enable Swagger UI / OpenAPI for local dev only.
+  # The base default is "false" (prod-safe); flip it back on here so devs
+  # still get /docs, /redoc, /openapi.json on localhost.
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: janua-api
+      spec:
+        template:
+          spec:
+            containers:
+              - name: janua-api
+                env:
+                  - name: ENABLE_DOCS
+                    value: "true"
+    target:
+      kind: Deployment
+      name: janua-api
 
 # Use local images for dev
 images:


### PR DESCRIPTION
## Summary

Audit 2026-04-23 **H9** finding: `ENABLE_DOCS=true` in the base K8s deployment (`k8s/base/deployments/janua-api.yaml:128`) exposes `/docs`, `/redoc`, and `/openapi.json` publicly on `auth.madfam.io`, enumerating every auth endpoint to anonymous callers. The prod overlay (`k8s/overlays/prod/kustomization.yaml`) does not override the base default, so the unsafe value reaches prod.

The app code at `apps/api/app/main.py:339-340` already gates docs visibility on `settings.ENABLE_DOCS`, so flipping the env var is sufficient to close the leak.

## Changes

- `k8s/base/deployments/janua-api.yaml`: `ENABLE_DOCS` default changed from `"true"` to `"false"` (prod-safe). Added a comment explaining the policy and the audit reference.
- `k8s/overlays/dev/kustomization.yaml`: added a strategic-merge patch that re-enables `ENABLE_DOCS=true` for local dev, so devs continue to get Swagger UI on `localhost:4100/docs`. (Strategic merge keyed by env-var name, not positional index, to be robust against future env-var reordering in the base.)

## Test plan

- [ ] `kustomize build k8s/overlays/prod | grep -A1 ENABLE_DOCS` shows `value: "false"`
- [ ] `kustomize build k8s/overlays/dev | grep -A1 ENABLE_DOCS` shows `value: "true"` (after patch merge)
- [ ] After deploy, `curl -I https://auth.madfam.io/docs` returns `404` (or whatever the gated branch returns)
- [ ] Local `uvicorn` boot still serves `/docs` at `localhost:4100`

## References

- Audit doc: `/Users/aldoruizluna/labspace/claudedocs/ECOSYSTEM_AUDIT_2026-04-23.md`
- `janua/CLAUDE.md` § "Known Issues - Audit 2026-04-23" → H9 entry
- Roadmap: Wave 1 hardening sweep follow-up

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>