### PR TITLE
fix(ci): use GITHUB_TOKEN for GHCR auth (MADFAM_BOT_PAT expired)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -98,8 +98,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
-          username: madfam-bot
-          password: ${{ secrets.MADFAM_BOT_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
@@ -145,8 +145,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
-          username: madfam-bot
-          password: ${{ secrets.MADFAM_BOT_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
@@ -195,8 +195,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
-          username: madfam-bot
-          password: ${{ secrets.MADFAM_BOT_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
@@ -246,8 +246,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
-          username: madfam-bot
-          password: ${{ secrets.MADFAM_BOT_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
@@ -295,8 +295,8 @@ jobs:
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
-          username: madfam-bot
-          password: ${{ secrets.MADFAM_BOT_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3


### PR DESCRIPTION
## Summary
Janua's \`docker-publish.yml\` has been failing on every push to main since 2026-05-02:

| Run | Commit | Result |
|---|---|---|
| 2026-05-02 19:31 | 2917c641 | ✅ last green |
| 2026-05-02 19:55 | b2f9263f | ❌ Log in to GHCR |
| 2026-05-05 03:15 | 4faf739e | ❌ Log in to GHCR |
| 2026-05-05 04:35 | b2fda6c7 | ❌ Log in to GHCR |

Failure (verbatim from latest run):
\`\`\`
Logging into ghcr.io...
Error response from daemon: Get \"https://ghcr.io/v2/\": denied: denied
\`\`\`

## Root cause
Workflow uses \`username: madfam-bot, password: \${{ secrets.MADFAM_BOT_PAT }}\`. PATs have lifetimes (30/60/90/180 days); this one expired around 2026-05-02. Operator rotation would unstick the immediate symptom but doesn't prevent recurrence.

## Why this matters beyond Janua
The deployed Janua image has been stuck for **3 days** because of this. Two cascading downstream impacts:

1. **CSP form-action fix [#374](https://github.com/madfam-org/janua/pull/374)** — added \`selva.town\` to the form-action allowlist — has not deployed. Login from \`app.selva.town\` is **silently CSP-blocked** today (verified live just now: \"Sending form data to ... violates the following Content Security Policy directive: form-action 'self' ...\" — selva.town not in the list).

2. **All other security/feature fixes** that have merged to Janua main since 2026-05-02 are sitting in main but not in prod.

## Fix
The job already declares \`permissions: packages: write\`, so the built-in \`\${{ secrets.GITHUB_TOKEN }}\` has exactly the scope needed for GHCR push. GITHUB_TOKEN auto-rotates per workflow run and cannot expire.

Five GHCR login steps switch from \`madfam-bot\` PAT to \`github.actor\` + \`GITHUB_TOKEN\`.

## Test plan
- [ ] Merge → next push to main triggers \`docker-publish\`
- [ ] \`Log in to GHCR\` step succeeds
- [ ] All 5 image build/push jobs (api, dashboard, admin, docs, website) succeed
- [ ] New \`janua-api\` digest committed to \`k8s/base/deployments/kustomization.yaml\`
- [ ] ArgoCD reconciles → CSP form-action allows selva.town → \`app.selva.town\` login works

## RFC 0021 alignment
This is exactly the **F8** failure class documented in [RFC 0021](https://github.com/madfam-org/internal-devops/pull/101) — \"OAuth tokens without workflow scope\" — generalized to any expiring credential governing CI. Phase 4 of that RFC standardizes auto-rotating tokens (or dropping PATs in favor of GITHUB_TOKEN where feasible) across the ecosystem.