### PR TITLE
fix(nextjs-sdk): bound /auth/me retries with circuit breaker + visibility gating

### DIFF
--- a/packages/nextjs-sdk/package.json
+++ b/packages/nextjs-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janua/nextjs",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "description": "Official Janua SDK for Next.js applications with App Router and Pages Router support",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/nextjs-sdk/package.json
+++ b/packages/nextjs-sdk/package.json
@@ -70,10 +70,13 @@
     "react-dom": ">=17.0.0"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.0.0",
     "@types/node": "^25.3.0",
     "@types/react": "^18.0.0",
+    "jsdom": "^27.0.0",
     "next": "16.2.4",
     "react": "18.3.1",
+    "react-dom": "18.3.1",
     "tsup": "^8.0.0",
     "typescript": "^5.7.2",
     "vitest": "^1.0.0"

--- a/packages/nextjs-sdk/src/app/index.ts
+++ b/packages/nextjs-sdk/src/app/index.ts
@@ -1,6 +1,17 @@
 // App Router exports
 export { JanuaProvider, useJanua, useAuth, useUser, useOrganizations } from './provider';
-export type { JanuaProviderProps } from './provider';
+export type { JanuaProviderProps, JanuaAuthStatus, CircuitState } from './provider';
+
+// Retry policy primitives — exported for advanced consumers + testing.
+export {
+  RetryController,
+  isCorsOrNetworkError,
+  backoffDelay,
+  DEFAULT_MAX_FAILURES,
+  DEFAULT_BASE_DELAY_MS,
+  DEFAULT_MAX_DELAY_MS,
+} from './retry-policy';
+export type { RetryControllerOptions, RetrySnapshot } from './retry-policy';
 
 export {
   SignInForm,

--- a/packages/nextjs-sdk/src/app/provider.test.tsx
+++ b/packages/nextjs-sdk/src/app/provider.test.tsx
@@ -1,0 +1,247 @@
+/**
+ * Integration tests for JanuaProvider's retry-storm guard.
+ *
+ * Uses raw ReactDOM to avoid a hard dep on @testing-library/react inside
+ * the SDK package. The goal is to verify request budget under failure modes.
+ */
+import React from 'react';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { createRoot, type Root } from 'react-dom/client';
+import { act } from 'react';
+import { JanuaProvider, useAuth } from './provider';
+
+// Tell React this is a test environment so act() works without warnings.
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// --- Stub the JanuaClient module ---------------------------------------
+
+let getCurrentUserCalls = 0;
+let getCurrentUserBehavior: 'cors-fail' | '5xx-fail' | 'success' = 'cors-fail';
+
+vi.mock('@janua/typescript-sdk', () => {
+  class FakeJanuaClient {
+    auth = {
+      getCurrentUser: vi.fn(async () => {
+        getCurrentUserCalls += 1;
+        if (getCurrentUserBehavior === 'cors-fail') {
+          throw new TypeError('Failed to fetch');
+        }
+        if (getCurrentUserBehavior === '5xx-fail') {
+          throw new Error('500 Internal Server Error');
+        }
+        return { id: 'u1', email: 'a@b.c' };
+      }),
+      signOut: vi.fn(async () => undefined),
+      handleOAuthCallback: vi.fn(async () => undefined),
+      refreshToken: vi.fn(async () => undefined),
+    };
+    getAccessToken = vi.fn(async () => null);
+    getRefreshToken = vi.fn(async () => null);
+  }
+  return { JanuaClient: FakeJanuaClient };
+});
+
+vi.mock('../utils/pkce', () => ({
+  validateState: () => true,
+  retrievePKCEParams: () => null,
+  clearPKCEParams: () => undefined,
+}));
+
+// --- Test harness ------------------------------------------------------
+
+interface ProbeHandle {
+  status: () => string;
+  retry: () => void;
+}
+
+const probeHandles: ProbeHandle[] = [];
+
+function Probe() {
+  const { status, manualRetry } = useAuth();
+  // Expose to test
+  React.useEffect(() => {
+    probeHandles.push({
+      status: () => status,
+      retry: () => void manualRetry(),
+    });
+  });
+  return <div data-testid="status">{status}</div>;
+}
+
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
+
+async function renderProvider(opts?: { fastBackoff?: boolean }) {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  // Aggressive backoff for tests: 5ms base, 100ms cap, no jitter so
+  // 5 fail cycles complete inside a single test second.
+  const retryOptions = opts?.fastBackoff
+    ? { baseDelayMs: 5, maxDelayMs: 100, jitter: 0, random: () => 0.5 }
+    : undefined;
+
+  await act(async () => {
+    root!.render(
+      <JanuaProvider
+        config={{ baseURL: 'https://auth.example.test' } as any}
+        retryOptions={retryOptions}
+      >
+        <Probe />
+      </JanuaProvider>
+    );
+  });
+
+  // Drain any pending microtasks from the initial fetch.
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 30));
+  });
+}
+
+function getStatus(): string {
+  return container!.querySelector('[data-testid="status"]')!.textContent || '';
+}
+
+async function clickRetry() {
+  // Find the latest hook value via probeHandles last entry.
+  const handle = probeHandles[probeHandles.length - 1];
+  await act(async () => {
+    handle.retry();
+    await new Promise((r) => setTimeout(r, 20));
+  });
+}
+
+beforeEach(() => {
+  getCurrentUserCalls = 0;
+  getCurrentUserBehavior = 'cors-fail';
+  probeHandles.length = 0;
+  Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+});
+
+afterEach(async () => {
+  if (root) {
+    await act(async () => {
+      root!.unmount();
+    });
+    root = null;
+  }
+  if (container) {
+    container.remove();
+    container = null;
+  }
+  vi.clearAllMocks();
+});
+
+describe('JanuaProvider — retry storm guard', () => {
+  it('CORS failure does NOT trigger automatic re-fetch within the same render cycle', async () => {
+    await renderProvider();
+    expect(getCurrentUserCalls).toBeGreaterThan(0);
+
+    const initialCalls = getCurrentUserCalls;
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 200));
+    });
+
+    // The whole fix: 200ms after a CORS failure, no automatic retries.
+    expect(getCurrentUserCalls).toBe(initialCalls);
+  });
+
+  it('Manual retry resets the circuit and fires exactly one new request', async () => {
+    await renderProvider();
+    const before = getCurrentUserCalls;
+    await clickRetry();
+    expect(getCurrentUserCalls).toBe(before + 1);
+  });
+
+  it('After 5 forced 5xx failures the provider stops auto-fetching', async () => {
+    // 5xx failures DO auto-schedule retries (CORS does not). We use this
+    // path to drive the circuit to broken without manual resets in the loop.
+    getCurrentUserBehavior = '5xx-fail';
+    await renderProvider({ fastBackoff: true });
+
+    // With 5ms base / 100ms cap, the controller trips after ~5*100ms.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 1_500));
+    });
+
+    // The provider must have tripped before reaching 6 calls.
+    expect(getCurrentUserCalls).toBeLessThanOrEqual(5);
+    expect(getStatus()).toBe('circuit-broken');
+
+    const callsAtBreak = getCurrentUserCalls;
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 500));
+    });
+    expect(getCurrentUserCalls).toBe(callsAtBreak);
+  });
+
+  it('Visibility change while circuit is broken does NOT auto-retry', async () => {
+    getCurrentUserBehavior = '5xx-fail';
+    await renderProvider({ fastBackoff: true });
+    // Drain backoff cycles. We loop because each scheduled retry uses a new
+    // setTimeout that needs its own act() flush to commit setState updates.
+    for (let i = 0; i < 20; i++) {
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 150));
+      });
+      if (getStatus() === 'circuit-broken') break;
+    }
+    expect(getStatus()).toBe('circuit-broken');
+    const callsAtBreak = getCurrentUserCalls;
+
+    Object.defineProperty(document, 'hidden', { configurable: true, value: true });
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await new Promise((r) => setTimeout(r, 30));
+    });
+
+    Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await new Promise((r) => setTimeout(r, 100));
+    });
+
+    expect(getCurrentUserCalls).toBe(callsAtBreak);
+  });
+
+  it('Visibility change while healthy + cache stale fires exactly 1 request', async () => {
+    getCurrentUserBehavior = 'success';
+    await renderProvider();
+    expect(getStatus()).toBe('authenticated');
+
+    const before = getCurrentUserCalls;
+
+    Object.defineProperty(document, 'hidden', { configurable: true, value: true });
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await new Promise((r) => setTimeout(r, 30));
+    });
+
+    Object.defineProperty(document, 'hidden', { configurable: true, value: false });
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    expect(getCurrentUserCalls).toBe(before + 1);
+  });
+
+  it('30s of CORS failure simulation: total requests are bounded', async () => {
+    // Simulates the production failure with NO user clicks. The provider
+    // must hold to <= 5 requests.
+    await renderProvider();
+
+    await act(async () => {
+      // Burn through 1s of fake time and dispatch many ticks the way a
+      // misbehaving reactive system would have.
+      for (let i = 0; i < 30; i++) {
+        await new Promise((r) => setTimeout(r, 30));
+      }
+    });
+
+    // Without user interaction, only the initial fetch fires.
+    expect(getCurrentUserCalls).toBeLessThanOrEqual(5);
+  });
+});

--- a/packages/nextjs-sdk/src/app/provider.tsx
+++ b/packages/nextjs-sdk/src/app/provider.tsx
@@ -4,6 +4,24 @@ import React, { createContext, useContext, useEffect, useState, useCallback, use
 import { JanuaClient } from '@janua/typescript-sdk';
 import type { User, Session, JanuaConfig } from '@janua/typescript-sdk';
 import { validateState, retrievePKCEParams, clearPKCEParams } from '../utils/pkce';
+import {
+  RetryController,
+  type CircuitState,
+  type RetryControllerOptions,
+  type RetrySnapshot,
+  isCorsOrNetworkError,
+} from './retry-policy';
+
+/**
+ * Auth state machine — exposed to consumers so UI can render the correct
+ * surface (loading vs unauthenticated vs error vs circuit-broken).
+ */
+export type JanuaAuthStatus =
+  | 'loading'
+  | 'authenticated'
+  | 'unauthenticated'
+  | 'error'
+  | 'circuit-broken';
 
 interface JanuaContextValue {
   client: JanuaClient;
@@ -11,8 +29,14 @@ interface JanuaContextValue {
   session: Session | null;
   isLoading: boolean;
   isAuthenticated: boolean;
+  status: JanuaAuthStatus;
+  error: Error | null;
+  /** Snapshot of the retry controller — for diagnostics / dashboards. */
+  retryState: RetrySnapshot;
   signOut: () => Promise<void>;
   updateUser: () => Promise<void>;
+  /** User-triggered retry. Resets the circuit breaker and re-fetches. */
+  manualRetry: () => Promise<void>;
 }
 
 const JanuaContext = createContext<JanuaContextValue | undefined>(undefined);
@@ -21,140 +45,358 @@ export interface JanuaProviderProps {
   children: React.ReactNode;
   config: JanuaConfig;
   onAuthChange?: (user: User | null) => void;
+  /**
+   * Periodic background re-check interval, in ms. Default 60s.
+   * Background polling is automatically paused while the tab is hidden,
+   * paused when the circuit breaker is open, and is *not* a retry
+   * mechanism — failed background polls go through the same retry
+   * controller.
+   */
+  pollIntervalMs?: number;
+  /**
+   * Override the retry controller policy. Primarily for tests; production
+   * consumers should accept defaults (1s -> 30s, 5 fail circuit, 20% jitter).
+   */
+  retryOptions?: RetryControllerOptions;
 }
 
 export function JanuaProvider({
   children,
   config,
-  onAuthChange
+  onAuthChange,
+  pollIntervalMs = 60_000,
+  retryOptions,
 }: JanuaProviderProps) {
   const [client] = useState(() => new JanuaClient(config));
   const [user, setUser] = useState<User | null>(null);
   const userRef = useRef<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [status, setStatus] = useState<JanuaAuthStatus>('loading');
+  const [error, setError] = useState<Error | null>(null);
+  const [retryState, setRetryState] = useState<RetrySnapshot>({
+    state: 'closed',
+    consecutiveFailures: 0,
+    lastFailureAt: null,
+    nextRetryAt: null,
+  });
 
-  const updateAuthState = useCallback(async () => {
-    let currentUser: User | null = null;
+  // Per-provider retry controller. Survives renders.
+  const retryRef = useRef<RetryController>(new RetryController(retryOptions));
+  // Tracks the in-flight /auth/me request so we can cancel it on unmount /
+  // supersession.
+  const inFlightAbortRef = useRef<AbortController | null>(null);
+  // Backoff timer for scheduled retries.
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Background poll timer.
+  const pollTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-    if (!config.skipRemoteAuth) {
-      currentUser = await client.auth.getCurrentUser();
-    } else {
-      // Derive user from localStorage token if available
-      const token = typeof window !== 'undefined'
-        ? localStorage.getItem('janua_access_token') : null;
-      if (token) {
-        try {
-          const payload = JSON.parse(atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/')));
-          currentUser = { id: payload.sub, email: payload.email } as User;
-        } catch { /* invalid token */ }
-      }
+  const cancelInFlight = useCallback(() => {
+    if (inFlightAbortRef.current) {
+      inFlightAbortRef.current.abort();
+      inFlightAbortRef.current = null;
     }
+  }, []);
 
-    const currentSession = {
-      accessToken: await client.getAccessToken(),
-      refreshToken: await client.getRefreshToken()
-    };
-
-    setUser(currentUser);
-    userRef.current = currentUser;
-    setSession(currentSession as any);
-
-    if (onAuthChange) {
-      onAuthChange(currentUser);
+  const clearTimers = useCallback(() => {
+    if (retryTimerRef.current !== null) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
     }
-  }, [client, config, onAuthChange]);
-
-  const updateUser = useCallback(async () => {
-    try {
-      await client.auth.getCurrentUser();
-      updateAuthState();
-    } catch (error) {
-      // Error handled silently in production
+    if (pollTimerRef.current !== null) {
+      clearTimeout(pollTimerRef.current);
+      pollTimerRef.current = null;
     }
-  }, [client, updateAuthState]);
+  }, []);
 
-  const signOut = useCallback(async () => {
-    try {
-      await client.auth.signOut();
-      setUser(null);
-      setSession(null);
+  const publishRetryState = useCallback(() => {
+    setRetryState(retryRef.current.snapshot());
+  }, []);
 
-      if (onAuthChange) {
-        onAuthChange(null);
-      }
-    } catch (error) {
-      // Error handled silently in production
-    }
-  }, [client, onAuthChange]);
-
-  // OAuth callback handling and initial auth state
-  useEffect(() => {
-    const urlParams = new URLSearchParams(window.location.search);
-    if (urlParams.has('code') && urlParams.has('state')) {
-      const code = urlParams.get('code')!;
-      const state = urlParams.get('state')!;
-
-      // Validate PKCE state before proceeding
-      if (!validateState(state)) {
-        console.warn('OAuth state mismatch - possible CSRF attack');
-        setIsLoading(false);
+  /**
+   * Single source of truth for hitting /auth/me.
+   * - Cancels prior in-flight request.
+   * - Honors the circuit breaker.
+   * - Updates state machine.
+   * - Does NOT auto-retry. Scheduling is handled by the caller via
+   *   scheduleRetryAfterFailure() so we never end up in a recursive loop.
+   */
+  const fetchAuthState = useCallback(
+    async (opts: { source: 'init' | 'poll' | 'manual' | 'visibility' }) => {
+      const ctrl = retryRef.current;
+      if (!ctrl.canAttempt() && opts.source !== 'manual') {
         return;
       }
 
-      // Retrieve PKCE code verifier for the token exchange
+      cancelInFlight();
+      const abort = new AbortController();
+      inFlightAbortRef.current = abort;
+
+      try {
+        let currentUser: User | null = null;
+
+        if (!config.skipRemoteAuth) {
+          // NOTE: We rely on JanuaClient.auth.getCurrentUser() honoring
+          // AbortSignal via its underlying http-client. If the SDK ignores
+          // the signal we still safely no-op the result on unmount because
+          // we check `abort.signal.aborted` below.
+          currentUser = await client.auth.getCurrentUser();
+        } else {
+          const token =
+            typeof window !== 'undefined' ? localStorage.getItem('janua_access_token') : null;
+          if (token) {
+            try {
+              const payload = JSON.parse(
+                atob(token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/'))
+              );
+              currentUser = { id: payload.sub, email: payload.email } as User;
+            } catch {
+              /* invalid token — treat as unauthenticated */
+            }
+          }
+        }
+
+        if (abort.signal.aborted) return;
+
+        const accessToken = await client.getAccessToken();
+        const refreshToken = await client.getRefreshToken();
+
+        if (abort.signal.aborted) return;
+
+        const currentSession = { accessToken, refreshToken } as unknown as Session;
+
+        ctrl.noteSuccess();
+        publishRetryState();
+
+        setUser(currentUser);
+        userRef.current = currentUser;
+        setSession(currentSession);
+        setStatus(currentUser ? 'authenticated' : 'unauthenticated');
+        setError(null);
+        if (onAuthChange) onAuthChange(currentUser);
+      } catch (err) {
+        if (abort.signal.aborted) return;
+
+        const e = err as Error;
+        ctrl.noteFailure(e);
+        publishRetryState();
+
+        // Surface the FIRST failure to UI; subsequent failures within the
+        // window stay quiet (status already reflects the problem).
+        setError(e);
+
+        if (ctrl.isCircuitBroken()) {
+          setStatus('circuit-broken');
+        } else if (status !== 'authenticated') {
+          // Don't downgrade an authenticated session on a transient blip
+          setStatus('error');
+        }
+
+        // CORS / network failures: do NOT schedule a retry on the same
+        // source path. The visibility API or a manual retry will recover.
+        // For other errors (5xx, etc.) the controller's nextRetryAt drives
+        // the next attempt.
+        if (!ctrl.isCircuitBroken() && !isCorsOrNetworkError(e)) {
+          scheduleRetryAfterFailure();
+        }
+      } finally {
+        if (inFlightAbortRef.current === abort) {
+          inFlightAbortRef.current = null;
+        }
+      }
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [client, config.skipRemoteAuth, onAuthChange, publishRetryState, cancelInFlight]
+  );
+
+  // Forward declaration (set below after fetchAuthState is bound).
+  const scheduleRetryAfterFailureRef = useRef<() => void>(() => undefined);
+
+  const scheduleRetryAfterFailure = useCallback(() => {
+    scheduleRetryAfterFailureRef.current();
+  }, []);
+
+  useEffect(() => {
+    scheduleRetryAfterFailureRef.current = () => {
+      const ctrl = retryRef.current;
+      const snap = ctrl.snapshot();
+      if (snap.state === 'open' || snap.nextRetryAt === null) return;
+
+      const delay = Math.max(0, snap.nextRetryAt - Date.now());
+      if (retryTimerRef.current !== null) {
+        clearTimeout(retryTimerRef.current);
+      }
+      retryTimerRef.current = setTimeout(() => {
+        retryTimerRef.current = null;
+        // Don't auto-retry while the tab is hidden — saves the user from
+        // returning to a circuit-broken state caused by background failures.
+        if (typeof document !== 'undefined' && document.hidden) return;
+        void fetchAuthState({ source: 'poll' });
+      }, delay);
+    };
+  }, [fetchAuthState]);
+
+  const updateUser = useCallback(async () => {
+    await fetchAuthState({ source: 'manual' });
+  }, [fetchAuthState]);
+
+  const manualRetry = useCallback(async () => {
+    retryRef.current.manualReset();
+    publishRetryState();
+    setError(null);
+    setStatus('loading');
+    await fetchAuthState({ source: 'manual' });
+  }, [fetchAuthState, publishRetryState]);
+
+  const signOut = useCallback(async () => {
+    cancelInFlight();
+    try {
+      await client.auth.signOut();
+      setUser(null);
+      userRef.current = null;
+      setSession(null);
+      setStatus('unauthenticated');
+      retryRef.current.manualReset();
+      publishRetryState();
+
+      if (onAuthChange) onAuthChange(null);
+    } catch (e) {
+      // Sign-out failure is surfaced but does not retry-storm; nothing to do.
+      setError(e as Error);
+    }
+  }, [client, onAuthChange, cancelInFlight, publishRetryState]);
+
+  // OAuth callback handling and initial auth state
+  useEffect(() => {
+    const urlParams =
+      typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : null;
+
+    if (urlParams && urlParams.has('code') && urlParams.has('state')) {
+      const code = urlParams.get('code')!;
+      const state = urlParams.get('state')!;
+
+      if (!validateState(state)) {
+        console.warn('OAuth state mismatch - possible CSRF attack');
+        setIsLoading(false);
+        setStatus('unauthenticated');
+        return;
+      }
+
       const pkceParams = retrievePKCEParams();
       const codeVerifier = pkceParams?.verifier;
 
-      client.auth.handleOAuthCallback(code, codeVerifier || state)
+      client.auth
+        .handleOAuthCallback(code, codeVerifier || state)
         .then(() => {
           clearPKCEParams();
           window.history.replaceState({}, '', window.location.pathname);
-          return updateAuthState();
+          return fetchAuthState({ source: 'init' });
         })
         .catch(() => {
           clearPKCEParams();
-          // Error handled silently in production
+          // Error captured inside fetchAuthState path on retry; here we just
+          // mark unauthenticated.
+          setStatus('unauthenticated');
         })
         .finally(() => setIsLoading(false));
     } else {
-      // Load initial auth state
-      updateAuthState();
-      setIsLoading(false);
+      void fetchAuthState({ source: 'init' }).finally(() => setIsLoading(false));
     }
 
-    // Set up auth state polling (60 second interval)
-    const checkInterval = setInterval(async () => {
-      if (config.skipRemoteAuth) return; // Skip remote polling when auth is server-managed
-      try {
-        const hasToken = typeof window !== 'undefined' && !!localStorage.getItem('janua_access_token');
-        if (!hasToken) return;
-        const currentUser = await client.auth.getCurrentUser();
-        if (currentUser?.id !== userRef.current?.id) {
-          updateAuthState();
-        }
-      } catch {
-        // Non-fatal: polling failure is handled by next cycle
-      }
-    }, 60_000);
-
     return () => {
-      clearInterval(checkInterval);
+      cancelInFlight();
+      clearTimers();
     };
-  }, [client, updateAuthState]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [client]);
 
-  // Proactive token auto-refresh before expiry
+  // Background polling — only runs when:
+  //   - Not in skipRemoteAuth mode
+  //   - Tab is visible
+  //   - Circuit is closed
+  //   - We have a token to validate
+  useEffect(() => {
+    if (config.skipRemoteAuth) return;
+    if (typeof window === 'undefined') return;
+
+    const schedule = () => {
+      if (pollTimerRef.current !== null) {
+        clearTimeout(pollTimerRef.current);
+      }
+      pollTimerRef.current = setTimeout(async () => {
+        pollTimerRef.current = null;
+        if (typeof document !== 'undefined' && document.hidden) {
+          schedule();
+          return;
+        }
+        if (retryRef.current.isCircuitBroken()) {
+          // No background polling while broken — wait for manual retry.
+          return;
+        }
+        const hasToken = !!localStorage.getItem('janua_access_token');
+        if (!hasToken) {
+          schedule();
+          return;
+        }
+        await fetchAuthState({ source: 'poll' });
+        schedule();
+      }, pollIntervalMs);
+    };
+
+    schedule();
+    return () => {
+      if (pollTimerRef.current !== null) {
+        clearTimeout(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+    };
+  }, [config.skipRemoteAuth, pollIntervalMs, fetchAuthState]);
+
+  // Visibility API — pause / resume on tab visibility changes.
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+
+    const handleVisibility = () => {
+      if (document.hidden) return;
+      // Tab became visible. Don't auto-retry if circuit is broken — user
+      // must explicitly hit the retry button.
+      if (retryRef.current.isCircuitBroken()) return;
+
+      // If we are currently in error state, attempt one recovery fetch now.
+      // Otherwise, the next scheduled poll handles it.
+      const snap = retryRef.current.snapshot();
+      if (snap.consecutiveFailures > 0) {
+        void fetchAuthState({ source: 'visibility' });
+      } else if (status === 'authenticated' || status === 'unauthenticated') {
+        // Cache stale on tab return — refresh exactly once.
+        void fetchAuthState({ source: 'visibility' });
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibility);
+    return () => document.removeEventListener('visibilitychange', handleVisibility);
+  }, [fetchAuthState, status]);
+
+  // Proactive token auto-refresh before expiry — preserved from prior impl,
+  // but now respects the circuit breaker so a broken refresh path does not
+  // tight-loop schedule itself.
   useEffect(() => {
     let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let cancelled = false;
 
     const scheduleRefresh = async () => {
+      if (cancelled) return;
       try {
-        const hasToken = typeof window !== 'undefined' && !!localStorage.getItem('janua_access_token');
+        if (retryRef.current.isCircuitBroken()) {
+          // Park the refresh loop until manual recovery.
+          return;
+        }
+        const hasToken =
+          typeof window !== 'undefined' && !!localStorage.getItem('janua_access_token');
         if (!hasToken) return;
         const accessToken = await client.getAccessToken();
         if (!accessToken) return;
 
-        // Parse JWT exp claim (base64 decode the payload segment)
         const parts = accessToken.split('.');
         if (parts.length !== 3) return;
 
@@ -165,33 +407,28 @@ export function JanuaProvider({
         const now = Math.floor(Date.now() / 1000);
         const timeUntilExpiry = exp - now;
 
-        // If already expired or less than 60s remaining, refresh immediately
         if (timeUntilExpiry < 60) {
           try {
             await client.auth.refreshToken();
           } catch {
-            // Non-fatal: token refresh failure is handled by next auth check
+            // Refresh failure is surfaced via the next /auth/me cycle.
           }
-          // Schedule next check in 30 seconds
           timeoutId = setTimeout(scheduleRefresh, 30_000);
           return;
         }
 
-        // Schedule refresh for 60 seconds before expiry (minimum 30s delay)
         const delay = Math.max((timeUntilExpiry - 60) * 1000, 30_000);
         timeoutId = setTimeout(scheduleRefresh, delay);
       } catch {
-        // Non-fatal: schedule a retry in 30 seconds
         timeoutId = setTimeout(scheduleRefresh, 30_000);
       }
     };
 
-    scheduleRefresh();
+    void scheduleRefresh();
 
     return () => {
-      if (timeoutId !== null) {
-        clearTimeout(timeoutId);
-      }
+      cancelled = true;
+      if (timeoutId !== null) clearTimeout(timeoutId);
     };
   }, [client]);
 
@@ -201,15 +438,15 @@ export function JanuaProvider({
     session,
     isLoading,
     isAuthenticated: !!user && !!session,
+    status,
+    error,
+    retryState,
     signOut,
     updateUser,
+    manualRetry,
   };
 
-  return (
-    <JanuaContext.Provider value={value}>
-      {children}
-    </JanuaContext.Provider>
-  );
+  return <JanuaContext.Provider value={value}>{children}</JanuaContext.Provider>;
 }
 
 export function useJanua(): JanuaContextValue {
@@ -221,14 +458,18 @@ export function useJanua(): JanuaContextValue {
 }
 
 export function useAuth() {
-  const { client, user, session, isAuthenticated, isLoading, signOut } = useJanua();
+  const { client, user, session, isAuthenticated, isLoading, status, error, signOut, manualRetry } =
+    useJanua();
   return {
     auth: client.auth,
     user,
     session,
     isAuthenticated,
     isLoading,
+    status,
+    error,
     signOut,
+    manualRetry,
   };
 }
 
@@ -245,3 +486,5 @@ export function useOrganizations() {
   const { client } = useJanua();
   return client.organizations;
 }
+
+export type { CircuitState };

--- a/packages/nextjs-sdk/src/app/retry-policy.test.ts
+++ b/packages/nextjs-sdk/src/app/retry-policy.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RetryController,
+  isCorsOrNetworkError,
+  backoffDelay,
+  DEFAULT_MAX_FAILURES,
+} from './retry-policy';
+
+describe('isCorsOrNetworkError', () => {
+  it('detects TypeError as CORS / network class failure', () => {
+    expect(isCorsOrNetworkError(new TypeError('Failed to fetch'))).toBe(true);
+    expect(isCorsOrNetworkError(new TypeError('Load failed'))).toBe(true);
+  });
+
+  it('detects message-based CORS errors', () => {
+    expect(isCorsOrNetworkError(new Error('NetworkError when attempting'))).toBe(true);
+    expect(isCorsOrNetworkError(new Error('CORS policy blocked'))).toBe(true);
+  });
+
+  it('does not match application errors', () => {
+    expect(isCorsOrNetworkError(new Error('Validation failed'))).toBe(false);
+    expect(isCorsOrNetworkError({ code: 'JANUA_401' })).toBe(false);
+  });
+
+  it('handles nullish input', () => {
+    expect(isCorsOrNetworkError(null)).toBe(false);
+    expect(isCorsOrNetworkError(undefined)).toBe(false);
+  });
+
+  it('walks .cause chain', () => {
+    const inner = new TypeError('Failed to fetch');
+    const outer = new Error('wrapped');
+    (outer as Error & { cause?: unknown }).cause = inner;
+    expect(isCorsOrNetworkError(outer)).toBe(true);
+  });
+});
+
+describe('backoffDelay', () => {
+  it('produces 1s, 2s, 4s, 8s sequence with zero jitter', () => {
+    const opts = {
+      baseDelayMs: 1000,
+      maxDelayMs: 30_000,
+      backoffMultiplier: 2,
+      jitter: 0,
+      random: () => 0.5, // jitter centered = 1.0 multiplier
+    };
+    expect(backoffDelay(0, opts)).toBe(1000);
+    expect(backoffDelay(1, opts)).toBe(2000);
+    expect(backoffDelay(2, opts)).toBe(4000);
+    expect(backoffDelay(3, opts)).toBe(8000);
+  });
+
+  it('caps at maxDelayMs', () => {
+    const opts = {
+      baseDelayMs: 1000,
+      maxDelayMs: 30_000,
+      backoffMultiplier: 2,
+      jitter: 0,
+      random: () => 0.5,
+    };
+    expect(backoffDelay(5, opts)).toBe(30_000); // 32s -> capped to 30s
+    expect(backoffDelay(10, opts)).toBe(30_000);
+  });
+
+  it('applies +/- 20% jitter symmetrically', () => {
+    const lower = { baseDelayMs: 1000, maxDelayMs: 30_000, backoffMultiplier: 2, jitter: 0.2, random: () => 0 };
+    const upper = { baseDelayMs: 1000, maxDelayMs: 30_000, backoffMultiplier: 2, jitter: 0.2, random: () => 1 };
+    expect(backoffDelay(0, lower)).toBe(800); // -20%
+    expect(backoffDelay(0, upper)).toBe(1200); // +20%
+  });
+});
+
+describe('RetryController', () => {
+  function makeController(initialNow = 1_000_000) {
+    let now = initialNow;
+    const ctrl = new RetryController({
+      jitter: 0,
+      random: () => 0.5,
+      now: () => now,
+    });
+    return {
+      ctrl,
+      advance: (ms: number) => {
+        now += ms;
+      },
+      setNow: (t: number) => {
+        now = t;
+      },
+    };
+  }
+
+  it('starts in closed state and permits attempts', () => {
+    const { ctrl } = makeController();
+    expect(ctrl.canAttempt()).toBe(true);
+    expect(ctrl.isCircuitBroken()).toBe(false);
+  });
+
+  it('trips circuit after MAX_FAILURES consecutive failures', () => {
+    const { ctrl } = makeController();
+    for (let i = 0; i < DEFAULT_MAX_FAILURES; i++) {
+      ctrl.noteFailure(new Error('boom'));
+    }
+    expect(ctrl.isCircuitBroken()).toBe(true);
+    expect(ctrl.canAttempt()).toBe(false);
+    const snap = ctrl.snapshot();
+    expect(snap.state).toBe('open');
+    expect(snap.consecutiveFailures).toBe(DEFAULT_MAX_FAILURES);
+  });
+
+  it('THE storm regression: 5 failures -> no 6th request fires until manual retry', () => {
+    const { ctrl, advance } = makeController();
+
+    // Simulate 5 sequential failed attempts.
+    for (let attempt = 1; attempt <= 5; attempt++) {
+      expect(ctrl.canAttempt()).toBe(true); // pre-attempt gate
+      ctrl.noteFailure(new TypeError('Failed to fetch'));
+      // Move time forward past any reasonable backoff window
+      advance(60_000);
+    }
+
+    // Critical assertion: no 6th attempt is permitted automatically.
+    expect(ctrl.canAttempt()).toBe(false);
+    expect(ctrl.isCircuitBroken()).toBe(true);
+
+    // Even after a long wait, the circuit stays open.
+    advance(10 * 60_000);
+    expect(ctrl.canAttempt()).toBe(false);
+
+    // Only manual reset re-arms the controller.
+    ctrl.manualReset();
+    expect(ctrl.canAttempt()).toBe(true);
+    expect(ctrl.isCircuitBroken()).toBe(false);
+    expect(ctrl.snapshot().consecutiveFailures).toBe(0);
+  });
+
+  it('blocks attempts inside the backoff window', () => {
+    const { ctrl, advance } = makeController();
+    ctrl.noteFailure(new Error('5xx'));
+    expect(ctrl.canAttempt()).toBe(false); // still inside backoff
+    advance(2_000); // backoff was 1s for first failure
+    expect(ctrl.canAttempt()).toBe(true);
+  });
+
+  it('exponential backoff sequence: 1s, 2s, 4s, 8s', () => {
+    const { ctrl, advance } = makeController();
+    let prevNext = 0;
+    const delays: number[] = [];
+    for (let i = 0; i < 4; i++) {
+      const before = ctrl.snapshot().nextRetryAt;
+      const next = ctrl.noteFailure();
+      if (next !== null && before !== null) {
+        delays.push(next - before);
+      } else if (next !== null) {
+        delays.push(next - 1_000_000); // first failure: relative to start
+      }
+      advance(60_000);
+      prevNext = next ?? 0;
+    }
+    // First three (i=0,1,2) should produce 1s, 2s, 4s deltas (with our
+    // controlled time advance the prevNext bookkeeping above is rough).
+    // We simply assert the controller's internal ladder: nextDelayMs grows.
+    const ctrl2 = makeController().ctrl;
+    ctrl2.noteFailure();
+    const d1 = ctrl2.nextDelayMs();
+    ctrl2.noteFailure();
+    const d2 = ctrl2.nextDelayMs();
+    expect(d2).toBeGreaterThan(d1);
+  });
+
+  it('successful call resets the failure counter', () => {
+    const { ctrl } = makeController();
+    ctrl.noteFailure();
+    ctrl.noteFailure();
+    expect(ctrl.snapshot().consecutiveFailures).toBe(2);
+    ctrl.noteSuccess();
+    expect(ctrl.snapshot().consecutiveFailures).toBe(0);
+    expect(ctrl.snapshot().state).toBe('closed');
+  });
+
+  it('manualReset clears state including the circuit', () => {
+    const { ctrl } = makeController();
+    for (let i = 0; i < DEFAULT_MAX_FAILURES; i++) ctrl.noteFailure();
+    expect(ctrl.isCircuitBroken()).toBe(true);
+    ctrl.manualReset();
+    expect(ctrl.isCircuitBroken()).toBe(false);
+    expect(ctrl.canAttempt()).toBe(true);
+  });
+});
+
+describe('integration: 30 seconds of fake CORS failures', () => {
+  it('fires at most MAX_FAILURES requests in 30s of continuous failure', () => {
+    let now = 0;
+    const ctrl = new RetryController({
+      jitter: 0,
+      random: () => 0.5,
+      now: () => now,
+    });
+
+    let attempts = 0;
+    const startedAt = now;
+    const endsAt = startedAt + 30_000;
+
+    while (now < endsAt) {
+      if (ctrl.canAttempt()) {
+        attempts += 1;
+        ctrl.noteFailure(new TypeError('Failed to fetch'));
+      }
+      now += 100; // simulate 100ms tick
+    }
+
+    // The whole point of the fix: even with a tight 100ms simulation loop
+    // over 30 seconds (300 ticks), we cap at MAX_FAILURES total requests.
+    expect(attempts).toBe(DEFAULT_MAX_FAILURES);
+    expect(ctrl.isCircuitBroken()).toBe(true);
+  });
+});

--- a/packages/nextjs-sdk/src/app/retry-policy.ts
+++ b/packages/nextjs-sdk/src/app/retry-policy.ts
@@ -1,0 +1,200 @@
+/**
+ * Retry policy with circuit breaker for Janua auth calls.
+ *
+ * Prevents the "auth storm" failure mode where a transient CORS / network /
+ * 401 failure on `/auth/me` causes an unbounded burst of retries — observed
+ * in production as 170+ requests in 6 seconds.
+ *
+ * Behavior:
+ *   - Exponential backoff with jitter: 1s -> 2s -> 4s -> 8s -> 30s cap, +/-20% jitter.
+ *   - Circuit breaker: after `MAX_FAILURES` (5) consecutive failures, transition
+ *     to `circuit-broken`. No further automatic retries until `manualReset()` is
+ *     called or `noteSuccess()` is invoked from another path.
+ *   - CORS errors short-circuit retries on the SAME attempt (a CORS misconfig
+ *     is not a transient error and retrying within the same render cycle just
+ *     amplifies the storm). Each CORS failure still counts toward the circuit
+ *     breaker.
+ *
+ * This module is pure — no React, no DOM. Side effects are managed by the
+ * provider that owns a RetryController instance.
+ */
+
+export const DEFAULT_MAX_FAILURES = 5;
+export const DEFAULT_FAILURE_WINDOW_MS = 30_000;
+export const DEFAULT_BASE_DELAY_MS = 1_000;
+export const DEFAULT_MAX_DELAY_MS = 30_000;
+export const DEFAULT_BACKOFF_MULTIPLIER = 2;
+export const DEFAULT_JITTER = 0.2;
+
+export type CircuitState = 'closed' | 'open' | 'half-open';
+
+export interface RetryControllerOptions {
+  maxFailures?: number;
+  failureWindowMs?: number;
+  baseDelayMs?: number;
+  maxDelayMs?: number;
+  backoffMultiplier?: number;
+  jitter?: number;
+  /** Inject for deterministic tests. Default: Math.random. */
+  random?: () => number;
+  /** Inject for deterministic tests. Default: Date.now. */
+  now?: () => number;
+}
+
+export interface RetrySnapshot {
+  state: CircuitState;
+  consecutiveFailures: number;
+  lastFailureAt: number | null;
+  nextRetryAt: number | null;
+}
+
+/**
+ * Detect CORS / network-level failures that the browser exposes as opaque
+ * errors. These are NOT transient and must not retry within the same cycle.
+ *
+ * The browser does not give us a status code for CORS-blocked responses; the
+ * fetch promise rejects with a generic TypeError whose message varies by
+ * engine ("Failed to fetch", "Load failed", "NetworkError when attempting to
+ * fetch resource"). We treat ANY TypeError on a fetch path as a CORS-class
+ * failure for retry purposes.
+ */
+export function isCorsOrNetworkError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  if (error instanceof TypeError) return true;
+  // Heuristic: some SDK wrappers wrap the original error
+  const anyErr = error as { name?: string; message?: string; cause?: unknown };
+  if (anyErr.name === 'TypeError') return true;
+  const msg = (anyErr.message || '').toLowerCase();
+  if (
+    msg.includes('failed to fetch') ||
+    msg.includes('load failed') ||
+    msg.includes('networkerror') ||
+    msg.includes('cors')
+  ) {
+    return true;
+  }
+  if (anyErr.cause && anyErr.cause !== error) {
+    return isCorsOrNetworkError(anyErr.cause);
+  }
+  return false;
+}
+
+/**
+ * Compute the next backoff delay for a given attempt index (0-indexed).
+ * Returns ms with +/- jitter applied.
+ */
+export function backoffDelay(
+  attempt: number,
+  opts: Required<
+    Pick<RetryControllerOptions, 'baseDelayMs' | 'maxDelayMs' | 'backoffMultiplier' | 'jitter'>
+  > & { random: () => number }
+): number {
+  const raw = opts.baseDelayMs * Math.pow(opts.backoffMultiplier, Math.max(0, attempt));
+  const capped = Math.min(raw, opts.maxDelayMs);
+  // Jitter: uniform in [-jitter, +jitter]
+  const jitterFactor = 1 + (opts.random() * 2 - 1) * opts.jitter;
+  return Math.max(0, Math.round(capped * jitterFactor));
+}
+
+/**
+ * Stateful retry controller. One instance per auth context.
+ *
+ * Usage:
+ *   const ctrl = new RetryController();
+ *   if (!ctrl.canAttempt()) return; // circuit broken
+ *   try { await fetch(...); ctrl.noteSuccess(); }
+ *   catch (e) { ctrl.noteFailure(e); ... }
+ *
+ *   // Schedule next attempt:
+ *   const delayMs = ctrl.nextDelayMs();
+ *   setTimeout(retry, delayMs);
+ */
+export class RetryController {
+  private opts: Required<RetryControllerOptions>;
+  private consecutiveFailures = 0;
+  private lastFailureAt: number | null = null;
+  private nextRetryAt: number | null = null;
+  private state: CircuitState = 'closed';
+
+  constructor(options: RetryControllerOptions = {}) {
+    this.opts = {
+      maxFailures: options.maxFailures ?? DEFAULT_MAX_FAILURES,
+      failureWindowMs: options.failureWindowMs ?? DEFAULT_FAILURE_WINDOW_MS,
+      baseDelayMs: options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS,
+      maxDelayMs: options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS,
+      backoffMultiplier: options.backoffMultiplier ?? DEFAULT_BACKOFF_MULTIPLIER,
+      jitter: options.jitter ?? DEFAULT_JITTER,
+      random: options.random ?? Math.random,
+      now: options.now ?? Date.now,
+    };
+  }
+
+  /**
+   * True if the controller permits an attempt RIGHT NOW. Returns false if:
+   *   - Circuit is open (broken), waiting for manual reset.
+   *   - We are still inside the backoff window for the next retry.
+   */
+  canAttempt(): boolean {
+    if (this.state === 'open') return false;
+    if (this.nextRetryAt !== null && this.opts.now() < this.nextRetryAt) {
+      return false;
+    }
+    return true;
+  }
+
+  /** True if the circuit has tripped. UI should show error + manual retry. */
+  isCircuitBroken(): boolean {
+    return this.state === 'open';
+  }
+
+  noteSuccess(): void {
+    this.consecutiveFailures = 0;
+    this.lastFailureAt = null;
+    this.nextRetryAt = null;
+    this.state = 'closed';
+  }
+
+  /**
+   * Record a failure. Returns the next scheduled retry-at timestamp, or null
+   * if the circuit just tripped.
+   */
+  noteFailure(_error?: unknown): number | null {
+    this.consecutiveFailures += 1;
+    this.lastFailureAt = this.opts.now();
+
+    if (this.consecutiveFailures >= this.opts.maxFailures) {
+      this.state = 'open';
+      this.nextRetryAt = null;
+      return null;
+    }
+
+    const delay = backoffDelay(this.consecutiveFailures - 1, this.opts);
+    this.nextRetryAt = this.opts.now() + delay;
+    return this.nextRetryAt;
+  }
+
+  /** Compute backoff for the NEXT attempt without recording a failure. */
+  nextDelayMs(): number {
+    return backoffDelay(this.consecutiveFailures, this.opts);
+  }
+
+  /**
+   * Manual reset — called when the user explicitly retries (button click)
+   * or when a successful auth event fires from another path.
+   */
+  manualReset(): void {
+    this.consecutiveFailures = 0;
+    this.lastFailureAt = null;
+    this.nextRetryAt = null;
+    this.state = 'closed';
+  }
+
+  snapshot(): RetrySnapshot {
+    return {
+      state: this.state,
+      consecutiveFailures: this.consecutiveFailures,
+      lastFailureAt: this.lastFailureAt,
+      nextRetryAt: this.nextRetryAt,
+    };
+  }
+}

--- a/packages/nextjs-sdk/vitest.config.ts
+++ b/packages/nextjs-sdk/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from 'vitest/config';
+import { resolve } from 'path';
+
+const REACT_DOM_18 = resolve(
+  __dirname,
+  '../../node_modules/.pnpm/react-dom@18.3.1_react@18.3.1/node_modules/react-dom'
+);
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      // Force react-dom 18.3.1 (matches react peer); the package's own
+      // node_modules symlink points to 19 due to pnpm hoisting.
+      'react-dom/client': resolve(REACT_DOM_18, 'client.js'),
+      'react-dom/test-utils': resolve(REACT_DOM_18, 'test-utils.js'),
+      'react-dom': REACT_DOM_18,
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+  },
+});


### PR DESCRIPTION
## Summary

Fixes the production retry storm where forgesight's app fired **170+ requests in 6 seconds** to `https://auth.madfam.io/api/v1/auth/me` when CORS was blocked (incident 2026-05-04). Even after the upstream CORS fix lands (enclii#228), the previous SDK retry behavior would amplify any future failure into a DDoS-class burst.

**Status: Draft — DO NOT MERGE without review.**

## Where the offender was

`packages/nextjs-sdk/src/app/provider.tsx` had:
- bare `setInterval(60s)` polling that retried failed `/auth/me` calls
- 401 handler in `typescript-sdk` HttpClient that recursively re-fired the same request after refresh
- token-refresh `setTimeout` that re-scheduled itself every 30s on errors
- no circuit breaker, no AbortController, no visibility gating, no bounded retry budget

Combined with React strict-mode double-mount and the underlying `executeWithRetry` (3 attempts × backoff), a single CORS failure compounded into 28+ req/sec.

## Fix design

Pure-module `RetryController` (`src/app/retry-policy.ts`, no React) wired into a refactored `JanuaProvider`:

| Behavior | Before | After |
|---|---|---|
| First failure | retry storm | surface error to UI |
| Within 30s of failure | dozens of retries | zero — circuit-breaker logic |
| Recovery polling | `setInterval` ignores tab visibility | paused while `document.hidden` |
| Tab returns visible (healthy) | nothing | exactly one revalidation fetch |
| Tab returns visible (broken) | new storm | nothing — wait for manual retry |
| Backoff | linear-ish | 1s -> 2s -> 4s -> 8s -> 30s cap, +/-20% jitter |
| Max retries | unbounded | 5 then `status: 'circuit-broken'` |
| In-flight cancellation | none | `AbortController` per fetch, cancelled on unmount/supersession |
| CORS / TypeError | retried (amplifies) | NOT auto-rescheduled (manual recovery only) |

New `useAuth()` surface (additive, backward-compatible): `status`, `error`, `manualRetry()`.

## Out of scope

- Upstream CORS allow-list (enclii#228).
- Auth endpoints / contracts unchanged.
- Underlying `typescript-sdk` HttpClient's internal `executeWithRetry` is unchanged. Bounded by the new outer circuit-breaker; a follow-up should pass an `AbortSignal` through `JanuaClient.auth.getCurrentUser()` so cancellations propagate to fetch level.

## Test plan

- [x] `pnpm test` — 22 vitest cases pass (16 retry-policy + 6 provider integration)
  - retry-policy: 30s of fake CORS failures @ 100ms ticks → exactly 5 attempts (DEFAULT_MAX_FAILURES)
  - provider: manual retry fires exactly one new request
  - provider: 5 forced 5xx failures → `status === 'circuit-broken'`, no auto-recovery for 500ms+
  - provider: visibility hidden→visible while broken → zero new requests
  - provider: visibility hidden→visible while healthy → exactly 1 revalidation
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — tsup CJS+ESM+DTS clean
- [ ] Manual: deploy to staging, point app at a stub `auth.example/api/v1/auth/me` returning 0 (CORS), verify <= 6 outbound requests in 30s via DevTools network tab
- [ ] Manual: confirm Sentry / PostHog still receive auth events (no event changes)

## Companion PR

forgesight#fix/auth-retry-storm — surfaces the circuit-broken state with a "Try again" button so users have a clear recovery action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)