### PR TITLE
fix(ci): run Janua CI on ARC self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   networkpolicy-port-lint:
     name: NetworkPolicy port consistency
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     timeout-minutes: 3
     # Prevents the 2026-05-04 status.enclii.dev outage class:
     # NetworkPolicy `ports:` clauses that don't intersect the selected pods'
@@ -38,7 +38,7 @@ jobs:
   # Lint and typecheck all packages
   lint:
     name: Lint & Typecheck
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -62,7 +62,7 @@ jobs:
 
   cli-test:
     name: CLI Tests (@janua/cli)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -90,7 +90,7 @@ jobs:
   # Build all packages
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     needs: lint
     steps:
       - uses: actions/checkout@v6
@@ -115,7 +115,7 @@ jobs:
     # Disabled - consolidated into tests.yml workflow
     if: false
     name: API Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     services:
       postgres:
         image: postgres:15-alpine
@@ -231,7 +231,7 @@ jobs:
   # E2E tests (optional, runs on main only)
   e2e:
     name: E2E Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     needs: [build, api-test]
     if: github.ref == 'refs/heads/main'
     steps:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,7 +34,7 @@ env:
 jobs:
   detect-changes:
     name: Detect Changes
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     outputs:
       api: ${{ steps.filter.outputs.api }}
       admin: ${{ steps.filter.outputs.admin }}
@@ -83,7 +83,7 @@ jobs:
 
   build-api:
     name: Build API
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     needs: detect-changes
     if: needs.detect-changes.outputs.api == 'true' || github.event_name == 'workflow_dispatch'
     outputs:
@@ -130,7 +130,7 @@ jobs:
 
   build-admin:
     name: Build Admin
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     needs: detect-changes
     if: needs.detect-changes.outputs.admin == 'true' || github.event_name == 'workflow_dispatch'
     outputs:
@@ -180,7 +180,7 @@ jobs:
 
   build-dashboard:
     name: Build Dashboard
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     needs: detect-changes
     if: needs.detect-changes.outputs.dashboard == 'true' || github.event_name == 'workflow_dispatch'
     outputs:
@@ -231,7 +231,7 @@ jobs:
 
   build-docs:
     name: Build Docs
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     needs: detect-changes
     if: needs.detect-changes.outputs.docs == 'true' || github.event_name == 'workflow_dispatch'
     outputs:
@@ -280,7 +280,7 @@ jobs:
 
   build-website:
     name: Build Website
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     needs: detect-changes
     if: needs.detect-changes.outputs.website == 'true' || github.event_name == 'workflow_dispatch'
     outputs:
@@ -331,7 +331,7 @@ jobs:
 
   commit-digests:
     name: Commit Digests to Kustomization
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     needs: [build-api, build-admin, build-dashboard, build-docs, build-website]
     if: always() && github.ref == 'refs/heads/main'
     steps:
@@ -419,7 +419,7 @@ jobs:
 
   report-lifecycle:
     name: Report Lifecycle Events
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     needs: [build-api, build-admin, build-dashboard, build-docs, build-website]
     if: always()
     steps:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   e2e-tests:
     name: Playwright E2E Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -18,7 +18,7 @@ env:
 jobs:
   code-quality:
     name: Code Quality
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -43,7 +43,7 @@ jobs:
 
   frontend-tests-build:
     name: Frontend Tests & Build
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -85,7 +85,7 @@ jobs:
     # Disabled - consolidated into tests.yml workflow
     if: false
     name: Backend Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
 
     services:
       postgres:
@@ -196,7 +196,7 @@ jobs:
 
   security-scan:
     name: Security Scan
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
 
     steps:
       - uses: actions/checkout@v6
@@ -218,7 +218,7 @@ jobs:
 
   security-scanning:
     name: Security Scanning
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     permissions:
       actions: read
       contents: read
@@ -243,7 +243,7 @@ jobs:
 
   smoke-tests:
     name: Smoke Tests
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     needs: [frontend-tests-build]  # backend-tests disabled, consolidated into tests.yml
 
     steps:

--- a/.github/workflows/publish-sdks.yml
+++ b/.github/workflows/publish-sdks.yml
@@ -35,7 +35,7 @@ on:
 jobs:
   publish-npm:
     name: Publish NPM SDK
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     permissions:
       contents: write
     env:
@@ -155,7 +155,7 @@ jobs:
 
   publish-python:
     name: Publish Python SDK
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     permissions:
       contents: write
     if: startsWith(github.ref, 'refs/tags/python-sdk-v')
@@ -217,7 +217,7 @@ jobs:
 
   publish-go:
     name: Publish Go SDK
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     permissions:
       contents: write
     if: startsWith(github.ref, 'refs/tags/go-sdk/v')
@@ -267,7 +267,7 @@ jobs:
 
   publish-flutter:
     name: Publish Flutter SDK
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     permissions:
       contents: write
     if: startsWith(github.ref, 'refs/tags/flutter-sdk-v')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ env:
 jobs:
   api-tests:
     name: API Tests (Python)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     timeout-minutes: 25
 
     services:
@@ -161,7 +161,7 @@ jobs:
 
   e2e-tests:
     name: E2E Tests (Playwright)
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     timeout-minutes: 15
 
     services:
@@ -263,7 +263,7 @@ jobs:
   coverage-gate:
     name: Coverage Quality Gate
     needs: [api-tests]
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
Routes publish-sdks, ci, docker-publish, pr-quality, tests, and e2e-tests to `madfam-runners-blue` when `ARC_BOOTSTRAP_COMPLETE=true` (already set on janua).

## Test plan
- [ ] CI green on PR
- [ ] Next tag publish / workflow_dispatch uses ARC runner label in job log

Made with [Cursor](https://cursor.com)