### PR TITLE
docs: index the service-tokens decision record in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Complete documentation for the Janua self-hosted authentication platform.
 - **[Flutter SDK](guides/flutter-sdk-complete-guide.md)** - Flutter mobile integration
 - **[SSO Integration](guides/SSO_INTEGRATION_GUIDE.md)** - Single Sign-On setup
 - **[Machine-to-Machine Auth](guides/machine-to-machine-authentication-guide.md)** - Service-account OAuth clients for automated ecosystem runs
+- **[Service Tokens](service-tokens.md)** - Decision record and integration contract for `client_credentials` service clients (token issuance, JWKS/introspection verification)
 - **[MFA Guide](guides/mfa-2fa-implementation-guide.md)** - Multi-factor authentication
 - **[Compliance Features](guides/COMPLIANCE_FEATURES_GUIDE.md)** - GDPR, SOC2, compliance
 


### PR DESCRIPTION
## Summary
- Adds `docs/service-tokens.md` (the `client_credentials` service-token decision record + integration contract, added in #443) to the documentation index in `docs/README.md`, next to the Machine-to-Machine Auth guide that already cross-links it.

Verification notes: the M2M guide and `docs/service-tokens.md` were checked against main and are already consistent with the shipped code — token endpoint paths match `apps/api/app/routers/v1/oauth_provider.py`, the two seeded clients match `apps/api/scripts/seed_service_clients.py`, and the documented 1-hour expiry (`expires_in` == JWT `exp`) matches the honest-expiry change. No other doc claimed a conflicting expiry. This index line was the only staleness found.

Docs-only; no application code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BoTA2XopaT23M7wkt92mcX

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoTA2XopaT23M7wkt92mcX)_