### PR TITLE
feat(status): declare 3 platform entries in enclii.yaml (zero-touch backfill)

### DIFF
--- a/enclii.yaml
+++ b/enclii.yaml
@@ -17,6 +17,32 @@ promotion:
   require_smoke_pass: true
 
 spec:
+  # status.madfam.io tracking — Janua is the ecosystem auth floor.
+  # Pre-existing entries on the platform configmap were hand-added in
+  # the legacy era (before zero-touch). Declaring them here locks them
+  # into the regenerate path so the next `POST /v1/admin/status/regenerate`
+  # cannot silently drop them. See Phase 2 follow-up backfill 2026-04-27.
+  status:
+    enabled: true
+    entries:
+      - name: Auth
+        url: https://auth.madfam.io/health
+        href: https://auth.madfam.io
+        group: Janua
+        family: MADFAM Platform
+        description: SSO authentication service
+      - name: Janua Website
+        url: https://janua.dev
+        href: https://janua.dev
+        group: Janua
+        family: MADFAM Platform
+        description: Product landing page
+      - name: Janua Docs
+        url: https://docs.janua.dev
+        href: https://docs.janua.dev
+        group: Janua
+        family: MADFAM Platform
+        description: Authentication documentation
   runtime:
     port: 8080
     replicas: 1


### PR DESCRIPTION
## Summary
- Declares the 3 Janua entries (Auth / Janua Website / Janua Docs) in this repo's `enclii.yaml` `status.entries[]`.
- These entries already appear on status.madfam.io but were **hand-added** to the platform configmap (`enclii/apps/status/k8s/madfam/configmap.yaml`) in the legacy era — before the Phase 2 zero-touch onboarding model.
- The `POST /v1/admin/status/regenerate` handler reads from each onboarded project's `ConfigSnapshot.status_entries` (set by enclii.yaml). **Without this PR, the next regenerate would silently drop these 3 entries** because they aren't declared anywhere reachable by the regenerate path.

## Why
Status-page stability — the platform configmap is regenerated, not hand-edited. Locking these into the zero-touch path means:
- The status page can never silently lose Janua entries on the next regenerate
- Adding/editing entries goes through normal repo PR flow (auditable, reviewable)
- Mirrors Tulana (#152) and Symbiosis-HCM (#8) precedents

## Field shape
Each entry uses the **exact** `name`, `url`, `href`, `group`, `family`, `description` values currently in the platform configmap — no probe-URL churn, no rename. Diff is purely additive.

## Test plan
- [x] YAML lint (additive change only, structure mirrors phyne-crm/symbiosis-hcm precedents)
- [ ] After merge: operator runs `enclii onboard --repo madfam-org/janua` (or its idempotent equivalent if already onboarded) + `POST /v1/admin/status/regenerate`
- [ ] Verify the 3 Janua entries persist in `status-config-madfam` configmap after regenerate

## Out of scope
- Operator action (run regenerate). The runbook lives at `internal-devops/runbooks/status-regenerate.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)