### PR TITLE
chore(janua): resolve 17 CodeQL lint findings (py/unused-import + py/empty-except)

### DIFF
--- a/apps/api/app/analytics.py
+++ b/apps/api/app/analytics.py
@@ -1,7 +1,10 @@
 """PostHog analytics client -- graceful no-op when API key is empty."""
 
+import logging
 import os
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 _client: Optional[object] = None
 
@@ -18,7 +21,8 @@ def init_posthog() -> None:
         posthog.host = os.environ.get("POSTHOG_HOST", "https://analytics.madfam.io")
         _client = posthog
     except ImportError:
-        pass
+        # posthog package not installed -- analytics permanently disabled.
+        logger.debug("posthog package not installed; analytics disabled")
 
 
 def track(distinct_id: str, event: str, properties: Optional[dict] = None) -> None:
@@ -28,7 +32,9 @@ def track(distinct_id: str, event: str, properties: Optional[dict] = None) -> No
     try:
         _client.capture(distinct_id, event, properties=properties or {})
     except Exception:
-        pass
+        # Telemetry must never break a request path. Log at debug to avoid
+        # log spam when the analytics endpoint is degraded.
+        logger.debug("posthog capture failed", exc_info=True)
 
 
 def identify(distinct_id: str, properties: Optional[dict] = None) -> None:
@@ -38,7 +44,9 @@ def identify(distinct_id: str, properties: Optional[dict] = None) -> None:
     try:
         _client.identify(distinct_id, properties=properties or {})
     except Exception:
-        pass
+        # Telemetry must never break a request path. Log at debug to avoid
+        # log spam when the analytics endpoint is degraded.
+        logger.debug("posthog identify failed", exc_info=True)
 
 
 def shutdown() -> None:
@@ -48,4 +56,5 @@ def shutdown() -> None:
     try:
         _client.shutdown()
     except Exception:
-        pass
+        # Shutdown is best-effort during process exit; failures are not actionable.
+        logger.debug("posthog shutdown failed", exc_info=True)

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -48,7 +48,6 @@ from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
 from starlette.exceptions import HTTPException as StarletteHTTPException
-from starlette.middleware.base import BaseHTTPMiddleware
 from urllib.parse import urlparse
 
 # Secure password hashing context - using bcrypt 2b to avoid passlib wrap bug detection issue

--- a/apps/api/app/middleware/api_key_auth.py
+++ b/apps/api/app/middleware/api_key_auth.py
@@ -18,7 +18,6 @@ Must be registered BEFORE DynamicCORSMiddleware in main.py so that
 the injected headers are available to route handlers.
 """
 
-import hashlib
 import logging
 import time
 from collections import defaultdict

--- a/apps/api/app/routers/v1/guest.py
+++ b/apps/api/app/routers/v1/guest.py
@@ -8,10 +8,9 @@ specifying an ``org_id`` directly (rate-limited more aggressively).
 from __future__ import annotations
 
 import logging
-import secrets
 import uuid
 from datetime import UTC, datetime, timedelta
-from typing import Any, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field

--- a/apps/api/app/routers/v1/oauth_provider.py
+++ b/apps/api/app/routers/v1/oauth_provider.py
@@ -20,7 +20,7 @@ import secrets
 import time
 from datetime import datetime, timedelta, timezone
 from typing import Optional
-from urllib.parse import urlencode, urlparse
+from urllib.parse import urlencode
 
 import structlog
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, status

--- a/apps/api/scripts/seed_core_clients.py
+++ b/apps/api/scripts/seed_core_clients.py
@@ -22,7 +22,7 @@ import os
 import secrets
 import sys
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 
 import bcrypt

--- a/apps/api/tests/unit/routers/test_api_keys.py
+++ b/apps/api/tests/unit/routers/test_api_keys.py
@@ -11,14 +11,14 @@ Covers:
 
 import hashlib
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
-from app.models import ApiKey, Organization, OrganizationMember, User, UserStatus
+from app.models import Organization, OrganizationMember, User, UserStatus
 from app.services.api_key_service import ApiKeyService
 
 

--- a/apps/api/tests/unit/routers/test_guest.py
+++ b/apps/api/tests/unit/routers/test_guest.py
@@ -3,10 +3,9 @@
 from __future__ import annotations
 
 import uuid
-from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime
+from unittest.mock import MagicMock, patch
 
-import pytest
 from fastapi.testclient import TestClient
 
 

--- a/scripts/secrets/test_rotation_monitor.py
+++ b/scripts/secrets/test_rotation_monitor.py
@@ -8,11 +8,8 @@ from __future__ import annotations
 
 from datetime import date
 
-import pytest
-
 from rotation_monitor import (
     BOOTSTRAP_SENTINEL,
-    Finding,
     _classify,
     evaluate,
 )


### PR DESCRIPTION
## Summary
- Removes 13 unused Python imports flagged by CodeQL (`py/unused-import`).
- Replaces 4 silent `except: pass` blocks in `apps/api/app/analytics.py` with `logger.debug(..., exc_info=True)` + explanatory comments. PostHog telemetry must remain best-effort, but fully silent excepts hide misconfigurations during ops triage.

## Files touched
- `scripts/secrets/test_rotation_monitor.py` -- drop unused `pytest`, `Finding`
- `apps/api/tests/unit/routers/test_api_keys.py` -- drop `timedelta`, `ApiKey`
- `apps/api/tests/unit/routers/test_guest.py` -- drop `pytest`, `AsyncMock`, `timedelta`, `UTC`
- `apps/api/app/middleware/api_key_auth.py` -- drop `hashlib`
- `apps/api/app/routers/v1/oauth_provider.py` -- drop `urlparse`
- `apps/api/app/routers/v1/guest.py` -- drop `secrets`, `Any`
- `apps/api/app/main.py` -- drop `BaseHTTPMiddleware`
- `apps/api/scripts/seed_core_clients.py` -- drop `timezone`
- `apps/api/app/analytics.py` -- instrument 4 except blocks (PostHog wrapper, no behavior change)

## NOT in this PR (deferred)
5 py/empty-except findings in apps/api/app/routers/v1/auth.py (lines 396, 400, 996, 1005, 1009). auth.py is the login/logout router; per Wave 2 charter "DO NOT merge anything that touches the JWT signing path without manual review", these are deferred to a focused manual-reviewed PR.

## Test plan
- [x] All modified Python files pass ast.parse (no syntax regressions).
- [ ] pytest in apps/api/ -- pre-existing CI debt on main may show unrelated failures; CodeQL re-run will confirm 17 findings closed.
- [ ] Local runtime sanity: imports remain consistent with all call sites grepped before removal.

## Related
- Plan: claudedocs/security-remediation-2026-04-27/remediation-plan.md (Wave 2: janua)
- Total CodeQL alerts before: 82 (29 medium / 17 high mix). This PR targets 17 of the lint-style ones; remaining work covered by separate dep-CVE bumps.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>