### PR TITLE
feat(oauth): service tokens for RFC 0024 §P4 cross-service consolidations

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -675,7 +675,15 @@ def openid_configuration():
         "grant_types_supported": ["authorization_code", "refresh_token", "client_credentials"],
         "subject_types_supported": ["public"],
         "id_token_signing_alg_values_supported": ["RS256"],
-        "scopes_supported": ["openid", "profile", "email", "offline_access"],
+        "scopes_supported": [
+            "openid",
+            "profile",
+            "email",
+            "offline_access",
+            # Service-to-service (client_credentials) scopes — see docs/service-tokens.md
+            "cfdi:issue",
+            "billing:events",
+        ],
         "token_endpoint_auth_methods_supported": [
             "client_secret_basic",
             "client_secret_post",

--- a/apps/api/app/routers/v1/oauth_provider.py
+++ b/apps/api/app/routers/v1/oauth_provider.py
@@ -55,6 +55,12 @@ logout_router = APIRouter(tags=["OAuth Provider"])
 # CSRF token TTL (10 minutes)
 CSRF_TOKEN_TTL = 600
 
+# Lifetime of client_credentials (service) access tokens. Machine tokens are
+# deliberately short-lived: services re-request tokens instead of refreshing,
+# so this must match the `expires_in` advertised in the token response rather
+# than inheriting the (much longer) human-session access-token TTL.
+SERVICE_TOKEN_TTL_SECONDS = 3600
+
 
 def _audiences_from_claims(claims: dict) -> list[str]:
     """Extract audience values embedded in a JWT (string or array claim)."""
@@ -1449,6 +1455,9 @@ async def _handle_client_credentials_grant(
     client_audience = client.audience or settings.JWT_AUDIENCE
     additional_claims = await _get_client_credentials_claims(client, scope, db)
     additional_claims["aud"] = client_audience
+    # Override the default (human-session) access-token TTL so the token's
+    # actual `exp` matches the `expires_in` we advertise below.
+    additional_claims["exp"] = datetime.utcnow() + timedelta(seconds=SERVICE_TOKEN_TTL_SECONDS)
 
     access_token, _, _ = jwt_manager.create_access_token(
         user_id=f"service-account:{client.client_id}",
@@ -1462,7 +1471,7 @@ async def _handle_client_credentials_grant(
     return TokenResponse(
         access_token=access_token,
         token_type="Bearer",
-        expires_in=3600,
+        expires_in=SERVICE_TOKEN_TTL_SECONDS,
         refresh_token=None,
         id_token=None,
         scope=scope,

--- a/apps/api/scripts/seed_core_clients.py
+++ b/apps/api/scripts/seed_core_clients.py
@@ -274,9 +274,7 @@ async def _get_admin_user_id(engine: AsyncEngine) -> uuid.UUID:
     """Return the id of the first admin user, or abort."""
     async with engine.connect() as conn:
         result = await conn.execute(
-            text(
-                "SELECT id FROM users WHERE is_admin = true ORDER BY created_at ASC LIMIT 1"
-            )
+            text("SELECT id FROM users WHERE is_admin = true ORDER BY created_at ASC LIMIT 1")
         )
         row = result.fetchone()
 
@@ -292,8 +290,20 @@ async def _get_admin_user_id(engine: AsyncEngine) -> uuid.UUID:
     return admin_id
 
 
-async def _seed_clients(engine: AsyncEngine) -> None:
-    """Insert missing ecosystem clients into ``oauth_clients``."""
+DEFAULT_GRANT_TYPES = ["authorization_code", "refresh_token"]
+
+
+async def _seed_clients(
+    engine: AsyncEngine,
+    clients: list[dict[str, Any]] | None = None,
+) -> None:
+    """Insert missing ecosystem clients into ``oauth_clients``.
+
+    Each client definition may carry an optional ``grant_types`` list
+    (default: interactive ``authorization_code`` + ``refresh_token``).
+    Machine clients (e.g. seeded by ``seed_service_clients.py``) set
+    ``grant_types: ["client_credentials"]`` and empty ``redirect_uris``.
+    """
     admin_id = await _get_admin_user_id(engine)
     now = datetime.utcnow()  # naive UTC — matches DB column type
 
@@ -301,16 +311,13 @@ async def _seed_clients(engine: AsyncEngine) -> None:
     skipped_count = 0
 
     async with engine.begin() as conn:
-        for client_def in ECOSYSTEM_CLIENTS:
+        for client_def in clients if clients is not None else ECOSYSTEM_CLIENTS:
             name = client_def["name"]
 
             # Idempotency check — match by name or pre-assigned client_id
             pre_assigned_id = client_def.get("client_id")
             existing = await conn.execute(
-                text(
-                    "SELECT id FROM oauth_clients "
-                    "WHERE name = :name OR client_id = :cid"
-                ),
+                text("SELECT id FROM oauth_clients " "WHERE name = :name OR client_id = :cid"),
                 {"name": name, "cid": pre_assigned_id or ""},
             )
             existing_row = existing.fetchone()
@@ -335,7 +342,7 @@ async def _seed_clients(engine: AsyncEngine) -> None:
                         "redirect_uris": _json_dumps(client_def["redirect_uris"]),
                         "allowed_scopes": _json_dumps(client_def["allowed_scopes"]),
                         "grant_types": _json_dumps(
-                            ["authorization_code", "refresh_token"]
+                            client_def.get("grant_types", DEFAULT_GRANT_TYPES)
                         ),
                         "audience": client_def.get("audience"),
                         "is_confidential": client_def.get("is_confidential", True),
@@ -399,9 +406,7 @@ async def _seed_clients(engine: AsyncEngine) -> None:
                     "description": client_def.get("description"),
                     "redirect_uris": _json_dumps(client_def["redirect_uris"]),
                     "allowed_scopes": _json_dumps(client_def["allowed_scopes"]),
-                    "grant_types": _json_dumps(
-                        ["authorization_code", "refresh_token"]
-                    ),
+                    "grant_types": _json_dumps(client_def.get("grant_types", DEFAULT_GRANT_TYPES)),
                     "audience": client_def.get("audience"),
                     "is_confidential": client_def.get("is_confidential", True),
                     "now": now,

--- a/apps/api/scripts/seed_service_clients.py
+++ b/apps/api/scripts/seed_service_clients.py
@@ -1,0 +1,97 @@
+"""
+Seed machine (client_credentials) OAuth clients for cross-service auth.
+
+These are the RFC 0024 §P4 consolidation service identities:
+
+- ``zavlo-cfdi-emitter``      — Zavlo → Karafiel CFDI stamping bridge
+- ``routecraft-billing-relay`` — RouteCraft → Dhanam billing delegation
+
+Unlike the interactive clients in ``seed_core_clients.py``, these clients:
+
+- allow ONLY the ``client_credentials`` grant (no browser flows),
+- have no redirect URIs,
+- are confidential (a ``client_secret`` is required), and
+- carry a narrow scope allowlist (least privilege).
+
+The client_secret is printed exactly once on creation — store it in the
+approved secret store (Enclii/Vault) for the calling service. Never commit it.
+
+Alternative (zero-touch) provisioning: each consumer service's bootstrap can
+instead call ``POST /api/v1/oauth/clients/register`` with ``X-Internal-API-Key``
+and the same payload shape. This script exists for operator-driven seeding.
+
+Usage:
+    cd apps/api
+    python scripts/seed_service_clients.py
+
+See docs/service-tokens.md for the full integration contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from typing import Any
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from seed_core_clients import (  # noqa: E402
+    _resolve_database_url,
+    _seed_clients,
+)
+from sqlalchemy.ext.asyncio import create_async_engine  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Service (machine-to-machine) client definitions
+# ---------------------------------------------------------------------------
+
+SERVICE_CLIENTS: list[dict[str, Any]] = [
+    {
+        "name": "zavlo-cfdi-emitter",
+        "description": (
+            "Zavlo → Karafiel CFDI stamping bridge service client "
+            "(internal-devops RFC 0024 §P4.2). Emits zavlo.* payment "
+            "envelopes to Karafiel's CFDI billing bridge."
+        ),
+        "audience": "karafiel-api",
+        "redirect_uris": [],
+        "allowed_scopes": ["cfdi:issue"],
+        "grant_types": ["client_credentials"],
+        "is_confidential": True,
+    },
+    {
+        "name": "routecraft-billing-relay",
+        "description": (
+            "RouteCraft → Dhanam billing delegation service client "
+            "(internal-devops RFC 0024 §P4.3). Emits signed billing events "
+            "and delegated checkout requests to Dhanam's billing APIs."
+        ),
+        "audience": "dhanam-api",
+        "redirect_uris": [],
+        "allowed_scopes": ["billing:events"],
+        "grant_types": ["client_credentials"],
+        "is_confidential": True,
+    },
+]
+
+
+async def main() -> None:
+    database_url = _resolve_database_url()
+    engine = create_async_engine(database_url, echo=False)
+
+    try:
+        await _seed_clients(engine, clients=SERVICE_CLIENTS)
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        logger.info("Interrupted.")
+        sys.exit(130)

--- a/apps/api/tests/unit/routers/test_service_token_clients.py
+++ b/apps/api/tests/unit/routers/test_service_token_clients.py
@@ -1,0 +1,331 @@
+"""
+Service-token (client_credentials) tests for the RFC 0024 §P4 consolidation
+clients — zavlo-cfdi-emitter (cfdi:issue → karafiel-api) and
+routecraft-billing-relay (billing:events → dhanam-api).
+
+Covers, end-to-end through POST /api/v1/oauth/token:
+- happy-path token issuance (scoped RS256/HS256 JWT, verifiable claims)
+- wrong-secret rejection
+- scope enforcement (fail closed on scopes outside the client allowlist)
+- expiry (token exp == advertised expires_in; expired tokens are inactive)
+
+See docs/service-tokens.md for the integration contract.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import bcrypt
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.core.database import get_db as core_get_db
+from app.core.jwt_manager import jwt_manager
+from app.core.redis import get_redis
+from app.database import get_db
+from app.main import app
+from app.models import Base, OAuthClient, User, UserStatus
+from app.routers.v1.oauth_provider import SERVICE_TOKEN_TTL_SECONDS
+
+TOKEN_URL = "/api/v1/oauth/token"
+INTROSPECT_URL = "/api/v1/oauth/introspect"
+
+# Placeholder credentials for tests only — never real secrets.
+ZAVLO_CLIENT_ID = "jnc_test_zavlo_cfdi_emitter"
+ZAVLO_SECRET = "jns_test_zavlo_secret_placeholder"
+ROUTECRAFT_CLIENT_ID = "jnc_test_routecraft_billing_relay"
+ROUTECRAFT_SECRET = "jns_test_routecraft_secret_placeholder"
+INTERACTIVE_CLIENT_ID = "jnc_test_interactive_only"
+INTERACTIVE_SECRET = "jns_test_interactive_secret_placeholder"
+
+
+def _hash(secret: str) -> str:
+    return bcrypt.hashpw(secret.encode(), bcrypt.gensalt(rounds=4)).decode()
+
+
+def _service_client(
+    *,
+    created_by: uuid.UUID,
+    name: str,
+    client_id: str,
+    secret: str,
+    audience: str,
+    allowed_scopes: list[str],
+    grant_types: list[str],
+) -> OAuthClient:
+    return OAuthClient(
+        id=uuid.uuid4(),
+        created_by=created_by,
+        client_id=client_id,
+        client_secret_hash=_hash(secret),
+        client_secret_prefix=secret[:8],
+        name=name,
+        redirect_uris=[],
+        allowed_scopes=allowed_scopes,
+        grant_types=grant_types,
+        audience=audience,
+        is_active=True,
+        is_confidential=True,
+    )
+
+
+@pytest_asyncio.fixture
+async def service_token_client():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with session_factory() as session:
+            yield session
+
+    redis = AsyncMock()
+    redis.ping.return_value = True
+    redis.get.return_value = None
+    redis.set.return_value = True
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[core_get_db] = override_get_db
+    app.dependency_overrides[get_redis] = lambda: redis
+
+    admin_id = uuid.uuid4()
+    admin = User(
+        id=admin_id,
+        email="admin-service-tokens@janua.test",
+        email_verified=True,
+        status=UserStatus.ACTIVE,
+        is_admin=True,
+        is_active=True,
+    )
+
+    async with session_factory() as session:
+        session.add(admin)
+        session.add(
+            _service_client(
+                created_by=admin_id,
+                name="zavlo-cfdi-emitter",
+                client_id=ZAVLO_CLIENT_ID,
+                secret=ZAVLO_SECRET,
+                audience="karafiel-api",
+                allowed_scopes=["cfdi:issue"],
+                grant_types=["client_credentials"],
+            )
+        )
+        session.add(
+            _service_client(
+                created_by=admin_id,
+                name="routecraft-billing-relay",
+                client_id=ROUTECRAFT_CLIENT_ID,
+                secret=ROUTECRAFT_SECRET,
+                audience="dhanam-api",
+                allowed_scopes=["billing:events"],
+                grant_types=["client_credentials"],
+            )
+        )
+        # Interactive-only client: client_credentials must be refused.
+        session.add(
+            _service_client(
+                created_by=admin_id,
+                name="interactive-only-app",
+                client_id=INTERACTIVE_CLIENT_ID,
+                secret=INTERACTIVE_SECRET,
+                audience="janua.dev",
+                allowed_scopes=["openid", "profile", "email"],
+                grant_types=["authorization_code", "refresh_token"],
+            )
+        )
+        await session.commit()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+    app.dependency_overrides.clear()
+    await engine.dispose()
+
+
+def _error_message(response) -> str:
+    """Extract the error detail regardless of error-envelope shape.
+
+    Plain FastAPI HTTPExceptions render as {"detail": ...}; the app's
+    error-handling middleware re-wraps them as {"error": {"message": ...}}.
+    """
+    body = response.json()
+    if "detail" in body:
+        return str(body["detail"])
+    return str(body.get("error", {}).get("message", ""))
+
+
+async def _request_token(client: AsyncClient, **overrides) -> object:
+    data = {
+        "grant_type": "client_credentials",
+        "client_id": ZAVLO_CLIENT_ID,
+        "client_secret": ZAVLO_SECRET,
+        "scope": "cfdi:issue",
+    }
+    data.update(overrides)
+    return await client.post(TOKEN_URL, data=data)
+
+
+class TestServiceTokenIssuance:
+    """Happy-path client_credentials issuance for the consolidation clients."""
+
+    async def test_zavlo_client_receives_scoped_service_token(self, service_token_client):
+        response = await _request_token(service_token_client)
+        assert response.status_code == 200, response.text
+
+        body = response.json()
+        assert body["token_type"] == "Bearer"
+        assert body["scope"] == "cfdi:issue"
+        assert body["expires_in"] == SERVICE_TOKEN_TTL_SECONDS
+        assert body["refresh_token"] is None
+        assert body["id_token"] is None
+
+        # The token must verify against the karafiel-api audience with the
+        # machine-identity claim shape documented in docs/service-tokens.md.
+        claims = jwt_manager.verify_token(
+            body["access_token"], token_type="access", audience="karafiel-api"
+        )
+        assert claims is not None
+        assert claims["sub"] == f"service-account:{ZAVLO_CLIENT_ID}"
+        assert claims["client_id"] == ZAVLO_CLIENT_ID
+        assert claims["token_use"] == "client_credentials"
+        assert claims["actor_type"] == "service_account"
+        assert "service_account" in claims["roles"]
+        assert claims["scope"] == "cfdi:issue"
+        assert claims["aud"] == "karafiel-api"
+
+    async def test_routecraft_client_defaults_to_full_allowlist(self, service_token_client):
+        """Omitting scope grants the client's (single-scope) allowlist."""
+        response = await _request_token(
+            service_token_client,
+            client_id=ROUTECRAFT_CLIENT_ID,
+            client_secret=ROUTECRAFT_SECRET,
+            scope="",
+        )
+        assert response.status_code == 200, response.text
+
+        body = response.json()
+        assert body["scope"] == "billing:events"
+        claims = jwt_manager.verify_token(
+            body["access_token"], token_type="access", audience="dhanam-api"
+        )
+        assert claims is not None
+        assert claims["sub"] == f"service-account:{ROUTECRAFT_CLIENT_ID}"
+        assert claims["scope"] == "billing:events"
+        assert claims["aud"] == "dhanam-api"
+
+
+class TestServiceTokenRejection:
+    """Fail-closed behavior: bad secrets, foreign scopes, wrong grants."""
+
+    async def test_wrong_secret_is_rejected(self, service_token_client):
+        response = await _request_token(
+            service_token_client, client_secret="jns_wrong_secret_placeholder"
+        )
+        assert response.status_code == 401
+        assert "invalid_client" in _error_message(response)
+
+    async def test_scope_outside_allowlist_is_rejected(self, service_token_client):
+        """zavlo-cfdi-emitter must not be able to mint billing:events tokens."""
+        response = await _request_token(service_token_client, scope="billing:events")
+        assert response.status_code == 400
+        detail = _error_message(response)
+        assert "invalid_scope" in detail
+        assert "billing:events" in detail
+
+    async def test_partially_escalated_scope_is_rejected(self, service_token_client):
+        """One allowed + one foreign scope must still fail closed."""
+        response = await _request_token(service_token_client, scope="cfdi:issue cfdi:cancel")
+        assert response.status_code == 400
+        assert "invalid_scope" in _error_message(response)
+
+    async def test_client_without_client_credentials_grant_is_rejected(self, service_token_client):
+        response = await _request_token(
+            service_token_client,
+            client_id=INTERACTIVE_CLIENT_ID,
+            client_secret=INTERACTIVE_SECRET,
+            scope="openid",
+        )
+        assert response.status_code == 400
+        assert "unauthorized_client" in _error_message(response)
+
+
+class TestServiceTokenExpiry:
+    """Service tokens are short-lived and expire honestly."""
+
+    async def test_token_exp_matches_advertised_expires_in(self, service_token_client):
+        response = await _request_token(service_token_client)
+        assert response.status_code == 200, response.text
+        body = response.json()
+
+        claims = jwt_manager.get_unverified_claims(body["access_token"])
+        assert claims["exp"] - claims["iat"] == body["expires_in"] == SERVICE_TOKEN_TTL_SECONDS
+
+    async def test_expired_service_token_fails_verification_and_introspection(
+        self, service_token_client
+    ):
+        now = datetime.now(timezone.utc)
+        expired_token = jwt_manager.encode_token(
+            {
+                "sub": f"service-account:{ZAVLO_CLIENT_ID}",
+                "client_id": ZAVLO_CLIENT_ID,
+                "scope": "cfdi:issue",
+                "token_use": "client_credentials",
+                "type": "access",
+                "iss": jwt_manager.issuer,
+                "aud": "karafiel-api",
+                "iat": int((now - timedelta(hours=2)).timestamp()),
+                "exp": int((now - timedelta(hours=1)).timestamp()),
+            }
+        )
+
+        # Offline (JWKS-style) verification rejects it.
+        assert (
+            jwt_manager.verify_token(expired_token, token_type="access", audience="karafiel-api")
+            is None
+        )
+
+        # RFC 7662 introspection reports it inactive.
+        response = await service_token_client.post(
+            INTROSPECT_URL,
+            data={
+                "token": expired_token,
+                "client_id": ZAVLO_CLIENT_ID,
+                "client_secret": ZAVLO_SECRET,
+            },
+        )
+        assert response.status_code == 200
+        assert response.json() == {"active": False}
+
+    async def test_live_service_token_is_active_via_introspection(self, service_token_client):
+        issued = await _request_token(service_token_client)
+        assert issued.status_code == 200, issued.text
+        access_token = issued.json()["access_token"]
+
+        response = await service_token_client.post(
+            INTROSPECT_URL,
+            data={
+                "token": access_token,
+                "client_id": ZAVLO_CLIENT_ID,
+                "client_secret": ZAVLO_SECRET,
+            },
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["active"] is True
+        assert body["sub"] == f"service-account:{ZAVLO_CLIENT_ID}"
+        assert body["client_id"] == ZAVLO_CLIENT_ID
+        assert body["scope"] == "cfdi:issue"

--- a/docs/guides/machine-to-machine-authentication-guide.md
+++ b/docs/guides/machine-to-machine-authentication-guide.md
@@ -5,6 +5,10 @@ operations. Use this pattern for automated probes, Selva platform agents, and
 Codex-assisted verification runs. Do not share human superadmin passwords with
 automation.
 
+For the RFC 0024 §P4 consolidation service clients (Zavlo→Karafiel `cfdi:issue`,
+RouteCraft→Dhanam `billing:events`) and resource-server verification recipes
+(JWKS + introspection), see [docs/service-tokens.md](../service-tokens.md).
+
 ## Recommended identity
 
 Create one Janua OAuth client per operational capability. For ecosystem-wide

--- a/docs/service-tokens.md
+++ b/docs/service-tokens.md
@@ -1,0 +1,259 @@
+# Janua Service Tokens (machine-to-machine auth)
+
+Cross-service identity for the RFC 0024 §P4 consolidations:
+
+| Flow | Service client | Scope | Token audience | Resource server |
+|---|---|---|---|---|
+| Zavlo → Karafiel CFDI bridge (§P4.2) | `zavlo-cfdi-emitter` | `cfdi:issue` | `karafiel-api` | Karafiel API |
+| RouteCraft → Dhanam billing (§P4.3) | `routecraft-billing-relay` | `billing:events` | `dhanam-api` | Dhanam API |
+
+Both migration plans (`zavlo/docs/karafiel-cfdi-migration-plan.md`,
+`routecraft/docs/dhanam-payments-migration-plan.md`) are gated on this
+decision. This document is the decision record + integration contract.
+
+**Decision**: service-to-service calls authenticate with Janua-issued
+OAuth 2.0 `client_credentials` tokens (RFC 6749 §4.4). One confidential
+OAuth client per producer→consumer edge, scoped to exactly the capability
+that edge needs. Resource servers verify tokens offline via Janua's JWKS
+(RS256) or online via RFC 7662 introspection.
+
+Janua's `client_credentials` support (token endpoint, per-client scope
+allowlist, introspection, JWKS) **already exists** — see
+[`docs/guides/machine-to-machine-authentication-guide.md`](./guides/machine-to-machine-authentication-guide.md)
+for the general pattern. This page pins down the two concrete
+consolidation clients and how each side integrates.
+
+## Endpoints
+
+Issuer (production): `https://auth.madfam.io`
+
+| Purpose | Endpoint |
+|---|---|
+| Discovery | `GET /.well-known/openid-configuration` |
+| JWKS (public keys) | `GET /.well-known/jwks.json` |
+| Token | `POST /api/v1/oauth/token` |
+| Introspection (RFC 7662) | `POST /api/v1/oauth/introspect` |
+| Client registration (internal) | `POST /api/v1/oauth/clients/register` |
+
+## Service clients
+
+Provisioned by an operator with `apps/api/scripts/seed_service_clients.py`
+(or zero-touch via `POST /api/v1/oauth/clients/register` +
+`X-Internal-API-Key`). Registration properties:
+
+```jsonc
+// zavlo-cfdi-emitter
+{
+  "name": "zavlo-cfdi-emitter",
+  "audience": "karafiel-api",
+  "allowed_scopes": ["cfdi:issue"],
+  "grant_types": ["client_credentials"],
+  "redirect_uris": [],
+  "is_confidential": true
+}
+
+// routecraft-billing-relay
+{
+  "name": "routecraft-billing-relay",
+  "audience": "dhanam-api",
+  "allowed_scopes": ["billing:events"],
+  "grant_types": ["client_credentials"],
+  "redirect_uris": [],
+  "is_confidential": true
+}
+```
+
+The `client_secret` is shown **once** at provisioning. Store it in the
+approved secret store (Enclii/Vault) and mount it into the calling
+service's runtime environment. Placeholders only in code and docs —
+never commit real `jnc_`/`jns_` values.
+
+## How Zavlo / RouteCraft obtain tokens
+
+`POST /api/v1/oauth/token` with `grant_type=client_credentials`. Client
+authentication is `client_secret_basic` or `client_secret_post`.
+
+```bash
+curl -sS https://auth.madfam.io/api/v1/oauth/token \
+  -u "$JANUA_CLIENT_ID:$JANUA_CLIENT_SECRET" \
+  -d grant_type=client_credentials \
+  -d scope="cfdi:issue"          # routecraft: scope="billing:events"
+```
+
+Response:
+
+```json
+{
+  "access_token": "<RS256 JWT>",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": null,
+  "scope": "cfdi:issue"
+}
+```
+
+Rules for callers:
+
+- Tokens live **1 hour** (`expires_in` matches the JWT `exp`). There is no
+  refresh token — request a new token when the old one is near expiry.
+  Cache the token in memory and re-request ~60s before expiry; do not
+  request a fresh token per call (the token endpoint is rate-limited).
+- Omitting `scope` grants **all** scopes on the client's allowlist; the
+  seeded clients have exactly one scope, so both forms are equivalent.
+- Requesting a scope outside the client's allowlist fails closed with
+  `400 invalid_scope`.
+- Send the token as `Authorization: Bearer <access_token>` on every
+  Karafiel/Dhanam call.
+
+TypeScript sketch for `zavlo-backend` (NestJS) / RouteCraft:
+
+```ts
+let cached: { token: string; exp: number } | null = null;
+
+async function serviceToken(): Promise<string> {
+  if (cached && cached.exp - 60_000 > Date.now()) return cached.token;
+  const res = await fetch(`${JANUA_ISSUER}/api/v1/oauth/token`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Authorization:
+        "Basic " +
+        Buffer.from(`${CLIENT_ID}:${CLIENT_SECRET}`).toString("base64"),
+    },
+    body: new URLSearchParams({ grant_type: "client_credentials" }),
+  });
+  if (!res.ok) throw new Error(`janua token: ${res.status}`);
+  const body = await res.json();
+  cached = { token: body.access_token, exp: Date.now() + body.expires_in * 1000 };
+  return cached.token;
+}
+```
+
+## Token shape
+
+Service tokens are RS256 JWTs (`kid` in the header, key published at
+`/.well-known/jwks.json`) with these claims:
+
+```jsonc
+{
+  "iss": "https://auth.madfam.io",
+  "sub": "service-account:jnc_...",     // stable machine identity
+  "aud": "karafiel-api",                // per-client audience
+  "exp": 1780000000,                    // iat + 3600
+  "iat": 1779996400,
+  "jti": "...",
+  "type": "access",
+  "client_id": "jnc_...",
+  "scope": "cfdi:issue",                // space-separated granted scopes
+  "token_use": "client_credentials",
+  "actor_type": "service_account",
+  "roles": ["service_account"],
+  "email": "zavlo-cfdi-emitter@service.auth.madfam.io"
+}
+```
+
+## How Karafiel verifies (offline, JWKS)
+
+Karafiel (FastAPI) verifies without calling Janua on the hot path:
+
+1. Fetch + cache JWKS from `https://auth.madfam.io/.well-known/jwks.json`.
+2. Verify signature (RS256), `iss == https://auth.madfam.io`,
+   `aud == "karafiel-api"`, and `exp` (PyJWT does all four).
+3. Enforce `token_use == "client_credentials"` and that the required
+   scope is present in the `scope` claim.
+
+```python
+import jwt
+from jwt import PyJWKClient
+
+_jwks = PyJWKClient("https://auth.madfam.io/.well-known/jwks.json")
+
+def verify_service_token(token: str, required_scope: str = "cfdi:issue") -> dict:
+    key = _jwks.get_signing_key_from_jwt(token).key
+    claims = jwt.decode(
+        token,
+        key,
+        algorithms=["RS256"],
+        issuer="https://auth.madfam.io",
+        audience="karafiel-api",
+    )  # raises on bad signature / issuer / audience / expiry
+    if claims.get("token_use") != "client_credentials":
+        raise PermissionError("not a service token")
+    if required_scope not in (claims.get("scope") or "").split():
+        raise PermissionError(f"missing scope {required_scope}")
+    return claims  # claims["sub"] / claims["client_id"] for audit rows
+```
+
+Karafiel's CFDI billing bridge guards `POST` envelope ingestion with
+`required_scope="cfdi:issue"` and attributes the envelope to
+`claims["client_id"]` alongside the existing `source: "zavlo.*"`
+discriminator and idempotency key.
+
+## How Dhanam verifies (offline, JWKS)
+
+Dhanam (NestJS) uses the same pattern via `passport-jwt` + `jwks-rsa`
+(mirrors `zavlo-backend/src/modules/janua/janua-jwt.strategy.ts`):
+
+```ts
+import { passportJwtSecret } from "jwks-rsa";
+import { ExtractJwt, Strategy } from "passport-jwt";
+
+export class JanuaServiceJwtStrategy extends PassportStrategy(Strategy, "janua-service") {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      algorithms: ["RS256"],
+      issuer: "https://auth.madfam.io",
+      audience: "dhanam-api",
+      secretOrKeyProvider: passportJwtSecret({
+        jwksUri: "https://auth.madfam.io/.well-known/jwks.json",
+        cache: true,
+        rateLimit: true,
+      }),
+    });
+  }
+
+  validate(claims: Record<string, unknown>) {
+    if (claims.token_use !== "client_credentials") throw new UnauthorizedException();
+    const scopes = String(claims.scope ?? "").split(" ");
+    if (!scopes.includes("billing:events")) throw new ForbiddenException();
+    return claims; // claims.sub === "service-account:jnc_..."
+  }
+}
+```
+
+Scope map on the Dhanam side:
+
+- `billing:events` — RouteCraft's signed `payment.succeeded` /
+  attribution emission to `POST /v1/billing/madfam-events` and the
+  delegated `POST /v1/billing/checkout` call. The existing HMAC envelope
+  signature (`t=<ts>,v1=<hex>`) stays as content integrity on the event
+  body; the Bearer token is the caller *identity*.
+
+## Alternative: introspection (RFC 7662)
+
+Resource servers that prefer online checks (or need immediate-revocation
+semantics) can call introspection instead of JWKS verification:
+
+```bash
+curl -sS https://auth.madfam.io/api/v1/oauth/introspect \
+  -u "$RESOURCE_CLIENT_ID:$RESOURCE_CLIENT_SECRET" \
+  -d token="$ACCESS_TOKEN"
+# => {"active": true, "sub": "service-account:jnc_...",
+#     "client_id": "jnc_...", "scope": "cfdi:issue", "exp": ..., "iat": ...}
+```
+
+Expired or otherwise invalid tokens return `{"active": false}`.
+Introspection itself requires client authentication (the resource
+server's own Janua client credentials).
+
+## Rotation & operations
+
+- Rotate secrets via Janua's OAuth client secret-rotation endpoint;
+  `CLIENT_SECRET_ROTATION_ENABLED` gives a dual-secret grace window so
+  callers roll without downtime.
+- One client per edge: do not reuse `zavlo-cfdi-emitter` for anything but
+  Zavlo→Karafiel, nor `routecraft-billing-relay` for anything but
+  RouteCraft→Dhanam. New edges get new clients with their own scopes.
+- Widening a client's `allowed_scopes` is an operator action on the Janua
+  side (seed script re-run or admin API) and must be reflected here.


### PR DESCRIPTION
## Description

Implements the **Janua service token** prerequisite that gates the two RFC 0024 §P4 consolidations:

- **zavlo → karafiel CFDI** (`zavlo/docs/karafiel-cfdi-migration-plan.md`, PR #6) — needs a Zavlo→Karafiel service identity (audience/scope/rotation decision)
- **routecraft → dhanam payments** (`routecraft/docs/dhanam-payments-migration-plan.md`, PR #47) — the delegated `POST /v1/billing/checkout` + `madfam-events` calls need a caller identity beyond body HMAC

**Stated plainly: Janua already supports `client_credentials`** (RFC 6749 §4.4) end-to-end — confidential-client enforcement, per-client `allowed_scopes` fail-closed validation, per-client `audience`, RFC 7662 introspection, JWKS/RS256, registration via `POST /api/v1/oauth/clients/register`, and secret rotation. Nothing was rebuilt. This PR adds the missing integration pieces:

## Changes Made

- **`docs/service-tokens.md`** — decision record + integration contract: the two service clients (`zavlo-cfdi-emitter` → scope `cfdi:issue`, aud `karafiel-api`; `routecraft-billing-relay` → scope `billing:events`, aud `dhanam-api`), how zavlo/routecraft obtain + cache tokens, and how Karafiel (PyJWT + JWKS) and Dhanam (passport-jwt + jwks-rsa) verify offline, with introspection as the online alternative. Cross-linked from the existing M2M guide.
- **`apps/api/scripts/seed_service_clients.py`** — idempotent operator seeding of the two confidential machine clients (`client_credentials`-only, empty redirect URIs, least-privilege single scopes). `seed_core_clients.py` now honors per-client `grant_types` instead of hardcoding the interactive grants (previously machine clients could not be seeded correctly).
- **Honest expiry** (`oauth_provider.py`) — client-credentials tokens previously advertised `expires_in: 3600` while the JWT `exp` silently inherited the 8-hour human-session TTL (`JWT_ACCESS_TOKEN_EXPIRE_MINUTES=480`). Service tokens now genuinely expire at `SERVICE_TOKEN_TTL_SECONDS` (3600) matching the advertised value.
- **Discovery** — `scopes_supported` now advertises `cfdi:issue` and `billing:events`.
- **Tests** — `tests/unit/routers/test_service_token_clients.py` (9 tests, end-to-end through `POST /api/v1/oauth/token`): happy-path scoped issuance for both clients, wrong-secret rejection (401 `invalid_client`), scope enforcement fail-closed (400 `invalid_scope`, incl. partial escalation), grant-type restriction (400 `unauthorized_client`), `exp − iat == expires_in`, expired-token rejection via both JWKS-style verification and introspection (`{"active": false}`), and live-token introspection.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Testing

- `pytest tests/unit/routers/test_service_token_clients.py` — **9 passed**
- `pytest tests/unit/routers/test_oauth_provider_router.py tests/unit/routers/test_oauth_clients_register.py` — **68 passed**
- Full `pytest tests/unit -m "not slow"` — **2812 passed, 100 skipped, 0 failed**
- `ruff check` + `black --check` clean on all touched Python files (mypy unchanged; CI runs it `continue-on-error` with pre-existing findings)

## Security Considerations

- [x] No sensitive data exposed — placeholder credentials only (`jns_test_*`); real secrets are printed once at seed time for capture into Enclii/Vault
- [x] Input validation added — scope requests fail closed against the client allowlist (pre-existing, now covered by tests)
- [x] Rate limiting considered — token endpoint already rate-limited; docs instruct callers to cache tokens until near expiry

## Database Changes

- [x] No database changes (seeding uses the existing `oauth_clients` table)

## Reviewer Notes

The one behavioral change to review is the service-token TTL: machine tokens issued via `client_credentials` now live 1 hour (matching what the endpoint has always advertised) instead of 8. Existing machine clients (e.g. `madfam-ecosystem-probe`) that honor `expires_in` are unaffected; anything relying on the undocumented 8-hour lifetime would need to re-request on expiry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoTA2XopaT23M7wkt92mcX

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoTA2XopaT23M7wkt92mcX)_