### PR TITLE
fix(admin): repair three broken admin endpoints on api.janua.dev

### DIFF
--- a/apps/api/app/routers/v1/admin.py
+++ b/apps/api/app/routers/v1/admin.py
@@ -355,25 +355,28 @@ async def list_all_users(
         except Exception:
             pass  # Table may not exist in production yet
 
+        # Coalesce nullable boolean columns (legacy rows may have NULL).
+        # See migration 000_init.py: email_verified, is_admin, mfa_enabled are nullable=True.
+        # Without this guard, pydantic raises ValidationError -> 500 on the whole list.
         result.append(
             UserAdminResponse(
                 id=str(user.id),
                 email=user.email,
-                email_verified=user.email_verified,
+                email_verified=bool(user.email_verified),
                 username=user.username,
                 first_name=user.first_name,
                 last_name=user.last_name,
-                status=user.status.value,
-                mfa_enabled=user.mfa_enabled,
-                is_admin=user.is_admin,
-                organizations_count=orgs_count,
-                sessions_count=sessions_count,
+                status=user.status.value if user.status else UserStatus.ACTIVE.value,
+                mfa_enabled=bool(user.mfa_enabled),
+                is_admin=bool(user.is_admin),
+                organizations_count=orgs_count or 0,
+                sessions_count=sessions_count or 0,
                 oauth_providers=[
                     p.value if hasattr(p, "value") else str(p) for p in oauth_providers
                 ],
-                passkeys_count=passkeys_count,
+                passkeys_count=passkeys_count or 0,
                 created_at=user.created_at,
-                updated_at=user.updated_at,
+                updated_at=user.updated_at or user.created_at,
                 last_sign_in_at=user.last_sign_in_at,
             )
         )
@@ -574,18 +577,20 @@ async def list_all_organizations(
         )
         members_count = members_result.scalar()
 
+        # Coalesce nullable columns (legacy rows may have NULL billing_plan/owner_id/updated_at).
+        # See migration 000_init.py: owner_id and billing_plan are nullable=True.
         result.append(
             OrganizationAdminResponse(
                 id=str(org.id),
                 name=org.name,
                 slug=org.slug,
-                owner_id=str(org.owner_id),
+                owner_id=str(org.owner_id) if org.owner_id else "",
                 owner_email=owner.email if owner else "unknown",
-                billing_plan=org.billing_plan,
+                billing_plan=org.billing_plan or "free",
                 billing_email=org.billing_email,
-                members_count=members_count,
+                members_count=members_count or 0,
                 created_at=org.created_at,
-                updated_at=org.updated_at,
+                updated_at=org.updated_at or org.created_at,
             )
         )
 

--- a/apps/api/app/routers/v1/organizations.py
+++ b/apps/api/app/routers/v1/organizations.py
@@ -338,6 +338,8 @@ async def list_organizations(
 
     result = []
     for org, role, member_count in user_orgs:
+        # Coalesce nullable columns (legacy rows may have NULL owner_id/billing_plan/updated_at).
+        # See migration 000_init.py for organizations table.
         result.append(
             OrganizationResponse(
                 id=str(org.id),
@@ -345,16 +347,16 @@ async def list_organizations(
                 slug=org.slug,
                 description=org.description,
                 logo_url=org.logo_url,
-                owner_id=str(org.owner_id),
+                owner_id=str(org.owner_id) if org.owner_id else "",
                 settings=org.settings or {},
                 org_metadata=org.org_metadata or {},
                 billing_email=org.billing_email,
-                billing_plan=org.billing_plan,
+                billing_plan=org.billing_plan or "free",
                 created_at=org.created_at,
-                updated_at=org.updated_at,
-                member_count=member_count,  # Already loaded from subquery!
+                updated_at=org.updated_at or org.created_at,
+                member_count=member_count or 0,  # Already loaded from subquery!
                 is_owner=org.owner_id == current_user.id,
-                user_role=role.value if role else None,
+                user_role=role.value if hasattr(role, "value") else (role if role else None),
             )
         )
 

--- a/apps/api/app/routers/v1/organizations/core.py
+++ b/apps/api/app/routers/v1/organizations/core.py
@@ -136,6 +136,9 @@ async def list_organizations(
             if owner:
                 owner_email = owner.email
 
+        # Coalesce nullable columns. Migration 000_init.py declared updated_at
+        # as nullable, and legacy rows can still have NULL values that would
+        # crash pydantic validation for the whole list (-> 500 in dashboard).
         orgs_result.append(
             OrganizationResponse(
                 id=str(org.id),
@@ -145,12 +148,13 @@ async def list_organizations(
                 logo_url=org.logo_url,
                 billing_email=org.billing_email,
                 created_at=org.created_at,
-                updated_at=org.updated_at,
-                member_count=member_count,
+                updated_at=org.updated_at or org.created_at,
+                member_count=member_count or 0,
                 settings=org.settings or {},
                 # Include plan (subscription_tier) and owner_email for UI
                 plan=getattr(org, "subscription_tier", None)
-                or getattr(org, "billing_plan", "community"),
+                or getattr(org, "billing_plan", None)
+                or "community",
                 owner_email=owner_email,
             )
         )

--- a/apps/api/app/routers/v1/sessions.py
+++ b/apps/api/app/routers/v1/sessions.py
@@ -116,7 +116,7 @@ async def list_sessions(
             UserSession.revoked_at.is_(None),
             UserSession.expires_at > datetime.utcnow(),
         )
-        .order_by(UserSession.last_activity_at.desc())
+        .order_by(UserSession.last_activity.desc())
     )
     sessions = result.scalars().all()
 
@@ -137,7 +137,7 @@ async def list_sessions(
                 os=device_info["os"],
                 is_current=session.access_token_jti == current_jti,
                 created_at=session.created_at,
-                last_activity_at=session.last_activity_at,
+                last_activity_at=session.last_activity,
                 expires_at=session.expires_at,
                 revoked=session.revoked,
             )
@@ -193,7 +193,7 @@ async def get_session(
         os=device_info["os"],
         is_current=session.access_token_jti == current_jti,
         created_at=session.created_at,
-        last_activity_at=session.last_activity_at,
+        last_activity_at=session.last_activity,
         expires_at=session.expires_at,
         revoked=session.revoked,
     )
@@ -287,7 +287,7 @@ async def refresh_session(
         raise HTTPException(status_code=404, detail="Session not found or revoked")
 
     # Update last activity
-    session.last_activity_at = datetime.utcnow()
+    session.last_activity = datetime.utcnow()
     await db.commit()
 
     return {"message": "Session refreshed successfully"}
@@ -304,7 +304,7 @@ async def get_recent_activity(
     result = await db.execute(
         select(UserSession)
         .where(UserSession.user_id == current_user.id)
-        .order_by(UserSession.last_activity_at.desc())
+        .order_by(UserSession.last_activity.desc())
         .limit(limit)
     )
     sessions = result.scalars().all()
@@ -317,9 +317,9 @@ async def get_recent_activity(
             {
                 "session_id": str(session.id),
                 "activity_type": "session_created"
-                if session.created_at == session.last_activity_at
+                if session.created_at == session.last_activity
                 else "session_active",
-                "timestamp": session.last_activity_at,
+                "timestamp": session.last_activity,
                 "ip_address": session.ip_address,
                 "device": f"{device_info['browser']} on {device_info['os']}",
                 "device_type": device_info["device_type"],

--- a/apps/api/tests/unit/routers/test_admin_nullable_columns.py
+++ b/apps/api/tests/unit/routers/test_admin_nullable_columns.py
@@ -1,0 +1,243 @@
+"""
+Regression tests for admin endpoints that 500'd on legacy data.
+
+Three production bugs (browser-verified for admin@madfam.io on app.janua.dev):
+
+  1. GET /api/v1/admin/users -> 500
+     Root cause: User.is_admin / mfa_enabled / email_verified are nullable=True
+     in migration 000_init.py. UserAdminResponse declared them as non-Optional
+     `bool`, so any legacy NULL row crashed pydantic validation for the whole list.
+
+  2. GET /api/v1/admin/organizations -> 500 (manifested as "Network request failed"
+     in the dashboard after the SDK fallback to the non-admin endpoint also failed).
+     Root cause: Organization.billing_plan / owner_id are nullable=True; the
+     OrganizationAdminResponse and the user-scoped OrganizationResponse both
+     required `billing_plan: str` and `owner_id: str`.
+
+  3. GET /api/v1/sessions -> 500 (separate from the SDK 404 that was the primary
+     symptom). Router referenced UserSession.last_activity_at, but the model
+     column is `last_activity` (per migration 000_init.py).
+
+These tests construct the response models directly with rows containing the
+nullable fields set to None and assert no validation error is raised.
+"""
+from datetime import datetime
+from uuid import uuid4
+
+from app.models import Organization, User, UserStatus
+from app.routers.v1.admin import OrganizationAdminResponse, UserAdminResponse
+
+# NOTE: `app/routers/v1/organizations.py` (file) is shadowed at import time by
+# the `app/routers/v1/organizations/` package. The package's `core.py` is what
+# the FastAPI app actually serves. Import the response model from the package
+# so the test matches production reality.
+from app.routers.v1.organizations.schemas import OrganizationResponse
+
+
+def _legacy_user_with_nulls() -> User:
+    """Simulate a legacy user row predating the boolean defaults backfill."""
+    user = User(
+        id=uuid4(),
+        email="legacy@example.com",
+        password_hash="hashed",
+        status=UserStatus.ACTIVE,
+        # All three of these were added later as nullable=True and could be NULL:
+        email_verified=None,
+        is_admin=None,
+        mfa_enabled=None,
+        created_at=datetime.utcnow(),
+        updated_at=None,
+        last_sign_in_at=None,
+    )
+    return user
+
+
+def _build_user_admin_response(user: User) -> UserAdminResponse:
+    """Mirror the construction logic in admin.list_all_users()."""
+    return UserAdminResponse(
+        id=str(user.id),
+        email=user.email,
+        email_verified=bool(user.email_verified),
+        username=user.username,
+        first_name=user.first_name,
+        last_name=user.last_name,
+        status=user.status.value if user.status else UserStatus.ACTIVE.value,
+        mfa_enabled=bool(user.mfa_enabled),
+        is_admin=bool(user.is_admin),
+        organizations_count=0,
+        sessions_count=0,
+        oauth_providers=[],
+        passkeys_count=0,
+        created_at=user.created_at,
+        updated_at=user.updated_at or user.created_at,
+        last_sign_in_at=user.last_sign_in_at,
+    )
+
+
+class TestAdminUsersNullableColumns:
+    """Regression: GET /api/v1/admin/users no longer 500s on legacy NULL booleans."""
+
+    def test_legacy_user_with_null_booleans_serializes_cleanly(self):
+        user = _legacy_user_with_nulls()
+        response = _build_user_admin_response(user)
+
+        # Coalesced None -> False (matches column default in the model definition).
+        assert response.email_verified is False
+        assert response.is_admin is False
+        assert response.mfa_enabled is False
+
+        # updated_at falls back to created_at when null.
+        assert response.updated_at == user.created_at
+
+        # last_sign_in_at remains Optional and stays None.
+        assert response.last_sign_in_at is None
+
+    def test_active_admin_with_all_flags_set(self):
+        user = User(
+            id=uuid4(),
+            email="admin@madfam.io",
+            password_hash="hashed",
+            status=UserStatus.ACTIVE,
+            email_verified=True,
+            is_admin=True,
+            mfa_enabled=True,
+            created_at=datetime.utcnow(),
+            updated_at=datetime.utcnow(),
+        )
+        response = _build_user_admin_response(user)
+
+        assert response.email_verified is True
+        assert response.is_admin is True
+        assert response.mfa_enabled is True
+
+    def test_user_with_null_status_falls_back_to_active(self):
+        """Defensive: even if the enum read somehow returns None, no crash."""
+        user = _legacy_user_with_nulls()
+        user.status = None
+        response = _build_user_admin_response(user)
+        assert response.status == UserStatus.ACTIVE.value
+
+
+def _build_admin_org_response(org: Organization) -> OrganizationAdminResponse:
+    """Mirror admin.list_all_organizations() construction."""
+    return OrganizationAdminResponse(
+        id=str(org.id),
+        name=org.name,
+        slug=org.slug,
+        owner_id=str(org.owner_id) if org.owner_id else "",
+        owner_email="unknown",
+        billing_plan=org.billing_plan or "free",
+        billing_email=org.billing_email,
+        members_count=0,
+        created_at=org.created_at,
+        updated_at=org.updated_at or org.created_at,
+    )
+
+
+class TestAdminOrganizationsNullableColumns:
+    """Regression: GET /api/v1/admin/organizations no longer 500s on legacy rows."""
+
+    def test_legacy_org_with_null_billing_plan_serializes(self):
+        org = Organization(
+            id=uuid4(),
+            name="Legacy Org",
+            slug="legacy-org",
+            owner_id=None,  # Orphaned (FK was nullable in 000_init).
+            billing_plan=None,  # Pre-default backfill.
+            created_at=datetime.utcnow(),
+            updated_at=None,
+        )
+        response = _build_admin_org_response(org)
+
+        assert response.billing_plan == "free"
+        assert response.owner_id == ""
+        assert response.updated_at == org.created_at
+
+
+def _build_user_org_response(org: Organization, owner_email=None, member_count=0) -> OrganizationResponse:
+    """Mirror organizations/core.list_organizations() construction (non-admin path)."""
+    return OrganizationResponse(
+        id=str(org.id),
+        name=org.name,
+        slug=org.slug,
+        description=org.description,
+        logo_url=org.logo_url,
+        billing_email=org.billing_email,
+        created_at=org.created_at,
+        updated_at=org.updated_at or org.created_at,
+        member_count=member_count or 0,
+        settings=org.settings or {},
+        plan=getattr(org, "subscription_tier", None)
+        or getattr(org, "billing_plan", None)
+        or "community",
+        owner_email=owner_email,
+    )
+
+
+class TestUserOrganizationsNullableColumns:
+    """Regression: GET /api/v1/organizations (non-admin) no longer 500s on legacy rows.
+
+    This is the dashboard's fallback when the admin endpoint isn't accessible,
+    so it must be hardened too. The user-scoped router lives in
+    apps/api/app/routers/v1/organizations/core.py (the package, which shadows
+    the legacy organizations.py file with the same name).
+    """
+
+    def test_legacy_org_with_null_updated_at(self):
+        org = Organization(
+            id=uuid4(),
+            name="Legacy Org",
+            slug="legacy-org",
+            owner_id=None,
+            billing_plan=None,
+            subscription_tier=None,
+            description=None,
+            logo_url=None,
+            settings=None,
+            org_metadata=None,
+            created_at=datetime.utcnow(),
+            updated_at=None,
+        )
+        response = _build_user_org_response(org, owner_email=None, member_count=None)
+
+        # plan falls back to "community" (the legacy default) when both
+        # subscription_tier and billing_plan are NULL.
+        assert response.plan == "community"
+        # updated_at falls back to created_at to satisfy the required schema field.
+        assert response.updated_at == org.created_at
+        assert response.member_count == 0
+        assert response.settings == {}
+        assert response.owner_email is None
+
+
+class TestSessionsModelColumnFix:
+    """Regression: GET /api/v1/sessions referenced UserSession.last_activity_at.
+
+    The model column is `last_activity` (no `_at`). Importing the router with
+    the wrong attribute would not crash at import time (SQLAlchemy attributes
+    are looked up lazily), but the first request would AttributeError.
+    """
+
+    def test_session_model_has_last_activity_not_last_activity_at(self):
+        from app.models import Session as UserSession
+
+        # The only column should be `last_activity`. The router previously
+        # referenced `last_activity_at` which does not exist on the model.
+        assert hasattr(UserSession, "last_activity")
+        assert not hasattr(UserSession, "last_activity_at")
+
+    def test_router_uses_correct_column_name(self):
+        """The fixed router file should not reference the bad column."""
+        import inspect
+
+        from app.routers.v1 import sessions as sessions_router
+
+        source = inspect.getsource(sessions_router)
+        # The pydantic *response field* is named last_activity_at (public contract);
+        # but every SQLAlchemy access must use .last_activity, not .last_activity_at.
+        # We assert that there is no `UserSession.last_activity_at` or
+        # `session.last_activity_at` in the source.
+        assert "UserSession.last_activity_at" not in source
+        assert "session.last_activity_at" not in source
+        # Sanity: the correct attribute IS used.
+        assert "UserSession.last_activity" in source

--- a/claudedocs/admin-endpoints-three-fixes-repro.sh
+++ b/claudedocs/admin-endpoints-three-fixes-repro.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Manual reproduction script for the three admin endpoint fixes shipped on
+# branch fix/admin-endpoints-three-fixes.
+#
+# Symptoms (browser-verified for admin@madfam.io on app.janua.dev before fix):
+#   1. GET /api/v1/admin/users?page=1&per_page=20 -> 500 Internal Server Error
+#   2. SDK call to list sessions -> 404 Not Found (URL was /sessions, not /api/v1/sessions)
+#      AND, even with the URL fixed, GET /api/v1/sessions -> 500 (column name bug)
+#   3. GET /api/v1/admin/organizations -> 500 (presented in dashboard as "Network
+#      request failed" because the SDK fallback to /api/v1/organizations also 500'd
+#      with the same nullable-column root cause).
+#
+# Usage:
+#   export JANUA_ADMIN_TOKEN="eyJhbGc..."          # admin@madfam.io access token
+#   export JANUA_API="https://api.janua.dev"        # or http://localhost:4100 for local
+#   bash claudedocs/admin-endpoints-three-fixes-repro.sh
+#
+# Expected output AFTER the fix:
+#   [users]   200 (list of users including legacy NULL-flag rows)
+#   [orgs]    200 (list of orgs including legacy NULL billing_plan rows)
+#   [me]      200 (current session)
+#   [list]    200 (active sessions list, ordered by last_activity desc)
+
+set -euo pipefail
+
+JANUA_API="${JANUA_API:-https://api.janua.dev}"
+TOKEN="${JANUA_ADMIN_TOKEN:?JANUA_ADMIN_TOKEN must be set}"
+
+curl_admin() {
+  local label="$1"; shift
+  local path="$1"; shift
+  local code
+  code=$(curl -sS -o /tmp/janua-${label}.json -w "%{http_code}" \
+    -H "Authorization: Bearer ${TOKEN}" \
+    -H "Origin: https://app.janua.dev" \
+    "${JANUA_API}${path}")
+  printf "[%-7s] %s %s\n" "${label}" "${code}" "${path}"
+  if [ "${code}" -ge 400 ]; then
+    head -c 400 /tmp/janua-${label}.json; echo
+  fi
+}
+
+echo "=== Fix 1: /api/v1/admin/users (was 500 on legacy NULL booleans) ==="
+curl_admin users "/api/v1/admin/users?page=1&per_page=20"
+
+echo
+echo "=== Fix 2a: /api/v1/sessions (SDK now uses correct prefix; was 404) ==="
+curl_admin me   "/api/v1/sessions/current"
+curl_admin list "/api/v1/sessions"
+
+echo
+echo "=== Fix 3: /api/v1/admin/organizations (was 500 on legacy NULL billing_plan) ==="
+curl_admin orgs "/api/v1/admin/organizations?page=1&per_page=20"
+
+echo
+echo "All four endpoints should report 200 after the fix is deployed."

--- a/packages/typescript-sdk/package.json
+++ b/packages/typescript-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janua/typescript-sdk",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "description": "Official TypeScript/JavaScript SDK for the Janua authentication API",
   "main": "dist/index.js",

--- a/packages/typescript-sdk/src/__tests__/sessions.test.ts
+++ b/packages/typescript-sdk/src/__tests__/sessions.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for Sessions module
+ *
+ * Regression: All paths must include the `/api/v1` prefix. Prior versions
+ * accidentally called `/sessions/...` which 404'd against `api.janua.dev`.
+ * See branch fix/admin-endpoints-three-fixes.
+ */
+
+import { Sessions } from '../sessions';
+import type { HttpClient } from '../http-client';
+
+describe('Sessions', () => {
+  let sessions: Sessions;
+  let mockHttpClient: jest.Mocked<HttpClient>;
+
+  beforeEach(() => {
+    mockHttpClient = {
+      request: jest.fn().mockResolvedValue({ data: {} }),
+    } as any;
+
+    sessions = new Sessions(mockHttpClient);
+  });
+
+  describe('URL prefixing (regression: 404 on app.janua.dev Sessions tab)', () => {
+    it('listSessions hits /api/v1/sessions', async () => {
+      mockHttpClient.request.mockResolvedValueOnce({
+        data: { data: [], total: 0, page: 1, per_page: 20 },
+      } as any);
+
+      await sessions.listSessions();
+
+      expect(mockHttpClient.request).toHaveBeenCalledWith({
+        method: 'GET',
+        url: '/api/v1/sessions',
+        params: undefined,
+      });
+    });
+
+    it('listSessions forwards params', async () => {
+      mockHttpClient.request.mockResolvedValueOnce({
+        data: { data: [], total: 0, page: 1, per_page: 20 },
+      } as any);
+
+      await sessions.listSessions({ page: 2, per_page: 10 });
+
+      expect(mockHttpClient.request).toHaveBeenCalledWith({
+        method: 'GET',
+        url: '/api/v1/sessions',
+        params: { page: 2, per_page: 10 },
+      });
+    });
+
+    it('getCurrentSession hits /api/v1/sessions/current', async () => {
+      mockHttpClient.request.mockResolvedValueOnce({
+        data: { session: { id: 's1', revoked: false } },
+      } as any);
+
+      await sessions.getCurrentSession();
+
+      expect(mockHttpClient.request).toHaveBeenCalledWith({
+        method: 'GET',
+        url: '/api/v1/sessions/current',
+      });
+    });
+
+    it('getSession hits /api/v1/sessions/{id}', async () => {
+      const id = '11111111-2222-3333-4444-555555555555';
+      mockHttpClient.request.mockResolvedValueOnce({
+        data: { session: { id, revoked: false } },
+      } as any);
+
+      await sessions.getSession(id);
+
+      expect(mockHttpClient.request).toHaveBeenCalledWith({
+        method: 'GET',
+        url: `/api/v1/sessions/${id}`,
+      });
+    });
+
+    it('revokeSession hits DELETE /api/v1/sessions/{id}', async () => {
+      const id = '11111111-2222-3333-4444-555555555555';
+
+      await sessions.revokeSession(id);
+
+      expect(mockHttpClient.request).toHaveBeenCalledWith({
+        method: 'DELETE',
+        url: `/api/v1/sessions/${id}`,
+      });
+    });
+
+    it('revokeAllSessions hits POST /api/v1/sessions/revoke-all', async () => {
+      mockHttpClient.request.mockResolvedValueOnce({
+        data: { revokedCount: 3 },
+      } as any);
+
+      await sessions.revokeAllSessions();
+
+      expect(mockHttpClient.request).toHaveBeenCalledWith({
+        method: 'POST',
+        url: '/api/v1/sessions/revoke-all',
+      });
+    });
+
+    it('refreshSession hits POST /api/v1/sessions/refresh', async () => {
+      mockHttpClient.request.mockResolvedValueOnce({
+        data: { session: { id: 's1', revoked: false } },
+      } as any);
+
+      await sessions.refreshSession();
+
+      expect(mockHttpClient.request).toHaveBeenCalledWith({
+        method: 'POST',
+        url: '/api/v1/sessions/refresh',
+      });
+    });
+
+    it('refresh() alias delegates to refreshSession()', async () => {
+      mockHttpClient.request.mockResolvedValueOnce({
+        data: { session: { id: 's1', revoked: false } },
+      } as any);
+
+      await sessions.refresh();
+
+      expect(mockHttpClient.request).toHaveBeenCalledWith({
+        method: 'POST',
+        url: '/api/v1/sessions/refresh',
+      });
+    });
+  });
+
+  describe('verifySession', () => {
+    it('returns valid=true when session exists and is not revoked', async () => {
+      const id = '11111111-2222-3333-4444-555555555555';
+      mockHttpClient.request.mockResolvedValueOnce({
+        data: { session: { id, revoked: false } },
+      } as any);
+
+      const result = await sessions.verifySession(id);
+
+      expect(result.valid).toBe(true);
+      expect(result.session?.id).toBe(id);
+    });
+
+    it('returns valid=false when session is revoked', async () => {
+      const id = '11111111-2222-3333-4444-555555555555';
+      mockHttpClient.request.mockResolvedValueOnce({
+        data: { session: { id, revoked: true } },
+      } as any);
+
+      const result = await sessions.verifySession(id);
+
+      expect(result.valid).toBe(false);
+    });
+
+    it('returns valid=false when getSession throws', async () => {
+      const id = '11111111-2222-3333-4444-555555555555';
+      mockHttpClient.request.mockRejectedValueOnce(new Error('Not found'));
+
+      const result = await sessions.verifySession(id);
+
+      expect(result.valid).toBe(false);
+      expect(result.session).toBeUndefined();
+    });
+  });
+});

--- a/packages/typescript-sdk/src/sessions.ts
+++ b/packages/typescript-sdk/src/sessions.ts
@@ -7,6 +7,12 @@ import type { Session, SessionListParams, PaginatedResponse, UUID } from './type
 
 /**
  * Sessions module for managing user sessions
+ *
+ * NOTE: All paths must include the `/api/v1` prefix to match the FastAPI
+ * router mount point (apps/api/app/main.py: include_router(..., prefix="/api/v1")).
+ * Prior versions called `/sessions/...` directly which 404'd in production
+ * because baseURL was `https://api.janua.dev` (the dashboard's Sessions tab
+ * displayed "Failed to Load Sessions — Request failed with status code 404").
  */
 export class Sessions {
   constructor(private httpClient: HttpClient) {}
@@ -17,7 +23,7 @@ export class Sessions {
   async getCurrentSession(): Promise<Session> {
     const response = await this.httpClient.request<{ session: Session }>({
       method: 'GET',
-      url: '/sessions/current'
+      url: '/api/v1/sessions/current'
     });
     return response.data.session;
   }
@@ -28,7 +34,7 @@ export class Sessions {
   async listSessions(params?: SessionListParams): Promise<PaginatedResponse<Session>> {
     const response = await this.httpClient.request<PaginatedResponse<Session>>({
       method: 'GET',
-      url: '/sessions',
+      url: '/api/v1/sessions',
       params
     });
     return response.data;
@@ -40,7 +46,7 @@ export class Sessions {
   async getSession(sessionId: UUID): Promise<Session> {
     const response = await this.httpClient.request<{ session: Session }>({
       method: 'GET',
-      url: `/sessions/${sessionId}`
+      url: `/api/v1/sessions/${sessionId}`
     });
     return response.data.session;
   }
@@ -51,7 +57,7 @@ export class Sessions {
   async revokeSession(sessionId: UUID): Promise<void> {
     await this.httpClient.request({
       method: 'DELETE',
-      url: `/sessions/${sessionId}`
+      url: `/api/v1/sessions/${sessionId}`
     });
   }
 
@@ -61,7 +67,7 @@ export class Sessions {
   async revokeAllSessions(): Promise<{ revokedCount: number }> {
     const response = await this.httpClient.request<{ revokedCount: number }>({
       method: 'POST',
-      url: '/sessions/revoke-all'
+      url: '/api/v1/sessions/revoke-all'
     });
     return response.data;
   }
@@ -72,7 +78,7 @@ export class Sessions {
   async refreshSession(): Promise<Session> {
     const response = await this.httpClient.request<{ session: Session }>({
       method: 'POST',
-      url: '/sessions/refresh'
+      url: '/api/v1/sessions/refresh'
     });
     return response.data.session;
   }


### PR DESCRIPTION
## Summary

Three production admin endpoints on api.janua.dev were broken (browser-verified for admin@madfam.io on app.janua.dev). Each had a distinct root cause:

- **GET /api/v1/admin/users -> 500**: Pydantic validation crashed on legacy rows with NULL `email_verified` / `is_admin` / `mfa_enabled` (all declared `nullable=True` in 000_init.py but typed as non-Optional `bool` in `UserAdminResponse`). Fixed by coalescing via `bool()`.
- **Sessions tab -> 404 + 500**: Two compounding bugs.
  1. `packages/typescript-sdk/src/sessions.ts` called `/sessions/...` directly while every other SDK module uses `/api/v1/...`. Resolved against `https://api.janua.dev` -> 404.
  2. The API router referenced `UserSession.last_activity_at` but the model column is `last_activity` (no `_at`). Even with the URL fixed it would AttributeError. The pydantic *response field* is unchanged — only the SQLAlchemy attribute reads were wrong.
- **GET /api/v1/admin/organizations -> "Network request failed"**: Same nullable-column pattern — `Organization.billing_plan` and `owner_id` are nullable, response schemas required them. The dashboard's SDK fallback to `/api/v1/organizations` (the user-scoped path served by `organizations/core.py`, which shadows `organizations.py`) also 500'd on NULL `updated_at`. Both paths hardened.

@janua/typescript-sdk bumped 0.1.3 -> 0.1.4.

## Test plan
- [x] 11 new SDK tests in `packages/typescript-sdk/src/__tests__/sessions.test.ts` lock in `/api/v1/sessions/...` URLs
- [x] 7 new API tests in `apps/api/tests/unit/routers/test_admin_nullable_columns.py` cover NULL booleans/strings on user + org rows and assert `UserSession.last_activity_at` is no longer referenced in the sessions router
- [x] Existing admin/organizations SDK tests still pass (54 tests)
- [x] `ruff check` clean on all touched Python files
- [x] `tsc --noEmit` clean on the SDK
- [ ] Manual `curl` reproduction (blocked on admin token) via `claudedocs/admin-endpoints-three-fixes-repro.sh`
- [ ] Browser smoke on app.janua.dev once deployed: Users / Sessions / Organizations tabs all load 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)