### PR TITLE
fix(marketing): clean up dubious public claims flagged in #355

### DIFF
--- a/apps/dashboard/app/settings/billing/page.tsx
+++ b/apps/dashboard/app/settings/billing/page.tsx
@@ -72,6 +72,16 @@ interface PlanDetails {
   badge?: string
 }
 
+// Source of truth for prices and MAU caps:
+//   apps/api/app/services/billing_service.py → PRICING_TIERS
+// Community: free, 2,000 MAU
+// Pro:       $69 / 1,380 MXN, 10,000 MAU
+// Scale:     $299 / 5,980 MXN, 50,000 MAU
+// Enterprise: custom
+//
+// If you change these, update PRICING_TIERS first and propagate. The
+// marketing site (apps/website/components/sections/pricing.tsx) and
+// comparison table are aligned to the same canonical values.
 const plans: PlanDetails[] = [
   {
     id: 'community',
@@ -80,7 +90,7 @@ const plans: PlanDetails[] = [
     period: 'forever',
     description: 'For personal projects and small teams getting started.',
     features: [
-      'Up to 1,000 monthly active users',
+      'Up to 2,000 monthly active users',
       'Email/password authentication',
       'Social login (Google, GitHub)',
       'Basic MFA (TOTP)',
@@ -92,7 +102,7 @@ const plans: PlanDetails[] = [
   {
     id: 'pro',
     name: 'Pro',
-    price: '$49',
+    price: '$69',
     period: '/month',
     description: 'For growing teams that need more power and flexibility.',
     features: [
@@ -111,11 +121,11 @@ const plans: PlanDetails[] = [
   {
     id: 'scale',
     name: 'Scale',
-    price: '$199',
+    price: '$299',
     period: '/month',
     description: 'For scaling businesses with advanced security needs.',
     features: [
-      'Up to 100,000 monthly active users',
+      'Up to 50,000 monthly active users',
       'All Pro features',
       'SCIM provisioning',
       'Advanced audit logs',
@@ -136,8 +146,8 @@ const plans: PlanDetails[] = [
       'Unlimited monthly active users',
       'All Scale features',
       'Dedicated infrastructure',
-      'SLA guarantees (99.99%)',
-      'SOC 2 compliance support',
+      'SLA negotiated per contract',
+      'SOC 2 compliance support (audit in progress)',
       'Custom integrations',
       'On-call engineering support',
       'Migration assistance',

--- a/apps/website/app/solutions/enterprise/page.tsx
+++ b/apps/website/app/solutions/enterprise/page.tsx
@@ -5,7 +5,7 @@ import { ArrowRight, Building2, Shield, Globe, Users, Settings, Lock, FileText, 
 
 export const metadata: Metadata = {
   title: 'Enterprise Authentication | Janua',
-  description: 'Enterprise-grade authentication with SOC 2 compliance, 99.99% uptime, and dedicated support. Secure your organization at scale.',
+  description: 'Enterprise-grade authentication for organizations that need SSO, SCIM, audit logging, and dedicated support. Janua is in Private Alpha; SLAs are negotiated per enterprise contract at launch.',
 }
 
 export default function EnterprisePage() {
@@ -30,8 +30,9 @@ export default function EnterprisePage() {
             </h1>
 
             <p className="text-xl text-slate-600 dark:text-slate-300 mb-10 max-w-3xl mx-auto">
-              SOC 2 compliant, 99.99% uptime SLA, and enterprise-grade security.
-              Secure your organization with authentication infrastructure built for the largest enterprises.
+              SSO, SCIM, audit logging, and a security posture designed for
+              enterprise review. Janua is in Private Alpha — uptime targets and
+              SLAs are agreed in writing as part of each enterprise contract.
             </p>
 
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
@@ -64,9 +65,9 @@ export default function EnterprisePage() {
               <div className="w-16 h-16 bg-blue-100 dark:bg-blue-900/20 rounded-full flex items-center justify-center mx-auto mb-4">
                 <Award className="w-8 h-8 text-blue-600 dark:text-blue-400" />
               </div>
-              <h3 className="font-semibold text-slate-900 dark:text-white mb-2">SOC 2 Type II</h3>
+              <h3 className="font-semibold text-slate-900 dark:text-white mb-2">SOC 2 (in progress)</h3>
               <p className="text-sm text-slate-600 dark:text-slate-400">
-                Certified secure by independent auditors
+                Internal controls implemented; Type II audit not yet started.
               </p>
             </div>
 
@@ -76,7 +77,7 @@ export default function EnterprisePage() {
               </div>
               <h3 className="font-semibold text-slate-900 dark:text-white mb-2">GDPR & CCPA</h3>
               <p className="text-sm text-slate-600 dark:text-slate-400">
-                Full compliance with global privacy regulations
+                Privacy controls implemented and self-attested. External counsel review pending.
               </p>
             </div>
 
@@ -86,7 +87,7 @@ export default function EnterprisePage() {
               </div>
               <h3 className="font-semibold text-slate-900 dark:text-white mb-2">Zero Trust</h3>
               <p className="text-sm text-slate-600 dark:text-slate-400">
-                Built on zero-trust security principles
+                Built on zero-trust principles: every request verified at the edge.
               </p>
             </div>
 
@@ -94,9 +95,9 @@ export default function EnterprisePage() {
               <div className="w-16 h-16 bg-amber-100 dark:bg-amber-900/20 rounded-full flex items-center justify-center mx-auto mb-4">
                 <Globe className="w-8 h-8 text-amber-600 dark:text-amber-400" />
               </div>
-              <h3 className="font-semibold text-slate-900 dark:text-white mb-2">99.99% Uptime</h3>
+              <h3 className="font-semibold text-slate-900 dark:text-white mb-2">SLA (Private Alpha)</h3>
               <p className="text-sm text-slate-600 dark:text-slate-400">
-                Enterprise SLA with financial guarantees
+                Uptime targets are negotiated per enterprise contract. No public SLA is published yet.
               </p>
             </div>
           </div>
@@ -208,16 +209,16 @@ export default function EnterprisePage() {
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-12">
             <div className="text-center">
-              <div className="text-2xl font-bold text-slate-900 dark:text-white mb-2">99.99%</div>
-              <div className="text-sm text-slate-600 dark:text-slate-400">Uptime SLA</div>
+              <div className="text-2xl font-bold text-slate-900 dark:text-white mb-2">SSO + SCIM</div>
+              <div className="text-sm text-slate-600 dark:text-slate-400">SAML 2.0 and SCIM 2.0 supported</div>
             </div>
             <div className="text-center">
-              <div className="text-2xl font-bold text-slate-900 dark:text-white mb-2">&lt; 24h</div>
-              <div className="text-sm text-slate-600 dark:text-slate-400">Support Response</div>
+              <div className="text-2xl font-bold text-slate-900 dark:text-white mb-2">Per-contract</div>
+              <div className="text-sm text-slate-600 dark:text-slate-400">Support response negotiated with each customer</div>
             </div>
             <div className="text-center">
               <div className="text-2xl font-bold text-slate-900 dark:text-white mb-2">SOC 2</div>
-              <div className="text-sm text-slate-600 dark:text-slate-400">Type II Certified</div>
+              <div className="text-sm text-slate-600 dark:text-slate-400">Audit in progress (not yet certified)</div>
             </div>
           </div>
 

--- a/apps/website/components/footer.tsx
+++ b/apps/website/components/footer.tsx
@@ -12,8 +12,10 @@ const navigation = {
     { name: 'Security', href: '#security' },
     { name: 'Performance', href: '#performance' },
     { name: 'Integrations', href: '#integrations' },
-    { name: 'Pricing', href: '/pricing' },
-    { name: 'Changelog', href: '/changelog' }
+    { name: 'Pricing', href: '/pricing' }
+    // 'Changelog' removed — no /changelog page exists yet (was 404).
+    // Re-add when apps/website/app/changelog/page.tsx ships, sourced
+    // from docs/CHANGELOG.md.
   ],
   developers: [
     { name: 'Documentation', href: 'https://docs.janua.dev' },
@@ -42,9 +44,10 @@ const navigation = {
   legal: [
     { name: 'Privacy Policy', href: '/privacy' },
     { name: 'Terms of Service', href: '/terms' },
-    { name: 'Cookie Policy', href: '/cookies' },
-    { name: 'Security', href: '/security' },
-    { name: 'Compliance', href: '/compliance' }
+    { name: 'Cookie Policy', href: '/cookies' }
+    // 'Security' (/security) and 'Compliance' (/compliance) removed —
+    // both 404. Re-add only after thin honest pages exist (e.g. linking
+    // to /.well-known/security.txt and the in-progress audit status).
   ]
 }
 

--- a/apps/website/components/sections/comparison.tsx
+++ b/apps/website/components/sections/comparison.tsx
@@ -76,13 +76,17 @@ export function ComparisonSection() {
       category: 'Pricing',
       items: [
         {
+          // Aligned to apps/api/app/services/billing_service.py PRICING_TIERS
+          // (Community tier mau_limit=2000). Was '10,000' here, which
+          // contradicted the canonical billing config.
           metric: 'Free Tier MAU',
-          janua: '10,000',
+          janua: '2,000',
           clerk: '5,000',
           auth0: '7,000',
           supabase: '50,000'
         },
         {
+          // Pro = $69/mo per PRICING_TIERS (apps/api). Includes 10,000 MAU.
           metric: 'Pro Tier Price',
           janua: '$69/mo',
           clerk: '$99/mo',

--- a/apps/website/components/sections/pricing.tsx
+++ b/apps/website/components/sections/pricing.tsx
@@ -98,7 +98,10 @@ export function PricingSection() {
         'SCIM provisioning',
         'Custom contracts & SLAs',
         'Dedicated support',
-        '99.99% uptime SLA',
+        // SLA is negotiated per contract at launch. We will not advertise a
+        // specific uptime percentage publicly until we have an SRE on-call
+        // rotation, an SLO definition file, and reproducible measurements.
+        'Uptime SLA negotiated per contract',
         'Audit logs (unlimited)',
         'Custom integrations',
         'Data residency options',

--- a/apps/website/components/sections/security-trust-center.tsx
+++ b/apps/website/components/sections/security-trust-center.tsx
@@ -25,61 +25,63 @@ interface Certification {
 export function SecurityTrustCenter() {
   const [selectedCert, setSelectedCert] = useState<Certification | null>(null)
 
+  // Janua is in Private Alpha. None of the frameworks below are independently
+  // certified yet. Each entry reflects the controls implemented internally and
+  // the audit/certification track being pursued. Issuer + validity dates are
+  // published only after a real certification body has signed off.
   const certifications: Certification[] = [
     {
       name: 'SOC 2 Type II',
-      status: 'certified',
-      issuer: 'AICPA',
-      validUntil: '2026-03-15',
+      status: 'in-progress',
+      issuer: 'AICPA (audit pending)',
       logo: '🔒',
-      description: 'Comprehensive security, availability, and confidentiality controls validated by independent auditors.'
+      description: 'Internal controls implemented for security, availability, and confidentiality. Independent audit not yet started.'
     },
     {
       name: 'ISO 27001',
-      status: 'certified',
-      issuer: 'ISO',
-      validUntil: '2025-12-01',
+      status: 'in-progress',
+      issuer: 'ISO (audit pending)',
       logo: '🛡️',
-      description: 'International standard for information security management systems.'
+      description: 'Information security management controls being mapped to ISO 27001 Annex A. Not yet certified.'
     },
     {
       name: 'HIPAA',
-      status: 'certified',
-      issuer: 'HHS',
-      validUntil: '2025-08-30',
+      status: 'in-progress',
+      issuer: 'Self-attested controls only',
       logo: '🏥',
-      description: 'Healthcare data protection and privacy compliance.'
+      description: 'Technical safeguards implemented (encryption, audit trails, access controls). HIPAA does not issue certifications; BAAs are not yet offered.'
     },
     {
       name: 'GDPR',
-      status: 'certified',
-      issuer: 'EU',
+      status: 'in-progress',
+      issuer: 'Self-attested controls only',
       logo: '🇪🇺',
-      description: 'European Union data protection and privacy regulation compliance.'
+      description: 'Data subject rights, data minimization, and EU data residency under active implementation. Not yet validated by external counsel.'
     },
     {
       name: 'PCI DSS',
-      status: 'in-progress',
+      status: 'planned',
       issuer: 'PCI SSC',
       logo: '💳',
-      description: 'Payment card industry data security standard.'
+      description: 'Payment data is processed by Stripe/Conekta/Polar; Janua does not store card data. PCI DSS scope assessment planned alongside SOC 2.'
     },
     {
       name: 'FedRAMP',
       status: 'planned',
       issuer: 'GSA',
       logo: '🏛️',
-      description: 'US government cloud security authorization.'
+      description: 'US government cloud security authorization. Not started; no committed timeline.'
     }
   ]
 
+  // Verifiable, non-fabricated controls. Counts that change over time
+  // (threats blocked, incident-response time) require a real metrics
+  // pipeline before being shown publicly.
   const securityMetrics: SecurityMetric[] = [
-    { label: 'Threats Blocked (24h)', value: '12,453', trend: 'up', status: 'healthy' },
-    { label: 'Security Score', value: '98/100', trend: 'stable', status: 'healthy' },
-    { label: 'Vulnerabilities', value: 0, trend: 'stable', status: 'healthy' },
-    { label: 'Incident Response', value: '<15min', trend: 'stable', status: 'healthy' },
-    { label: 'Encryption', value: 'AES-256', trend: 'stable', status: 'healthy' },
-    { label: 'Audit Logs', value: '100%', trend: 'stable', status: 'healthy' }
+    { label: 'Encryption at rest', value: 'AES-256', trend: 'stable', status: 'healthy' },
+    { label: 'Encryption in transit', value: 'TLS 1.3', trend: 'stable', status: 'healthy' },
+    { label: 'JWT signing', value: 'RS256', trend: 'stable', status: 'healthy' },
+    { label: 'Audit logging', value: 'Hash-chained', trend: 'stable', status: 'healthy' }
   ]
 
   const securityFeatures = [
@@ -131,8 +133,9 @@ export function SecurityTrustCenter() {
             </span>
           </h2>
           <p className="text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
-            Bank-level security with comprehensive compliance certifications.
-            Your data is protected by multiple layers of defense and continuous monitoring.
+            Strong cryptographic primitives, hash-chained audit logs, and zero-trust
+            request handling. Janua is in Private Alpha — formal certifications are
+            in progress and we publish only what we can independently verify.
           </p>
         </motion.div>
 
@@ -270,26 +273,24 @@ export function SecurityTrustCenter() {
           className="bg-gradient-to-r from-blue-600 to-purple-600 rounded-2xl p-12 text-center"
         >
           <h3 className="text-3xl font-bold text-white mb-4">
-            Complete Security Documentation
+            Security questions? Talk to us.
           </h3>
           <p className="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">
-            Access our comprehensive security whitepapers, audit reports, and compliance documentation.
+            We do not yet publish a security whitepaper or audit reports.
+            Reach out and we will share our threat model, controls matrix, and
+            current audit progress directly.
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <Button
+              asChild
               size="lg"
               variant="secondary"
               className="bg-white text-blue-600 hover:bg-gray-100"
             >
-              <FileCheck className="mr-2 w-5 h-5" />
-              Download Security Whitepaper
-            </Button>
-            <Button
-              size="lg"
-              variant="secondary"
-              className="bg-white/10 text-white hover:bg-white/20 border border-white/30"
-            >
-              View Audit Reports
+              <a href="mailto:security@janua.dev">
+                <FileCheck className="mr-2 w-5 h-5" />
+                Email security@janua.dev
+              </a>
             </Button>
           </div>
         </motion.div>

--- a/apps/website/components/sections/trust.tsx
+++ b/apps/website/components/sections/trust.tsx
@@ -2,64 +2,20 @@
 
 import { motion } from 'framer-motion'
 import { useInView } from 'react-intersection-observer'
-import { Badge } from '@janua/ui'
 
-const companies = [
-  {
-    name: 'TechCorp',
-    logo: '/logos/techcorp.svg',
-    size: 'Enterprise',
-    users: '50K+'
-  },
-  {
-    name: 'StartupHub',
-    logo: '/logos/startuphub.svg', 
-    size: 'Scale',
-    users: '25K+'
-  },
-  {
-    name: 'DevTools Inc',
-    logo: '/logos/devtools.svg',
-    size: 'Pro',
-    users: '10K+'
-  },
-  {
-    name: 'BuildCo',
-    logo: '/logos/buildco.svg',
-    size: 'Pro', 
-    users: '15K+'
-  },
-  {
-    name: 'CloudNative',
-    logo: '/logos/cloudnative.svg',
-    size: 'Enterprise',
-    users: '75K+'
-  }
-]
-
-const stats = [
-  {
-    value: '500K+',
-    label: 'Monthly Active Users',
-    description: 'Secured across all platforms'
-  },
-  {
-    value: '99.99%',
-    label: 'Uptime SLA',
-    description: 'Global infrastructure reliability'
-  },
-  {
-    value: '< 30ms',
-    label: 'Verification Speed', 
-    description: 'Edge-optimized performance'
-  },
-  {
-    value: '150+',
-    label: 'Global Locations',
-    description: 'Worldwide coverage'
-  }
-]
-
+/**
+ * TrustSection — Private Alpha placeholder.
+ *
+ * Previous versions of this component listed fictional customer logos
+ * ("TechCorp", "StartupHub", "CloudNative") with fabricated user counts
+ * (50K+, 75K+) and an unsupported 99.99% uptime SLA. Janua is in Private
+ * Alpha; we do not yet have public customers to showcase or an
+ * SRE-backed SLA to advertise.
+ *
+ * This component now renders an honest placeholder until we can replace
+ * it with real, verifiable signals. Do not re-introduce fabricated logos
+ * or stats here.
+ */
 export function TrustSection() {
   const [ref, inView] = useInView({
     triggerOnce: true,
@@ -69,122 +25,23 @@ export function TrustSection() {
   return (
     <section className="py-24 bg-white dark:bg-gray-950" ref={ref}>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        {/* Trust indicators */}
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={inView ? { opacity: 1, y: 0 } : {}}
           transition={{ duration: 0.6 }}
-          className="text-center mb-16"
+          className="text-center"
         >
-          <p className="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-8">
-            Trusted by teams at
+          <p className="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-4">
+            Private Alpha
           </p>
-          
-          {/* Company logos */}
-          <div className="grid grid-cols-2 md:grid-cols-5 gap-8 items-center justify-items-center">
-            {companies.map((company, index) => (
-              <motion.div
-                key={company.name}
-                initial={{ opacity: 0, scale: 0.8 }}
-                animate={inView ? { opacity: 1, scale: 1 } : {}}
-                transition={{ duration: 0.4, delay: index * 0.1 }}
-                className="flex flex-col items-center group cursor-pointer"
-              >
-                {/* Placeholder logo - in production would use actual logos */}
-                <div className="w-20 h-12 bg-gray-100 dark:bg-gray-800 rounded-lg flex items-center justify-center group-hover:bg-gray-200 dark:group-hover:bg-gray-700 transition-colors">
-                  <span className="text-xs font-medium text-gray-600 dark:text-gray-300">
-                    {company.name}
-                  </span>
-                </div>
-                <div className="mt-2 flex items-center gap-2">
-                  <Badge variant="secondary" className="text-xs">
-                    {company.size}
-                  </Badge>
-                  <span className="text-xs text-gray-500 dark:text-gray-400">
-                    {company.users} users
-                  </span>
-                </div>
-              </motion.div>
-            ))}
-          </div>
-        </motion.div>
-
-        {/* Stats */}
-        <motion.div
-          initial={{ opacity: 0 }}
-          animate={inView ? { opacity: 1 } : {}}
-          transition={{ duration: 0.6, delay: 0.3 }}
-          className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8"
-        >
-          {stats.map((stat, index) => (
-            <motion.div
-              key={stat.label}
-              initial={{ opacity: 0, y: 20 }}
-              animate={inView ? { opacity: 1, y: 0 } : {}}
-              transition={{ duration: 0.5, delay: 0.4 + index * 0.1 }}
-              className="text-center"
-            >
-              <div className="text-4xl font-bold text-gray-900 dark:text-white mb-2">
-                {stat.value}
-              </div>
-              <div className="text-lg font-medium text-gray-700 dark:text-gray-300 mb-1">
-                {stat.label}
-              </div>
-              <div className="text-sm text-gray-500 dark:text-gray-400">
-                {stat.description}
-              </div>
-            </motion.div>
-          ))}
-        </motion.div>
-
-        {/* Additional trust signals */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={inView ? { opacity: 1, y: 0 } : {}}
-          transition={{ duration: 0.6, delay: 0.8 }}
-          className="mt-16 grid grid-cols-1 md:grid-cols-3 gap-8"
-        >
-          <div className="text-center p-6 rounded-lg bg-gray-50 dark:bg-gray-900">
-            <div className="inline-flex items-center justify-center w-12 h-12 bg-green-100 dark:bg-green-900/30 rounded-lg mb-4">
-              <svg className="w-6 h-6 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
-            </div>
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
-              SOC 2 Type II
-            </h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              Audited security and availability controls
-            </p>
-          </div>
-
-          <div className="text-center p-6 rounded-lg bg-gray-50 dark:bg-gray-900">
-            <div className="inline-flex items-center justify-center w-12 h-12 bg-blue-100 dark:bg-blue-900/30 rounded-lg mb-4">
-              <svg className="w-6 h-6 text-blue-600 dark:text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
-              </svg>
-            </div>
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
-              GDPR & CCPA
-            </h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              Full compliance with privacy regulations
-            </p>
-          </div>
-
-          <div className="text-center p-6 rounded-lg bg-gray-50 dark:bg-gray-900">
-            <div className="inline-flex items-center justify-center w-12 h-12 bg-purple-100 dark:bg-purple-900/30 rounded-lg mb-4">
-              <svg className="w-6 h-6 text-purple-600 dark:text-purple-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-              </svg>
-            </div>
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
-              99.9% SLA
-            </h3>
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              Enterprise-grade uptime guarantee
-            </p>
-          </div>
+          <h2 className="text-2xl sm:text-3xl font-semibold text-gray-900 dark:text-white mb-4">
+            Customer logos available after public launch
+          </h2>
+          <p className="text-base text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
+            Janua is currently in Private Alpha. We will share customer
+            references, real usage metrics, and uptime data once we have
+            them — not before.
+          </p>
         </motion.div>
       </div>
     </section>


### PR DESCRIPTION
## Summary

PR #355 fixed the SOC 2 'certified' claim but flagged a longer list of similar over-claims that were left for follow-up. This PR clears that list.

- Compliance certifications: ISO 27001 / HIPAA / GDPR / PCI DSS flipped from 'certified' to 'in-progress' (or 'planned'). validUntil dates already in the past dropped.
- Fictional customer logos (TechCorp, StartupHub, CloudNative) and fabricated user counts (50K+, 75K+) removed from trust.tsx; replaced with a Private-Alpha placeholder.
- All four 99.99% uptime SLA claims on /solutions/enterprise dropped (no SRE on-call rotation, no SLO definition file). Replaced with 'SLA negotiated per enterprise contract'.
- Pricing alignment: dashboard $49/$199 -> $69/$299 and MAU caps 1,000 -> 2,000 / 100,000 -> 50,000 to match the canonical PRICING_TIERS in apps/api/app/services/billing_service.py (which actually drives Stripe/Conekta/Polar charges). Comparison table 'Free Tier MAU' 10,000 -> 2,000 for the same reason.
- Broken nav links removed from footer: /changelog, /security, /compliance (all 404'd). Comment in code documents the conditions for re-adding them.

## Files changed

- apps/website/components/sections/security-trust-center.tsx
- apps/website/components/sections/trust.tsx
- apps/website/components/sections/comparison.tsx
- apps/website/components/sections/pricing.tsx
- apps/website/app/solutions/enterprise/page.tsx
- apps/website/components/footer.tsx
- apps/dashboard/app/settings/billing/page.tsx

## Out of scope (flagged for follow-up)

- apps/website/components/sections/honest-pricing.tsx and pricing-preview.tsx contain a third, contradictory pricing scheme (Developer/Startup/Growth at \$0/\$99/\$499 with 10K/50K/250K MAU). honest-pricing.tsx is mounted on the home page; this needs a dedicated alignment PR.
- apps/website/components/sections/pricing.tsx still lists 99.9% (Pro) and 99.95% (Scale) uptime SLA. Same Private Alpha argument applies, but smaller numbers; deferring until a real SLO definition file lands in compliance/.
- apps/website/components/sections/use-cases.tsx and testimonials.tsx contain similar fabricated stats. Currently dead code (not imported by /, /pricing, or /solutions/*) so lower priority.

## Test plan

- [ ] grep -ri \"99.99%|certified secure|TechCorp|50K\\+|75K\\+|10,000 MAU|\\\$49|\\\$199\" apps/website apps/dashboard returns no in-scope hits
- [ ] /pricing page renders with 2K/10K/50K MAU caps matching API
- [ ] /solutions/enterprise hero copy contains no '99.99% SLA'
- [ ] Dashboard /settings/billing shows \$69 Pro / \$299 Scale
- [ ] Footer no longer renders /changelog, /security, /compliance links

## Notes

Pre-existing build errors in apps/website (missing posthog-js module, jest-dom matchers in *.test.tsx files) reproduce on main and are not introduced by this PR.

Refs: #355

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>