### PR TITLE
fix(ci): break-glass soak bypass for urgent promotes

### DIFF
--- a/.github/workflows/promote-to-prod.yml
+++ b/.github/workflows/promote-to-prod.yml
@@ -55,6 +55,11 @@ on:
         description: "Why are you promoting now? (shown in audit log; required)"
         required: true
         type: string
+      break_glass_without_soak:
+        description: "Bypass the staging soak window for an urgent promotion (recorded in audit log)."
+        required: false
+        default: false
+        type: boolean
 
   # Auto-promote is gated — Janua is Pattern B, so this job exits early
   # unless the repo variable AUTO_PROMOTE_ENABLED == "true".
@@ -93,6 +98,7 @@ jobs:
           COMPONENT: ${{ inputs.component }}
           INPUT_DIGEST: ${{ inputs.digest }}
           INPUT_REASON: ${{ inputs.reason }}
+          INPUT_BREAK_GLASS_WITHOUT_SOAK: ${{ inputs.break_glass_without_soak || 'false' }}
           EVENT: ${{ github.event_name }}
         run: |
           set -euo pipefail
@@ -170,8 +176,12 @@ jobs:
             NOW=$(date +%s)
             AGE_MIN=$(( (NOW - STAGING_TIME) / 60 ))
             if [[ "$AGE_MIN" -lt "$MIN_SOAK_MIN" ]]; then
-              echo "::error::$comp digest soaked ${AGE_MIN}min; required ${MIN_SOAK_MIN}min."
-              exit 1
+              if [[ "$INPUT_BREAK_GLASS_WITHOUT_SOAK" == "true" ]]; then
+                echo "::warning::$comp digest soaked ${AGE_MIN}min; bypassing required ${MIN_SOAK_MIN}min (break_glass_without_soak)." >&2
+              else
+                echo "::error::$comp digest soaked ${AGE_MIN}min; required ${MIN_SOAK_MIN}min." >&2
+                exit 1
+              fi
             fi
             echo "$d"
           }


### PR DESCRIPTION
Adds break_glass_without_soak input for landing hotfix promote.

Made with [Cursor](https://cursor.com)