### PR TITLE
fix(models): rename reserved 'metadata' column crashing janua-api rollout

### DIFF
--- a/apps/api/alembic/versions/008_connected_accounts.py
+++ b/apps/api/alembic/versions/008_connected_accounts.py
@@ -45,7 +45,7 @@ def upgrade() -> None:
         sa.Column("oauth_scopes", json_type, nullable=True),
         sa.Column("oauth_expires_at", sa.DateTime(), nullable=True),
         sa.Column("status", sa.String(20), server_default="active"),
-        sa.Column("metadata", json_type, nullable=True),
+        sa.Column("account_metadata", json_type, nullable=True),
         sa.Column("last_used_at", sa.DateTime(), nullable=True),
         sa.Column("created_at", sa.DateTime(), nullable=True),
         sa.Column("updated_at", sa.DateTime(), nullable=True),

--- a/apps/api/app/models/connected_account.py
+++ b/apps/api/app/models/connected_account.py
@@ -54,7 +54,9 @@ class ConnectedAccount(Base):
     oauth_expires_at = Column(DateTime, nullable=True)
 
     status = Column(String(20), default=ConnectedAccountStatus.ACTIVE.value)
-    account_metadata = Column("metadata", JSONB, default=dict)
+    # Column name must NOT be "metadata" — SQLAlchemy 2.0 Declarative reserves it
+    # on Base, which crashes the mapper at import (broke janua-api rollout 2913).
+    account_metadata = Column("account_metadata", JSONB, default=dict)
     last_used_at = Column(DateTime, nullable=True)
 
     created_at = Column(DateTime, default=datetime.utcnow)


### PR DESCRIPTION
## Incident
`janua-api` Deployment revision **2913** has been stuck for **~13 days**: its new ReplicaSet's single pod is in **CrashLoopBackOff** (200+ restarts). Auth (`auth.madfam.io`) stayed up **only** because two *old-revision* pods (which predate the `connected_account` model) kept serving — `ready=2/2`, so this was invisible from the outside but the rollout never completed and janua **cannot be safely restarted or scaled**.

## Root cause
`app/models/connected_account.py` maps a column literally named `metadata`:
```python
account_metadata = Column("metadata", JSONB, default=dict)  # column name = 'metadata'
```
SQLAlchemy 2.0's Declarative API **reserves `metadata`** on `Base`, so the mapper raises `InvalidRequestError: Attribute name 'metadata' is reserved` **at import**, before FastAPI starts. Commit `0cbf0616` previously renamed the *Python attribute* to `account_metadata` but left the *column-name string* as `"metadata"`, so the crash persisted.

## Fix
Rename the mapped column to `account_metadata` in the model **and** the creating migration (`008_connected_accounts`).

## Safety
- Migrations are **unapplied in prod** (alembic head is `002`; 008 is far ahead). `connected_accounts` table **does not exist** — verified in prod DB. No data to preserve, no rename migration needed.
- Python attribute was already `account_metadata` (used in `connected_account_service.py:125`) — **no call-site changes**.

## Validation
The definitive proof is the image build + deploy: revision 2913's successor should start cleanly and the rollout complete (new pod `1/1`, old pods retired). CI builds the image and would catch any remaining import error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)