### PR TITLE
fix(security): add missing ecosystem domains to CSP form-action allowlist

### DIFF
--- a/apps/api/app/middleware/security_headers.py
+++ b/apps/api/app/middleware/security_headers.py
@@ -63,6 +63,18 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
             "https://*.fortuna.tube https://*.avala.studio "
             "https://*.cotiza.studio https://*.almanac.solar https://*.yantra4d.com "
             "https://*.coforma.studio https://*.routecraft.app https://*.solar "
+            # 2026-05-04: added the remaining MADFAM ecosystem domains. Login
+            # via Janua SSO from these origins was browser-blocked by CSP
+            # form-action because the post-login redirect URL wasn't in the
+            # allowlist. Same bug class as the forgesight CORS regression
+            # fixed earlier (PR enclii#228 for CORS_ORIGINS).
+            "https://selva.town https://*.selva.town "
+            "https://rondel.io https://*.rondel.io "
+            "https://phynecrm.com https://*.phynecrm.com "
+            "https://pravara.mx https://*.pravara.mx "
+            "https://sim4d.io https://*.sim4d.io "
+            "https://aureo.studio https://*.aureo.studio "
+            "https://ceq.studio https://*.ceq.studio "
             "https://4d-admin.madfam.io https://sniper.madfam.io "
             "http://127.0.0.1:* http://localhost:*",
             "upgrade-insecure-requests",


### PR DESCRIPTION
## Summary

Login via Janua SSO from \`app.selva.town\` silently failed today — form posted to \`/api/v1/auth/login-form\`, browser blocked with \"violates form-action directive\". Caught while verifying the Selva ecosystem deployment as admin@madfam.io.

Same bug class as the forgesight CORS regression fixed earlier today (enclii#228) — Janua's allowlists don't include every active ecosystem domain.

## Why CSP \`'self'\` doesn't cover this

The login form posts to a same-origin endpoint, but \`form-action\` evaluates the **entire redirect chain**, including the eventual OAuth callback redirect to the consumer app. When \`selva.town\` (or any parent domain) isn't in the list, Chrome blocks the form submit the instant it tries to follow the chain. UX symptom: \"Sign In does nothing.\"

## Domains added

- \`selva.town\` + \`*.selva.town\` (Selva)
- \`rondel.io\` + \`*.rondel.io\` (Rondelio)
- \`phynecrm.com\` + \`*.phynecrm.com\` (PhyneCRM)
- \`pravara.mx\` + \`*.pravara.mx\` (Pravara MES)
- \`sim4d.io\` + \`*.sim4d.io\` (Sim4D, formerly BrepFlow)
- \`aureo.studio\` + \`*.aureo.studio\` (Áureo agent — preserved per rebrand)
- \`ceq.studio\` + \`*.ceq.studio\` (CEQ)

The OAuth authorize endpoint still validates each specific \`redirect_uri\` against the client's registered list (the existing comment in this file documents that). This CSP entry just permits the browser to follow the chain.

## Rollout

Janua redeploys via the existing GitOps path. After merge, verify:

\`\`\`bash
curl -sI 'https://auth.madfam.io/health' | grep -i 'content-security'
\`\`\`

Or just retry login from app.selva.town.

## Test plan

- [x] CSP string remains valid (one continuous string, semicolons preserved)
- [ ] Operator: merge + watch Janua redeploy
- [ ] Operator: re-test login from app.selva.town with admin@madfam.io
- [ ] Spot-test from app.rondel.io / studio.sim4d.io etc. once their consumers exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)