### PR TITLE
Fix CI Docker Hub rate limits and ARC prod smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,10 +118,7 @@ jobs:
     runs-on: ${{ vars.ARC_BOOTSTRAP_COMPLETE == 'true' && 'madfam-runners-blue' || 'ubuntu-latest' }}
     services:
       postgres:
-        image: postgres:15-alpine
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        image: public.ecr.aws/docker/library/postgres:15-alpine
         env:
           POSTGRES_USER: janua
           POSTGRES_PASSWORD: janua
@@ -135,10 +132,7 @@ jobs:
           --health-retries 5
 
       redis:
-        image: redis:7-alpine
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        image: public.ecr.aws/docker/library/redis:7-alpine
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -26,10 +26,7 @@ jobs:
     # This properly exposes ports to localhost unlike docker-compose
     services:
       postgres:
-        image: postgres:15-alpine
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        image: public.ecr.aws/docker/library/postgres:15-alpine
         env:
           POSTGRES_USER: janua
           POSTGRES_PASSWORD: janua
@@ -43,10 +40,7 @@ jobs:
           --health-retries 5
 
       redis:
-        image: redis:7-alpine
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        image: public.ecr.aws/docker/library/redis:7-alpine
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -89,10 +89,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        image: public.ecr.aws/docker/library/postgres:15
         env:
           POSTGRES_USER: janua
           POSTGRES_PASSWORD: janua
@@ -106,10 +103,7 @@ jobs:
           - 5432:5432
 
       redis:
-        image: redis:7
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        image: public.ecr.aws/docker/library/redis:7
         options: >-
           --health-cmd "redis-cli ping"
           --health-interval 10s

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -193,10 +193,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        image: public.ecr.aws/docker/library/postgres:15
         ports:
           - 5432:5432
         env:
@@ -210,10 +207,7 @@ jobs:
           --health-retries 5
 
       redis:
-        image: redis:7
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        image: public.ecr.aws/docker/library/redis:7
         ports:
           - 6379:6379
         options: >-

--- a/.github/workflows/sync-prod-gitops.yml
+++ b/.github/workflows/sync-prod-gitops.yml
@@ -110,7 +110,7 @@ jobs:
         run: |
           kustomize build k8s/overlays/production > /tmp/janua-production.yaml
           echo "Website image in manifest:"
-          rg 'image: ghcr.io/madfam-org/janua-website' /tmp/janua-production.yaml || true
+          grep 'image: ghcr.io/madfam-org/janua-website' /tmp/janua-production.yaml || true
           kubectl apply -f /tmp/janua-production.yaml
 
       - name: Wait for rollout
@@ -127,17 +127,20 @@ jobs:
         run: |
           set -euo pipefail
           for i in 1 2 3 4 5 6; do
-            css_path=$(curl -fsSL "https://janua.dev/" | rg -o '/_next/static/chunks/[^"]+\.css' | head -1 || true)
+            home_html=$(curl -fsSL "https://janua.dev/" || true)
+            css_path=$(echo "$home_html" | grep -oE '/_next/static/chunks/[^"]+\.css' | head -1 || true)
             if [ -n "$css_path" ]; then
               css=$(curl -fsSL "https://janua.dev${css_path}" || true)
-              if echo "$css" | rg -q '\.flex\{' && curl -fsSL "https://janua.dev/" | rg -q 'Stop writing OAuth'; then
-                echo "Landing content + Tailwind utilities present"
-                curl -fsSI "https://janua.dev/pricing" | rg -q '200' && echo "pricing OK"
+              if echo "$css" | grep -q '\.flex{' \
+                && echo "$home_html" | grep -q 'Stop writing OAuth' \
+                && curl -fsSI "https://janua.dev/pricing" | grep -q '200' \
+                && curl -fsSI "https://janua.dev/legal/privacy" | grep -q '200'; then
+                echo "Landing, pricing, legal, and Tailwind utilities present"
                 exit 0
               fi
             fi
             echo "Waiting for janua.dev rollout (attempt $i)..."
             sleep 15
           done
-          echo "::warning::janua.dev smoke did not fully pass within timeout"
-          exit 0
+          echo "::error::janua.dev smoke did not pass within timeout"
+          exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,10 +24,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15-alpine
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        image: public.ecr.aws/docker/library/postgres:15-alpine
         env:
           POSTGRES_USER: janua
           POSTGRES_PASSWORD: janua_test
@@ -41,10 +38,7 @@ jobs:
           --health-retries 5
 
       redis:
-        image: redis:7-alpine
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        image: public.ecr.aws/docker/library/redis:7-alpine
         ports:
           - 6379:6379
         options: >-
@@ -172,10 +166,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15-alpine
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        image: public.ecr.aws/docker/library/postgres:15-alpine
         env:
           POSTGRES_USER: janua
           POSTGRES_PASSWORD: janua_test
@@ -189,10 +180,7 @@ jobs:
           --health-retries 5
 
       redis:
-        image: redis:7-alpine
-        credentials:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+        image: public.ecr.aws/docker/library/redis:7-alpine
         ports:
           - 6379:6379
         options: >-

--- a/docs/runbooks/incidents/2026-06-15-janua-website-prod-rollout.md
+++ b/docs/runbooks/incidents/2026-06-15-janua-website-prod-rollout.md
@@ -133,7 +133,8 @@ refreshed `janua/ghcr-credentials` with `madfam-bot` + `GHCR_PAT`, then
 | P2 | Add `prod-post-promote.yml` (mirror Dhanam) — Enclii lifecycle callback + best-effort Argo refresh | Platform |
 | P2 | Rotate or retire stale external `KUBECONFIG_PRODUCTION` secret; document ARC-only path | Platform |
 | P3 | Kyverno long-term: public GHCR packages or registry creds for verify-image-signatures | Security |
-| P3 | Phase 2 UX: typography beyond Inter, gradient cleanup, legal pages | Product |
+| P3 | Phase 2 UX: typography beyond Inter, gradient cleanup, legal pages | **Done** (#423, prod `sha256:92a73b80…`) |
+| P3 | `sync-prod-gitops` smoke: use `grep` not `rg` on ARC runners | **Done** |
 
 ---
 

--- a/docs/runbooks/production-gitops-reconcile.md
+++ b/docs/runbooks/production-gitops-reconcile.md
@@ -173,6 +173,7 @@ unavailable; use `enclii ops apps sync` from an authenticated operator session.
 - [ ] `enclii ops pods diagnose <deployment> -n janua` — single Ready pod on expected digest
 - [ ] Public URL health (`https://janua.dev/health`, `https://api.janua.dev/health`)
 - [ ] For website: Tailwind utilities in CSS; `(marketing)` layout on `/pricing`
+- [ ] For website: `/legal/privacy` returns 200 (post Phase 2 UX)
 - [ ] Footer links match current `apps/website/components/footer.tsx` (no dead 404s)
 
 ---


### PR DESCRIPTION
## Summary
- Switch postgres/redis CI service containers to `public.ecr.aws/docker/library/*` (Docker Hub rate limit was failing main-branch API + E2E jobs)
- Replace `rg` with portable `grep` in `sync-prod-gitops.yml` smoke step; fail closed on timeout; add `/legal/privacy` check
- Update runbook follow-ups for completed UX + smoke fix

## Test plan
- [ ] Tests & Coverage + E2E Tests pass on this PR (postgres pull succeeds)
- [ ] Optional: dispatch `sync-prod-gitops.yml` to confirm smoke step passes on ARC


Made with [Cursor](https://cursor.com)