### PR TITLE
ci+test: authenticate Docker Hub pulls + make org router tests robust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,9 @@ jobs:
     services:
       postgres:
         image: postgres:15-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         env:
           POSTGRES_USER: janua
           POSTGRES_PASSWORD: janua
@@ -133,6 +136,9 @@ jobs:
 
       redis:
         image: redis:7-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,6 +27,9 @@ jobs:
     services:
       postgres:
         image: postgres:15-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         env:
           POSTGRES_USER: janua
           POSTGRES_PASSWORD: janua
@@ -41,6 +44,9 @@ jobs:
 
       redis:
         image: redis:7-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -90,6 +90,9 @@ jobs:
     services:
       postgres:
         image: postgres:15
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         env:
           POSTGRES_USER: janua
           POSTGRES_PASSWORD: janua
@@ -104,6 +107,9 @@ jobs:
 
       redis:
         image: redis:7
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -194,6 +194,9 @@ jobs:
     services:
       postgres:
         image: postgres:15
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         ports:
           - 5432:5432
         env:
@@ -208,6 +211,9 @@ jobs:
 
       redis:
         image: redis:7
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,9 @@ jobs:
     services:
       postgres:
         image: postgres:15-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         env:
           POSTGRES_USER: janua
           POSTGRES_PASSWORD: janua_test
@@ -39,6 +42,9 @@ jobs:
 
       redis:
         image: redis:7-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         ports:
           - 6379:6379
         options: >-
@@ -167,6 +173,9 @@ jobs:
     services:
       postgres:
         image: postgres:15-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         env:
           POSTGRES_USER: janua
           POSTGRES_PASSWORD: janua_test
@@ -181,6 +190,9 @@ jobs:
 
       redis:
         image: redis:7-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         ports:
           - 6379:6379
         options: >-

--- a/apps/api/tests/unit/test_routers_organizations.py
+++ b/apps/api/tests/unit/test_routers_organizations.py
@@ -50,27 +50,6 @@ def test_organizations_router_imports(mock_env):
         pytest.skip(f"Organizations router imports failed: {e}")
 
 
-def _collect_route_paths(routes):
-    """Collect endpoint paths from a router, recursing into included sub-routers.
-
-    Newer FastAPI/Starlette can represent ``include_router`` results as wrapper
-    objects (``_IncludedRouter``/``Mount``) that expose nested ``.routes`` (or
-    ``.router.routes``) rather than a top-level ``.path``.
-    """
-    paths = []
-    for route in routes:
-        path = getattr(route, "path", None)
-        if isinstance(path, str):
-            paths.append(path)
-        nested = getattr(route, "routes", None)
-        if not nested:
-            inner = getattr(route, "router", None)
-            nested = getattr(inner, "routes", None) if inner is not None else None
-        if nested:
-            paths.extend(_collect_route_paths(nested))
-    return paths
-
-
 def test_organizations_router_structure(mock_env):
     """Test organizations router has expected route structure"""
     try:
@@ -84,17 +63,13 @@ def test_organizations_router_structure(mock_env):
             from app.routers.v1.organizations import router
 
             # Extract route paths
-            route_paths = _collect_route_paths(router.routes)
-
-            # Check for expected organization endpoints
-            org_routes = [
-                path
-                for path in route_paths
-                if any(keyword in path.lower() for keyword in ["org", "team", "company", "tenant"])
-            ]
-            assert (
-                len(org_routes) > 0
-            ), "Organizations router should have organization-related routes"
+            # Route-object introspection is FastAPI-version fragile here
+            # (include/mount wrappers), so assert the router's configuration
+            # directly: it mounts at /organizations and registers routes.
+            assert getattr(router, "prefix", "") == "/organizations", (
+                "organizations router should mount at /organizations"
+            )
+            assert len(router.routes) > 0, "organizations router should register routes"
 
     except ImportError as e:
         pytest.skip(f"Organizations router structure test failed: {e}")
@@ -288,11 +263,10 @@ def test_organizations_audit_logging(mock_env):
             assert router is not None
             assert hasattr(router, "routes")
 
-            # Check that audit logging structure exists. Resolve routes
-            # recursively so included sub-routers (Mount/_IncludedRouter) count.
-            assert _collect_route_paths(router.routes), (
-                "organizations router should expose endpoint routes"
-            )
+            # Verify the router is configured and registers routes (robust to
+            # FastAPI include/mount route representations).
+            assert router is not None and hasattr(router, "routes")
+            assert len(router.routes) > 0, "organizations router should register routes"
 
     except ImportError as e:
         pytest.skip(f"Organizations audit logging test failed: {e}")


### PR DESCRIPTION
Two changes that together get janua's API Tests reliably green.

## 1. Docker Hub auth for service containers (the rate-limit fix)
API Tests / E2E failed at **container setup** with `unauthenticated pull rate limit` (postgres/redis) — even on ARC runners (shared egress IP). Added `credentials` (`DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN`) to all 12 service-container blocks across ci, tests, e2e-tests, pr-quality, security. **Validated**: a prior run of this branch showed **0 rate-limit hits** and **E2E Tests now pass**. Secrets sourced from the cluster's existing `arc-runners/dockerhub-auth`.

## 2. Org router tests made robust
`test_organizations_router_structure` + `test_organizations_audit_logging` extracted route paths from `router.routes`, but FastAPI's include/mount wrappers make that introspection unreliable in the mocked unit context (routes surface as wrappers without `.path`). Switched to asserting the stable facts: the router mounts at `/organizations` and registers route objects.

## Net
With Docker Hub auth (containers pull) + the org-test fix, API Tests should reach **0 failures**. All security scans, Build, and E2E already green on this branch.