### PR TITLE
security: gate /metrics* and remove false SOC 2 Type II claim

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -39,7 +39,7 @@ if _sentry_dsn:
         pass  # sentry-sdk not installed
 
 
-from fastapi import FastAPI, HTTPException, Request
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.trustedhost import TrustedHostMiddleware
 from passlib.context import CryptContext
@@ -701,8 +701,42 @@ def jwks():
     return jwt_manager.get_jwks()
 
 
+# ---------------------------------------------------------------------------
+# Metrics auth guard
+#
+# /metrics, /metrics/performance, and /metrics/scalability disclose
+# endpoint inventory, latency profiles, and per-path call counters
+# (including paths probed by attackers). Public exposure on
+# api.janua.dev is an information-disclosure risk, so we gate them
+# behind a service-to-service token distinct from user auth.
+#
+# Set METRICS_TOKEN in the API deployment env. In-cluster Prometheus
+# scrapes must send it as `Authorization: Bearer <METRICS_TOKEN>`.
+# If METRICS_TOKEN is unset (e.g., local dev), the endpoints are open
+# only when ENVIRONMENT in {"development", "test"}; in any other
+# environment an unset token causes a 404 (fail-closed).
+# ---------------------------------------------------------------------------
+def _require_metrics_token(request: Request) -> None:
+    expected = os.getenv("METRICS_TOKEN", "").strip()
+    if not expected:
+        # Fail-open only in non-prod-like environments.
+        if settings.ENVIRONMENT in {"development", "test"}:
+            return
+        # Treat as not-configured -> 404 to avoid signalling existence.
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    auth = request.headers.get("authorization", "")
+    if not auth.lower().startswith("bearer "):
+        # 404 (not 401) so unauthenticated probes cannot fingerprint /metrics*.
+        raise HTTPException(status_code=404, detail="Not Found")
+
+    presented = auth.split(" ", 1)[1].strip()
+    if not secrets.compare_digest(presented, expected):
+        raise HTTPException(status_code=404, detail="Not Found")
+
+
 # Performance metrics endpoint
-@app.get("/metrics/performance")
+@app.get("/metrics/performance", dependencies=[Depends(_require_metrics_token)])
 async def performance_metrics():
     """Get API performance metrics"""
     from app.core.performance import get_performance_metrics
@@ -711,7 +745,7 @@ async def performance_metrics():
 
 
 # Prometheus metrics endpoint
-@app.get("/metrics")
+@app.get("/metrics", dependencies=[Depends(_require_metrics_token)])
 async def prometheus_metrics():
     """Prometheus metrics endpoint"""
     from prometheus_client import CONTENT_TYPE_LATEST, CollectorRegistry, generate_latest
@@ -813,7 +847,7 @@ async def prometheus_metrics():
 
 
 # Scalability status endpoint
-@app.get("/metrics/scalability")
+@app.get("/metrics/scalability", dependencies=[Depends(_require_metrics_token)])
 async def scalability_metrics():
     """Get enterprise scalability status and metrics"""
     return await get_scalability_status()

--- a/apps/api/tests/unit/test_metrics_auth.py
+++ b/apps/api/tests/unit/test_metrics_auth.py
@@ -1,0 +1,106 @@
+"""
+Tests for the /metrics* auth guard added to mitigate the public-surfaces
+audit finding (Prometheus exposition + per-endpoint latency profile reachable
+on api.janua.dev without authentication).
+
+These tests exercise `app.main._require_metrics_token` directly so they do
+not depend on the full FastAPI app graph (which pulls in DB, Redis, Vault).
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+
+def _make_request(headers: dict | None = None):
+    """Build a minimal Starlette Request wrapper exposing only `.headers`."""
+
+    class _Req:
+        def __init__(self, hdrs: dict | None):
+            # Starlette headers are case-insensitive; mimic that with a dict
+            # whose keys are lowercased for the .get() calls in the guard.
+            self.headers = {k.lower(): v for k, v in (hdrs or {}).items()}
+
+    return _Req(headers)
+
+
+@pytest.fixture
+def guard():
+    # Import lazily so the test file doesn't fail collection if a peer
+    # module breaks; this keeps the regression check tight.
+    from app.main import _require_metrics_token
+
+    return _require_metrics_token
+
+
+def test_guard_404_when_token_unset_in_production(guard):
+    with patch.dict(os.environ, {"METRICS_TOKEN": ""}, clear=False):
+        with patch("app.main.settings") as st:
+            st.ENVIRONMENT = "production"
+            with pytest.raises(HTTPException) as exc:
+                guard(_make_request())
+            assert exc.value.status_code == 404
+
+
+def test_guard_open_in_development_when_token_unset(guard):
+    with patch.dict(os.environ, {"METRICS_TOKEN": ""}, clear=False):
+        with patch("app.main.settings") as st:
+            st.ENVIRONMENT = "development"
+            # Should NOT raise.
+            assert guard(_make_request()) is None
+
+
+def test_guard_404_when_token_set_but_no_authorization_header(guard):
+    with patch.dict(os.environ, {"METRICS_TOKEN": "shh-secret"}, clear=False):
+        with patch("app.main.settings") as st:
+            st.ENVIRONMENT = "production"
+            with pytest.raises(HTTPException) as exc:
+                guard(_make_request())
+            assert exc.value.status_code == 404
+
+
+def test_guard_404_when_token_set_but_authorization_is_wrong_scheme(guard):
+    with patch.dict(os.environ, {"METRICS_TOKEN": "shh-secret"}, clear=False):
+        with patch("app.main.settings") as st:
+            st.ENVIRONMENT = "production"
+            req = _make_request({"authorization": "Basic Zm9vOmJhcg=="})
+            with pytest.raises(HTTPException) as exc:
+                guard(req)
+            assert exc.value.status_code == 404
+
+
+def test_guard_404_when_bearer_token_does_not_match(guard):
+    with patch.dict(os.environ, {"METRICS_TOKEN": "shh-secret"}, clear=False):
+        with patch("app.main.settings") as st:
+            st.ENVIRONMENT = "production"
+            req = _make_request({"authorization": "Bearer wrong-token"})
+            with pytest.raises(HTTPException) as exc:
+                guard(req)
+            assert exc.value.status_code == 404
+
+
+def test_guard_passes_when_bearer_token_matches(guard):
+    with patch.dict(os.environ, {"METRICS_TOKEN": "shh-secret"}, clear=False):
+        with patch("app.main.settings") as st:
+            st.ENVIRONMENT = "production"
+            req = _make_request({"authorization": "Bearer shh-secret"})
+            # Should NOT raise.
+            assert guard(req) is None
+
+
+def test_guard_uses_constant_time_compare(guard):
+    """
+    We compare with secrets.compare_digest. A near-miss must still 404, not
+    leak timing/length info.
+    """
+    with patch.dict(os.environ, {"METRICS_TOKEN": "shh-secret"}, clear=False):
+        with patch("app.main.settings") as st:
+            st.ENVIRONMENT = "production"
+            req = _make_request({"authorization": "Bearer shh-secre"})  # off by one
+            with pytest.raises(HTTPException) as exc:
+                guard(req)
+            assert exc.value.status_code == 404

--- a/apps/website/app/demo/compliance/page.tsx
+++ b/apps/website/app/demo/compliance/page.tsx
@@ -466,9 +466,9 @@ async function handleDataDeletionRequest(userId: string) {
           </div>
 
           <div>
-            <h4 className="font-medium text-gray-900 dark:text-white mb-2">SOC 2 Type II</h4>
+            <h4 className="font-medium text-gray-900 dark:text-white mb-2">SOC 2 Controls Support</h4>
             <p className="text-gray-600 dark:text-gray-400 mb-2">
-              System and Organization Controls:
+              Audit-log capabilities aligned with SOC 2 control families (audit not yet completed):
             </p>
             <ul className="text-gray-600 dark:text-gray-400 space-y-1">
               <li>✓ Comprehensive audit logging</li>

--- a/apps/website/app/solutions/enterprise/page.tsx
+++ b/apps/website/app/solutions/enterprise/page.tsx
@@ -64,9 +64,9 @@ export default function EnterprisePage() {
               <div className="w-16 h-16 bg-blue-100 dark:bg-blue-900/20 rounded-full flex items-center justify-center mx-auto mb-4">
                 <Award className="w-8 h-8 text-blue-600 dark:text-blue-400" />
               </div>
-              <h3 className="font-semibold text-slate-900 dark:text-white mb-2">SOC 2 Type II</h3>
+              <h3 className="font-semibold text-slate-900 dark:text-white mb-2">SOC 2: Type II Audit In Progress</h3>
               <p className="text-sm text-slate-600 dark:text-slate-400">
-                Certified secure by independent auditors
+                Controls implemented; certification audit in progress
               </p>
             </div>
 

--- a/apps/website/components/sections/security-trust-center.tsx
+++ b/apps/website/components/sections/security-trust-center.tsx
@@ -27,12 +27,11 @@ export function SecurityTrustCenter() {
 
   const certifications: Certification[] = [
     {
-      name: 'SOC 2 Type II',
-      status: 'certified',
+      name: 'SOC 2: Type II Audit In Progress',
+      status: 'in-progress',
       issuer: 'AICPA',
-      validUntil: '2026-03-15',
       logo: '🔒',
-      description: 'Comprehensive security, availability, and confidentiality controls validated by independent auditors.'
+      description: 'Security, availability, and confidentiality controls implemented. Independent Type II audit in progress; report not yet issued.'
     },
     {
       name: 'ISO 27001',

--- a/apps/website/components/sections/trust.tsx
+++ b/apps/website/components/sections/trust.tsx
@@ -151,10 +151,10 @@ export function TrustSection() {
               </svg>
             </div>
             <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
-              SOC 2 Type II
+              SOC 2: Type II Audit In Progress
             </h3>
             <p className="text-sm text-gray-600 dark:text-gray-400">
-              Audited security and availability controls
+              Controls implemented; audit in progress
             </p>
           </div>
 

--- a/k8s/base/deployments/janua-api.yaml
+++ b/k8s/base/deployments/janua-api.yaml
@@ -93,6 +93,15 @@ spec:
                 secretKeyRef:
                   name: janua-secrets
                   key: field-encryption-key
+            # Metrics auth (gates /metrics, /metrics/performance, /metrics/scalability).
+            # Optional: when unset in production, /metrics* return 404 (fail-closed).
+            # In-cluster Prometheus must send `Authorization: Bearer $METRICS_TOKEN`.
+            - name: METRICS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: janua-secrets
+                  key: metrics-token
+                  optional: true
             # Configuration
             - name: PORT
               value: "8080"


### PR DESCRIPTION
## Summary

Remediation for two findings in `claudedocs/janua-public-surfaces-audit.md`:

- **Finding 1 (info disclosure):** `/metrics`, `/metrics/performance`, and `/metrics/scalability` were reachable unauthenticated on `api.janua.dev`, leaking endpoint inventory, latency profiles, and per-path call counts (including a recent attacker-probe path `GET:/api/v1/auth/login-form'`). Added a bearer-token guard backed by `METRICS_TOKEN` (fail-closed in production: 404 when unset). Health probes (`/health`, `/ready`) untouched.
- **Finding 2 (fraudulent claim):** Removed `SOC 2 Type II` certification language from public marketing surfaces while the product is in Private Alpha. Replaced with `SOC 2: Type II Audit In Progress`. `grep -ri "SOC 2 Type II" apps/website` now returns zero hits.

## Test plan

- [x] `pytest apps/api/tests/unit/test_metrics_auth.py` -- 7 new tests pass (fail-closed prod, dev fallthrough, wrong/missing bearer, constant-time match)
- [x] `grep -ri "SOC 2 Type II" apps/website` returns zero hits
- [ ] Post-deploy: `curl -i https://api.janua.dev/metrics` returns 404 (not Prometheus output) once image is rolled out
- [ ] Post-deploy: in-cluster Prometheus scrape requires `METRICS_TOKEN` to be set in `janua-secrets` and the scrape config to send `Authorization: Bearer <token>` -- otherwise scrape will start returning 404 until the token is provisioned (deliberate fail-closed default)

## Deployment notes

`METRICS_TOKEN` is wired into `janua-api.yaml` as an **optional** `secretKeyRef` (`janua-secrets/metrics-token`). When the secret key is missing, the env var is unset and the guard returns 404 in production -- safe default. To re-enable in-cluster Prometheus scraping, populate `metrics-token` in the `janua-secrets` Secret and update the Prometheus scrape config to include `bearer_token` (or `bearer_token_file`).

## Other dubious public claims spotted but NOT fixed in this PR

Flagging for a follow-up; explicitly out of scope per the audit-task constraint:

- `apps/website/components/sections/security-trust-center.tsx` still marks ISO 27001, HIPAA, GDPR, PCI DSS as `certified` with `validUntil` dates already in the past (`2025-12-01`, `2025-08-30`).
- `apps/website/components/sections/trust.tsx` lists fictional customer companies with user counts (`50K+`, `75K+`, etc.) for a Private Alpha product (lines 12-36).
- `apps/website/app/solutions/enterprise/page.tsx` claims `99.99% uptime SLA` and SOC 2 compliance in page metadata/description for a Private Alpha product (lines 8, 33, 97, 211).

🤖 Generated with [Claude Code](https://claude.com/claude-code)