### PR TITLE
fix(admin): persist auth tokens to cookies so middleware reads them

### DIFF
--- a/apps/admin/app/api/auth/session/route.test.ts
+++ b/apps/admin/app/api/auth/session/route.test.ts
@@ -1,0 +1,213 @@
+/**
+ * @jest-environment node
+ */
+
+import { POST, DELETE } from './route'
+
+// Capture every cookies().set() call so we can assert flags.
+type CookieCall = {
+  name: string
+  value: string
+  options: {
+    httpOnly?: boolean
+    secure?: boolean
+    sameSite?: 'lax' | 'strict' | 'none'
+    path?: string
+    maxAge?: number
+  }
+}
+
+const cookieCalls: CookieCall[] = []
+
+jest.mock('next/headers', () => ({
+  cookies: jest.fn(async () => ({
+    set: (name: string, value: string, options: CookieCall['options']) => {
+      cookieCalls.push({ name, value, options })
+    },
+  })),
+}))
+
+jest.mock('next/server', () => {
+  class FakeNextResponse {
+    body: unknown
+    status: number
+    constructor(body: unknown, init?: { status?: number }) {
+      this.body = body
+      this.status = init?.status ?? 200
+    }
+    static json(body: unknown, init?: { status?: number }) {
+      return new FakeNextResponse(body, init)
+    }
+  }
+  return { NextResponse: FakeNextResponse }
+})
+
+function makeRequest(body: unknown, opts: { malformed?: boolean } = {}): any {
+  return {
+    json: jest.fn(async () => {
+      if (opts.malformed) throw new Error('invalid json')
+      return body
+    }),
+  }
+}
+
+describe('POST /api/auth/session', () => {
+  beforeEach(() => {
+    cookieCalls.length = 0
+    delete (process.env as any).NODE_ENV
+  })
+
+  it('sets HttpOnly, Lax, path=/ cookies for access token, email, and roles', async () => {
+    ;(process.env as any).NODE_ENV = 'production'
+    const future = Math.floor(Date.now() / 1000) + 3600
+
+    const res: any = await POST(
+      makeRequest({
+        access_token: 'jwt-abc',
+        refresh_token: 'refresh-xyz',
+        email: 'ops@janua.dev',
+        roles: ['superadmin', 'admin'],
+        expires_at: future,
+      })
+    )
+
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ ok: true })
+
+    const byName = Object.fromEntries(cookieCalls.map((c) => [c.name, c]))
+
+    expect(byName.janua_access_token.value).toBe('jwt-abc')
+    expect(byName.janua_access_token.options).toMatchObject({
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
+    })
+    expect(byName.janua_access_token.options.maxAge).toBeGreaterThan(0)
+    expect(byName.janua_access_token.options.maxAge).toBeLessThanOrEqual(3600)
+
+    expect(byName.janua_admin_email.value).toBe('ops@janua.dev')
+    expect(byName.janua_admin_email.options).toMatchObject({
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
+    })
+
+    expect(byName.janua_admin_roles.value).toBe('superadmin,admin')
+    expect(byName.janua_admin_roles.options).toMatchObject({
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
+    })
+
+    expect(byName.janua_refresh_token.value).toBe('refresh-xyz')
+    expect(byName.janua_refresh_token.options.httpOnly).toBe(true)
+  })
+
+  it('marks Secure=false outside production so dev http://localhost works', async () => {
+    ;(process.env as any).NODE_ENV = 'development'
+
+    await POST(
+      makeRequest({
+        access_token: 'jwt-abc',
+        email: 'ops@janua.dev',
+        roles: ['admin'],
+      })
+    )
+
+    const access = cookieCalls.find((c) => c.name === 'janua_access_token')!
+    expect(access.options.secure).toBe(false)
+    expect(access.options.httpOnly).toBe(true)
+    expect(access.options.sameSite).toBe('lax')
+  })
+
+  it('accepts comma-separated roles string and trims whitespace', async () => {
+    await POST(
+      makeRequest({
+        access_token: 'jwt',
+        email: 'ops@janua.dev',
+        roles: ' superadmin , admin ',
+      })
+    )
+
+    const roles = cookieCalls.find((c) => c.name === 'janua_admin_roles')!
+    expect(roles.value).toBe('superadmin , admin')
+  })
+
+  it('omits the refresh-token cookie when no refresh_token is supplied', async () => {
+    await POST(
+      makeRequest({
+        access_token: 'jwt',
+        email: 'ops@janua.dev',
+        roles: ['admin'],
+      })
+    )
+
+    expect(cookieCalls.find((c) => c.name === 'janua_refresh_token')).toBeUndefined()
+  })
+
+  it('rejects requests missing access_token', async () => {
+    const res: any = await POST(
+      makeRequest({ email: 'ops@janua.dev', roles: ['admin'] })
+    )
+    expect(res.status).toBe(400)
+    expect(cookieCalls).toHaveLength(0)
+  })
+
+  it('rejects requests missing email', async () => {
+    const res: any = await POST(makeRequest({ access_token: 'jwt' }))
+    expect(res.status).toBe(400)
+    expect(cookieCalls).toHaveLength(0)
+  })
+
+  it('rejects malformed JSON bodies', async () => {
+    const res: any = await POST(makeRequest(undefined, { malformed: true }))
+    expect(res.status).toBe(400)
+    expect(cookieCalls).toHaveLength(0)
+  })
+
+  it('falls back to a 1-day maxAge when expires_at is missing', async () => {
+    await POST(
+      makeRequest({
+        access_token: 'jwt',
+        email: 'ops@janua.dev',
+        roles: ['admin'],
+      })
+    )
+
+    const access = cookieCalls.find((c) => c.name === 'janua_access_token')!
+    expect(access.options.maxAge).toBe(60 * 60 * 24)
+  })
+})
+
+describe('DELETE /api/auth/session', () => {
+  beforeEach(() => {
+    cookieCalls.length = 0
+  })
+
+  it('expires all four admin cookies with maxAge=0 and HttpOnly=true', async () => {
+    const res: any = await DELETE()
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ ok: true })
+
+    const names = cookieCalls.map((c) => c.name).sort()
+    expect(names).toEqual(
+      [
+        'janua_access_token',
+        'janua_admin_email',
+        'janua_admin_roles',
+        'janua_refresh_token',
+      ].sort()
+    )
+
+    for (const call of cookieCalls) {
+      expect(call.value).toBe('')
+      expect(call.options.maxAge).toBe(0)
+      expect(call.options.httpOnly).toBe(true)
+      expect(call.options.sameSite).toBe('lax')
+      expect(call.options.path).toBe('/')
+    }
+  })
+})

--- a/apps/admin/app/api/auth/session/route.ts
+++ b/apps/admin/app/api/auth/session/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+
+/**
+ * Janua Admin — Session Cookie Bridge
+ *
+ * The browser-side <SignIn> component (and SSO callback) stores access /
+ * refresh tokens in localStorage via the Janua SDK. The admin middleware,
+ * however, gates protected routes on three HttpOnly cookies it reads from
+ * `request.cookies`:
+ *
+ *   - janua_access_token  → bearer used for upstream API calls
+ *   - janua_admin_email   → checked against the email domain allowlist
+ *   - janua_admin_roles   → comma-separated role list parsed by middleware
+ *
+ * Setting HttpOnly cookies from JS in the browser is impossible by design,
+ * so this route handler accepts the freshly-issued sign-in payload and
+ * sets the three cookies server-side. The client invokes POST after a
+ * successful sign-in (from the `afterSignIn` callback) and DELETE on
+ * logout.
+ *
+ * Security:
+ *   - HttpOnly  — JS cannot read the access token (mitigates XSS exfil)
+ *   - Secure    — only sent over TLS in production
+ *   - SameSite=Lax — protects against CSRF on top-level navigations while
+ *     still allowing the dashboard SSO redirect flow to land properly
+ *   - path '/'  — middleware runs on every protected route
+ */
+
+interface SessionPayload {
+  access_token: string
+  refresh_token?: string
+  email: string
+  roles?: string[] | string
+  expires_at?: number | string
+}
+
+const ONE_DAY_SECONDS = 60 * 60 * 24
+
+function normalizeRoles(roles: SessionPayload['roles']): string {
+  if (!roles) return ''
+  if (Array.isArray(roles)) return roles.map((r) => String(r).trim()).filter(Boolean).join(',')
+  return String(roles).trim()
+}
+
+function deriveMaxAge(expiresAt: SessionPayload['expires_at']): number {
+  if (expiresAt === undefined || expiresAt === null) return ONE_DAY_SECONDS
+  const expiresMs = typeof expiresAt === 'string' ? Date.parse(expiresAt) : Number(expiresAt) * 1000
+  if (!Number.isFinite(expiresMs)) return ONE_DAY_SECONDS
+  const seconds = Math.floor((expiresMs - Date.now()) / 1000)
+  if (seconds <= 0) return ONE_DAY_SECONDS
+  // Cap at 30 days to avoid unbounded sessions.
+  return Math.min(seconds, ONE_DAY_SECONDS * 30)
+}
+
+export async function POST(request: NextRequest) {
+  let payload: SessionPayload
+  try {
+    payload = (await request.json()) as SessionPayload
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const accessToken = typeof payload.access_token === 'string' ? payload.access_token.trim() : ''
+  const email = typeof payload.email === 'string' ? payload.email.trim() : ''
+
+  if (!accessToken || !email) {
+    return NextResponse.json(
+      { error: 'access_token and email are required' },
+      { status: 400 }
+    )
+  }
+
+  const roles = normalizeRoles(payload.roles)
+  const maxAge = deriveMaxAge(payload.expires_at)
+  const isProd = process.env.NODE_ENV === 'production'
+
+  const cookieStore = await cookies()
+  const baseOptions = {
+    httpOnly: true,
+    secure: isProd,
+    sameSite: 'lax' as const,
+    path: '/',
+    maxAge,
+  }
+
+  cookieStore.set('janua_access_token', accessToken, baseOptions)
+  cookieStore.set('janua_admin_email', email, baseOptions)
+  cookieStore.set('janua_admin_roles', roles, baseOptions)
+
+  if (payload.refresh_token && typeof payload.refresh_token === 'string') {
+    cookieStore.set('janua_refresh_token', payload.refresh_token, {
+      ...baseOptions,
+      // Refresh tokens get a longer life, capped at 30 days.
+      maxAge: ONE_DAY_SECONDS * 30,
+    })
+  }
+
+  return NextResponse.json({ ok: true }, { status: 200 })
+}
+
+export async function DELETE() {
+  const cookieStore = await cookies()
+  const isProd = process.env.NODE_ENV === 'production'
+  const expireOptions = {
+    httpOnly: true,
+    secure: isProd,
+    sameSite: 'lax' as const,
+    path: '/',
+    maxAge: 0,
+  }
+
+  cookieStore.set('janua_access_token', '', expireOptions)
+  cookieStore.set('janua_admin_email', '', expireOptions)
+  cookieStore.set('janua_admin_roles', '', expireOptions)
+  cookieStore.set('janua_refresh_token', '', expireOptions)
+
+  return NextResponse.json({ ok: true }, { status: 200 })
+}

--- a/apps/admin/app/login/page.tsx
+++ b/apps/admin/app/login/page.tsx
@@ -7,10 +7,17 @@ import { SignIn } from '@janua/ui'
 import { useAuth } from '@/lib/auth'
 import { januaClient } from '@/lib/janua-client'
 
+// localStorage keys written by the Janua SDK. Centralized so they stay in
+// sync with @janua/typescript-sdk's tokenStorage='localStorage' contract.
+const LS_ACCESS_TOKEN = 'janua_access_token'
+const LS_REFRESH_TOKEN = 'janua_refresh_token'
+const LS_EXPIRES_AT = 'janua_token_expires_at'
+
 export default function LoginPage() {
   const router = useRouter()
   const { isAuthenticated, isLoading: authLoading, checkSession } = useAuth()
   const [isCheckingSession, setIsCheckingSession] = useState(true)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   // On mount, check for existing SSO session via cookies
   useEffect(() => {
@@ -50,7 +57,62 @@ export default function LoginPage() {
   }
 
   const handleAfterSignIn = async (user: any) => {
-    router.push('/')
+    // The SDK has just persisted access/refresh tokens to localStorage. Mirror
+    // them into HttpOnly cookies via the server-side session bridge so the
+    // edge middleware can authorize subsequent navigations. Without this step
+    // the user lands on /login -> /, the middleware sees no cookies, and
+    // bounces them right back to /login.
+    try {
+      const accessToken =
+        typeof window !== 'undefined' ? window.localStorage.getItem(LS_ACCESS_TOKEN) : null
+      const refreshToken =
+        typeof window !== 'undefined' ? window.localStorage.getItem(LS_REFRESH_TOKEN) : null
+      const expiresAtRaw =
+        typeof window !== 'undefined' ? window.localStorage.getItem(LS_EXPIRES_AT) : null
+      const expiresAt = expiresAtRaw ? Number(expiresAtRaw) : undefined
+
+      if (!accessToken || !user?.email) {
+        setErrorMessage(
+          'Sign-in succeeded but the session token is missing. Please try again.'
+        )
+        return
+      }
+
+      // Roles may live on user.roles (array), or be derived from is_admin when
+      // the upstream API hasn't materialized roles yet. Lib/auth.tsx applies
+      // the same fallback for client-side state; the cookies must agree.
+      let roles: string[] = Array.isArray(user.roles) ? [...user.roles] : []
+      if (roles.length === 0 && user.is_admin) {
+        roles = ['admin']
+      }
+
+      const res = await fetch('/api/auth/session', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          access_token: accessToken,
+          refresh_token: refreshToken ?? undefined,
+          email: user.email,
+          roles,
+          expires_at: expiresAt,
+        }),
+      })
+
+      if (!res.ok) {
+        setErrorMessage('Failed to establish admin session. Please try again.')
+        return
+      }
+
+      router.push('/')
+    } catch (err) {
+      console.error('Session bridge failed:', err)
+      setErrorMessage('Failed to establish admin session. Please try again.')
+    }
+  }
+
+  const handleError = (error: Error) => {
+    console.error('Login error:', error)
+    setErrorMessage(error?.message || 'Sign-in failed. Please try again.')
   }
 
   return (
@@ -75,10 +137,22 @@ export default function LoginPage() {
           </div>
         </div>
 
+        {/* Sign-in error banner (AJ-2): surface SignIn onError instead of swallowing it */}
+        {errorMessage && (
+          <div
+            role="alert"
+            aria-live="polite"
+            className="mb-4 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive"
+          >
+            <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+            <p className="leading-snug">{errorMessage}</p>
+          </div>
+        )}
+
         <SignIn
           januaClient={januaClient}
           afterSignIn={handleAfterSignIn}
-          onError={(error) => console.error('Login error:', error)}
+          onError={handleError}
           socialProviders={{}}
           enableJanuaSSO={true}
           showEmailPassword={false}

--- a/apps/admin/lib/auth.tsx
+++ b/apps/admin/lib/auth.tsx
@@ -188,6 +188,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     await januaClient.auth.signOut()
     setUser(null)
     setMiddlewareCookies(null)
+    // Clear the HttpOnly admin cookies set by /api/auth/session (POST). The
+    // client-side cookie wipes in setMiddlewareCookies(null) cannot remove
+    // HttpOnly cookies, so we delegate to the server route handler.
+    try {
+      await fetch('/api/auth/session', { method: 'DELETE' })
+    } catch (err) {
+      console.error('Failed to clear admin session cookies:', err)
+    }
     window.location.href = '/login'
   }
 

--- a/apps/admin/next.config.js
+++ b/apps/admin/next.config.js
@@ -17,13 +17,21 @@ const nextConfig = {
     const isDev = process.env.NODE_ENV === 'development'
     const apiUrl = process.env.NEXT_PUBLIC_API_URL || 'https://api.janua.dev'
 
+    // Cloudflare Insights is auto-injected by the Cloudflare proxy on
+    // production hosts; allow its beacon script and analytics endpoint
+    // without weakening the rest of the CSP. Mirrors the dashboard fix
+    // landed on main in 628e3a85.
+    const cfInsightsScript = 'https://static.cloudflareinsights.com'
+    const cfInsightsConnect = 'https://cloudflareinsights.com'
+
     const cspDirectives = [
       "default-src 'self'",
-      `script-src 'self'${isDev ? " 'unsafe-eval'" : ""} 'unsafe-inline' https://static.cloudflareinsights.com`,
+      `script-src 'self'${isDev ? " 'unsafe-eval'" : ""} 'unsafe-inline' ${cfInsightsScript}`,
+      `script-src-elem 'self' 'unsafe-inline' ${cfInsightsScript}`,
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "font-src 'self' data: https://fonts.gstatic.com",
       "img-src 'self' data: https:",
-      `connect-src 'self' ${apiUrl} https://cloudflareinsights.com${isDev ? ' ws://localhost:*' : ''}`,
+      `connect-src 'self' ${apiUrl} ${cfInsightsConnect}${isDev ? ' ws://localhost:*' : ''}`,
       "object-src 'none'",
       "base-uri 'self'",
       "form-action 'self'",


### PR DESCRIPTION
## Summary
- Login on admin.janua.dev was unauthenticatable: the form persisted tokens to localStorage, while middleware reads cookies. Operator submitted credentials → form cleared → manual nav to / bounced back to /login. No error surfaced.
- New POST/DELETE /api/auth/session route handler sets/clears the four HttpOnly cookies the middleware expects (janua_access_token, janua_refresh_token, janua_admin_email, janua_admin_roles).
- afterSignIn callback now POSTs to /api/auth/session before router.push('/').
- logout() now DELETEs /api/auth/session so HttpOnly cookies clear server-side.
- AJ-2: errorMessage state + role=alert banner surfaces sign-in failures.
- AJ-3: CSP allowlist for static.cloudflareinsights.com (mirrors dashboard 628e3a85).

## Audit reference
claudedocs/janua-admin-fidelity-audit.md (in the enclii repo) findings AJ-1, AJ-2, AJ-3.

## Test plan
- [ ] 9 new tests in app/api/auth/session/route.test.ts pass (HttpOnly/Secure/SameSite/path/maxAge flags, prod-vs-dev Secure, role normalization, optional refresh_token, 400 validation, DELETE clears all four)
- [ ] Manual: login as admin@madfam.io → reaches dashboard, no console errors after CSP fix, error banner shows on bad creds

🤖 Generated with [Claude Code](https://claude.com/claude-code)