### PR TITLE
fix(sso): rewire "Sign in with Janua" to the OIDC provider flow

### DIFF
--- a/SSO_CRITICAL_PATH.md
+++ b/SSO_CRITICAL_PATH.md
@@ -141,7 +141,7 @@ PKCE-required, `grant_types = authorization_code + refresh_token`, scopes
 | `dhanam-web` | Dhanam web | `https://app.dhan.am/auth/callback` |
 | `enclii-switchyard` | Enclii Switchyard | `https://app.enclii.dev/auth/callback` |
 | `enclii-dispatch` | Enclii Dispatch | `https://admin.enclii.dev/auth/callback` |
-| `yantra4d-web` | Yantra4D studio | `https://app.yantra4d.com/auth/callback` **(TODO: verify host — sources disagree: `app.yantra4d.com` vs `4d-app.madfam.io` vs `studio.yantra4d.com`)** |
+| `yantra4d-web` | Yantra4D studio | `https://app.yantra4d.com/auth/callback` (host resolved 2026-07-08: `app.yantra4d.com` is live; `4d-app.madfam.io` / `studio.yantra4d.com` do not resolve) |
 | `tezca-web` | Tezca web | `https://tezca.mx/auth/callback` |
 | `dashboard` | Janua dashboard | `https://app.janua.dev/auth/callback` |
 

--- a/SSO_CRITICAL_PATH.md
+++ b/SSO_CRITICAL_PATH.md
@@ -9,8 +9,12 @@
 
 
 **Created**: 2026-02-26
-**Status**: In progress — 4 of 8 fixes merged (Fix 8 also promoted to prod), 4 remaining
-**Branch**: `fix/sso-verification-failures` (merged to `main`)
+**Status**: In progress — 4 of 8 fixes merged (Fix 8 admin login also promoted to
+prod), 4 remaining. The "Sign in with Janua" OIDC rewire (Fix 8 follow-up) is
+implemented in PR #447 — needs the 3-step go-live sequence below (seed → env
+vars → merge).
+**Branch**: `fix/sso-verification-failures` (merged to `main`);
+`claude/janua-sso-oidc-rewire` (PR #447 — the OIDC rewire)
 
 ---
 
@@ -28,6 +32,7 @@ Browser-based verification of Janua SSO login across all MADFAM platforms reveal
 | 6 | Dashboard social buttons deployment | **TODO** (deploy only) | `janua` |
 | 7 | Tezca auth UI | **Deferred** | `tezca` |
 | 8 | Admin login — broken `enableJanuaSSO` → email/password | **Merged + Promoted** | `janua` |
+| 8b | "Sign in with Janua" OIDC rewire + env-var wiring (Fix 8 follow-up) | Implemented in **PR #447** — needs seed + env vars + merge | `janua` |
 
 ---
 
@@ -91,6 +96,84 @@ Added `STORAGE_ENABLED`, `STORAGE_BUCKET_NAME`, `STORAGE_ACCESS_KEY_ID`, `STORAG
 > **TODO — open follow-up in `@janua/ui` (NOT yet fixed):** The underlying defect lives in the shared UI package. Both `enableJanuaSSO` (`packages/ui/src/components/auth/sign-in.tsx`) and `JanuaSSOLoginButton` (`packages/ui/src/components/auth/janua-sso-button.tsx`) push `'janua'` onto the **social**-OAuth path (`initiateOAuth('janua')`) instead of Janua's **OIDC provider** authorize endpoint (`GET /api/v1/oauth/authorize?client_id=…&response_type=code`). A real "Sign in with Janua" button for other ecosystem apps must use the OIDC flow with a registered `client_id` (ties into **Fix 1** above). **Any app still rendering that button has the same broken login.** The admin fix side-steps this by using email/password rather than repairing the button.
 >
 > Also worth noting (orthogonal): `GET /api/v1/auth/oauth/providers` returns `[]` in prod because the social-provider env vars are unset.
+
+---
+
+## "Sign in with Janua" OIDC rewire (Fix 8 follow-up — PR #447)
+
+**Repo**: `madfam-org/janua` · **Branch**: `claude/janua-sso-oidc-rewire` (draft PR #447)
+
+### What #447 changes (already implemented)
+
+The old "Sign in with Janua" button routed `janua` through the **social** OAuth
+path (`initiateOAuth('janua')`), which the API rejects with `400 "Invalid
+provider: janua"`. #447 rewires the button to Janua's **OIDC provider** flow:
+
+- **SDK** (`@janua/typescript-sdk`): adds `initiateJanuaSSO` /
+  `getJanuaAuthorizeUrl` / `handleJanuaSSOCallback` driving
+  `GET /api/v1/oauth/authorize` + PKCE (S256).
+- **UI** (`@janua/ui`): `SignIn` and `JanuaSSOLoginButton` now use the OIDC flow
+  and **fail loud** — the button is not rendered and an error is logged when no
+  `client_id` is available (instead of silently hitting the invalid social path).
+- **Env-var wiring (zero per-app code)**: `januaClientId` defaults to
+  `process.env.NEXT_PUBLIC_JANUA_CLIENT_ID` and `januaRedirectUri` to
+  `process.env.NEXT_PUBLIC_JANUA_REDIRECT_URI` (falling back to
+  `${origin}/auth/callback`). Threaded through `@janua/nextjs-sdk` `SignInForm`
+  and the `madfamAuthConfig` preset (`packages/ui/src/config/madfam-preset.ts`).
+  An explicit prop still overrides the env var. **Result: any ecosystem app gets
+  a working button by setting one public env var — no code change.**
+
+> `client_id` is a **public, PKCE-protected identifier** (OIDC), safe to commit,
+> print, and put in `NEXT_PUBLIC_*`. It is **NOT a secret** — these are public
+> clients with no `client_secret` (PKCE replaces it). Never confuse this with the
+> confidential `jnc_*` clients + `client_secret`s from Fix 1.
+
+### OIDC client seed (one operator command)
+
+**File**: `apps/api/scripts/seed_oidc_clients.py` (idempotent upsert on `client_id`).
+
+Registers each consuming app as a **first-party PUBLIC OIDC client** (public /
+PKCE-required, `grant_types = authorization_code + refresh_token`, scopes
+`openid profile email`, `redirect_uris` = the app's real `/auth/callback`):
+
+| `client_id` (public) | App | Redirect URI |
+|----------------------|-----|--------------|
+| `dhanam-web` | Dhanam web | `https://app.dhan.am/auth/callback` |
+| `enclii-switchyard` | Enclii Switchyard | `https://app.enclii.dev/auth/callback` |
+| `enclii-dispatch` | Enclii Dispatch | `https://admin.enclii.dev/auth/callback` |
+| `yantra4d-web` | Yantra4D studio | `https://app.yantra4d.com/auth/callback` **(TODO: verify host — sources disagree: `app.yantra4d.com` vs `4d-app.madfam.io` vs `studio.yantra4d.com`)** |
+| `tezca-web` | Tezca web | `https://tezca.mx/auth/callback` |
+| `dashboard` | Janua dashboard | `https://app.janua.dev/auth/callback` |
+
+Each entry also registers a localhost dev callback. The script prints the
+`client_id → app → redirect_uri` map at the end (all public). It is **not** run
+automatically — a prod DB write is an operator action.
+
+### Operator go-live sequence (NO broken-button gap)
+
+Run in this exact order so the button is functional the moment #447 merges:
+
+**1. Seed the public OIDC clients against prod** (registers the `client_id`s above):
+
+```bash
+# Port-forward to production Postgres (break-glass; prefer Enclii DB access)
+kubectl port-forward svc/janua-postgres -n janua 5432:5432
+
+cd apps/api
+DATABASE_URL=postgresql://<user>:<pass>@localhost:5432/janua \
+  python scripts/seed_oidc_clients.py
+# Idempotent — safe to re-run. Prints the client_id → app → redirect_uri map.
+# No client_secret is printed: these are PUBLIC (PKCE) clients.
+```
+
+**2. Set `NEXT_PUBLIC_JANUA_CLIENT_ID` for each app (via Enclii)** to its
+`client_id` from the table above (e.g. Dhanam → `dhanam-web`). Optionally set
+`NEXT_PUBLIC_JANUA_REDIRECT_URI` if an app's callback differs from
+`${origin}/auth/callback`. These are **public** build-time env vars — no secret
+store required. This is the entire per-app change (no code).
+
+**3. Merge PR #447.** Once the SDK/UI ship with steps 1–2 already in place, the
+button works for every app on first load — no gap.
 
 ---
 

--- a/apps/api/scripts/seed_oidc_clients.py
+++ b/apps/api/scripts/seed_oidc_clients.py
@@ -1,0 +1,320 @@
+"""
+Seed FIRST-PARTY PUBLIC OIDC clients for the "Sign in with Janua" button.
+
+These are the browser-facing OIDC clients consumed by the rewired
+"Sign in with Janua" button (@janua/ui + @janua/nextjs-sdk, PR #447). Each
+ecosystem app sets a single PUBLIC env var — ``NEXT_PUBLIC_JANUA_CLIENT_ID`` —
+to the stable, human-readable ``client_id`` seeded here, and the button drives
+Janua's OIDC provider flow (``GET /api/v1/oauth/authorize`` + PKCE). No per-app
+code change is required.
+
+How these differ from ``seed_core_clients.py``:
+
+- **Stable, human-readable ``client_id``** (e.g. ``dhanam-web``), pre-assigned
+  here and referenced by each app's ``NEXT_PUBLIC_JANUA_CLIENT_ID``. The
+  ``client_id`` is a PUBLIC identifier (OIDC) — safe to commit and print. It is
+  NOT a secret.
+- **Public client (no usable secret) with PKCE required.** ``is_confidential``
+  is ``False``; the OIDC provider (``oauth_provider.py``) then *requires* a
+  ``code_challenge`` (PKCE, S256) on ``/authorize`` and skips client_secret
+  verification at the token endpoint for these clients. A throwaway secret hash
+  is stored only to satisfy the NOT NULL column — it is never emitted and never
+  used.
+- **``redirect_uris`` match the button's default callback** — ``/auth/callback``
+  on each app's real production host (the SDK default is
+  ``${origin}/auth/callback``), plus a localhost dev callback.
+- **Idempotent upsert keyed on ``client_id``** — safe to re-run.
+
+This script is operator-driven and side-effectful (writes to the OAuth client
+registry). Per AGENTS.md it requires an explicit operator request and the
+appropriate guard env. It is intentionally NOT run automatically.
+
+Usage:
+    cd apps/api
+    DATABASE_URL=postgresql://<user>:<pass>@<host>:5432/janua \
+        python scripts/seed_oidc_clients.py
+
+Go-live sequence (SSO_CRITICAL_PATH.md § "Sign in with Janua" OIDC rewire):
+    1. Run this seed against prod.
+    2. Set NEXT_PUBLIC_JANUA_CLIENT_ID for each app (via Enclii) to the
+       matching client_id printed below.
+    3. Merge PR #447.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import secrets
+import sys
+import uuid
+from datetime import datetime
+from typing import Any
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from seed_core_clients import (  # noqa: E402
+    _get_admin_user_id,
+    _hash_secret,
+    _json_dumps,
+    _resolve_database_url,
+)
+from sqlalchemy import text  # noqa: E402
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# First-party PUBLIC OIDC client definitions
+# ---------------------------------------------------------------------------
+#
+# ``client_id`` values are PUBLIC identifiers (OIDC) — each app wires the
+# matching value into ``NEXT_PUBLIC_JANUA_CLIENT_ID``. Hosts are derived from
+# known ecosystem production domains; any uncertain host carries a ``TODO``
+# marker so the operator verifies the callback before go-live.
+
+_OIDC_SCOPES = ["openid", "profile", "email"]
+_OIDC_GRANT_TYPES = ["authorization_code", "refresh_token"]
+
+OIDC_CLIENTS: list[dict[str, Any]] = [
+    {
+        "client_id": "dhanam-web",
+        "name": "dhanam-web",
+        "description": "Dhanam financial management web app — Sign in with Janua (OIDC/PKCE)",
+        "audience": "dhanam-api",
+        "redirect_uris": [
+            "https://app.dhan.am/auth/callback",
+            "http://localhost:3000/auth/callback",
+        ],
+    },
+    {
+        "client_id": "enclii-switchyard",
+        "name": "enclii-switchyard",
+        "description": "Enclii Switchyard platform UI — Sign in with Janua (OIDC/PKCE)",
+        "audience": "enclii-api",
+        "redirect_uris": [
+            "https://app.enclii.dev/auth/callback",
+            "http://localhost:3000/auth/callback",
+        ],
+    },
+    {
+        "client_id": "enclii-dispatch",
+        "name": "enclii-dispatch",
+        "description": "Enclii Dispatch admin console — Sign in with Janua (OIDC/PKCE)",
+        "audience": "enclii-api",
+        "redirect_uris": [
+            "https://admin.enclii.dev/auth/callback",
+            "http://localhost:3001/auth/callback",
+        ],
+    },
+    {
+        "client_id": "yantra4d-web",
+        "name": "yantra4d-web",
+        # TODO(operator): confirm the production host before go-live. Ecosystem
+        # sources disagree: enclii AI_CONTEXT maps the studio app to
+        # `app.yantra4d.com`, while SSO_CRITICAL_PATH Fix 5 references
+        # `4d-app.madfam.io` and seed_core_clients uses `studio.yantra4d.com`.
+        # `app.yantra4d.com` is used here as the most authoritative (enclii
+        # domain registry). Adjust if the deployed host differs.
+        "description": "Yantra4D studio web app — Sign in with Janua (OIDC/PKCE)",
+        "audience": "yantra4d-api",
+        "redirect_uris": [
+            "https://app.yantra4d.com/auth/callback",  # TODO(operator): verify host
+            "http://localhost:5173/auth/callback",
+        ],
+    },
+    {
+        "client_id": "tezca-web",
+        "name": "tezca-web",
+        "description": "Tezca Mexican-law platform web app — Sign in with Janua (OIDC/PKCE)",
+        "audience": "tezca-api",
+        "redirect_uris": [
+            "https://tezca.mx/auth/callback",
+            "http://localhost:3000/auth/callback",
+        ],
+    },
+    {
+        "client_id": "dashboard",
+        "name": "dashboard",
+        "description": "Janua user dashboard — Sign in with Janua (OIDC/PKCE)",
+        "audience": "janua.dev",
+        "redirect_uris": [
+            "https://app.janua.dev/auth/callback",
+            "http://localhost:4101/auth/callback",
+        ],
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Seeding logic
+# ---------------------------------------------------------------------------
+
+
+def _throwaway_secret_hash() -> str:
+    """Return a bcrypt hash of a random, non-recoverable value.
+
+    Public (PKCE) clients never authenticate with a client_secret, but the
+    ``client_secret_hash`` column is NOT NULL. We store a random hash that is
+    never emitted and never usable rather than a well-known placeholder.
+    """
+    return _hash_secret(secrets.token_urlsafe(32))
+
+
+async def _seed_oidc_clients(engine: AsyncEngine) -> None:
+    """Idempotently upsert the public OIDC clients, keyed on ``client_id``."""
+    admin_id = await _get_admin_user_id(engine)
+    now = datetime.utcnow()  # naive UTC — matches DB column type
+
+    created_count = 0
+    updated_count = 0
+
+    async with engine.begin() as conn:
+        for client_def in OIDC_CLIENTS:
+            client_id = client_def["client_id"]
+            name = client_def["name"]
+
+            existing = await conn.execute(
+                text("SELECT id FROM oauth_clients WHERE client_id = :cid"),
+                {"cid": client_id},
+            )
+            existing_row = existing.fetchone()
+
+            if existing_row is not None:
+                await conn.execute(
+                    text(
+                        """
+                        UPDATE oauth_clients
+                           SET name = :name,
+                               description = :description,
+                               redirect_uris = CAST(:redirect_uris AS jsonb),
+                               allowed_scopes = CAST(:allowed_scopes AS jsonb),
+                               grant_types = CAST(:grant_types AS jsonb),
+                               audience = :audience,
+                               is_active = true,
+                               is_confidential = false,
+                               updated_at = :now
+                         WHERE id = :id
+                        """
+                    ),
+                    {
+                        "id": str(existing_row[0]),
+                        "name": name,
+                        "description": client_def.get("description"),
+                        "redirect_uris": _json_dumps(client_def["redirect_uris"]),
+                        "allowed_scopes": _json_dumps(_OIDC_SCOPES),
+                        "grant_types": _json_dumps(_OIDC_GRANT_TYPES),
+                        "audience": client_def.get("audience"),
+                        "now": now,
+                    },
+                )
+                logger.info("SYNC  %-20s (public OIDC client already exists)", client_id)
+                updated_count += 1
+                continue
+
+            secret_hash = _throwaway_secret_hash()
+            await conn.execute(
+                text(
+                    """
+                    INSERT INTO oauth_clients (
+                        id,
+                        created_by,
+                        client_id,
+                        client_secret_hash,
+                        client_secret_prefix,
+                        name,
+                        description,
+                        redirect_uris,
+                        allowed_scopes,
+                        grant_types,
+                        audience,
+                        is_active,
+                        is_confidential,
+                        created_at,
+                        updated_at
+                    ) VALUES (
+                        :id,
+                        :created_by,
+                        :client_id,
+                        :client_secret_hash,
+                        :client_secret_prefix,
+                        :name,
+                        :description,
+                        CAST(:redirect_uris AS jsonb),
+                        CAST(:allowed_scopes AS jsonb),
+                        CAST(:grant_types AS jsonb),
+                        :audience,
+                        true,
+                        false,
+                        :now,
+                        :now
+                    )
+                    """
+                ),
+                {
+                    "id": str(uuid.uuid4()),
+                    "created_by": str(admin_id),
+                    "client_id": client_id,
+                    "client_secret_hash": secret_hash,
+                    # Public client — no usable secret. Marker instead of a prefix.
+                    "client_secret_prefix": "public",
+                    "name": name,
+                    "description": client_def.get("description"),
+                    "redirect_uris": _json_dumps(client_def["redirect_uris"]),
+                    "allowed_scopes": _json_dumps(_OIDC_SCOPES),
+                    "grant_types": _json_dumps(_OIDC_GRANT_TYPES),
+                    "audience": client_def.get("audience"),
+                    "now": now,
+                },
+            )
+            logger.info("NEW   %-20s (public OIDC client, PKCE required)", client_id)
+            created_count += 1
+
+    _print_mapping()
+    logger.info(
+        "Done. Created %d, synced %d existing public OIDC client(s).",
+        created_count,
+        updated_count,
+    )
+
+
+def _print_mapping() -> None:
+    """Print the client_id → app → redirect_uri map (all values are public)."""
+    print(f"\n{'=' * 72}")
+    print("  Public OIDC clients for the \"Sign in with Janua\" button")
+    print("  Set each app's NEXT_PUBLIC_JANUA_CLIENT_ID to the client_id below.")
+    print("  client_id is a PUBLIC (PKCE-protected) identifier — NOT a secret.")
+    print(f"{'=' * 72}")
+    for client_def in OIDC_CLIENTS:
+        prod_uri = next(
+            (u for u in client_def["redirect_uris"] if u.startswith("https://")),
+            client_def["redirect_uris"][0],
+        )
+        todo = "  [TODO: verify host]" if "yantra4d" in client_def["client_id"] else ""
+        print(f"  NEXT_PUBLIC_JANUA_CLIENT_ID={client_def['client_id']:<18} "
+              f"-> {prod_uri}{todo}")
+    print(f"{'=' * 72}\n")
+
+
+async def main() -> None:
+    database_url = _resolve_database_url()
+    engine = create_async_engine(database_url, echo=False)
+
+    try:
+        await _seed_oidc_clients(engine)
+    finally:
+        await engine.dispose()
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        logger.info("Interrupted.")
+        sys.exit(130)

--- a/apps/api/scripts/seed_oidc_clients.py
+++ b/apps/api/scripts/seed_oidc_clients.py
@@ -116,16 +116,14 @@ OIDC_CLIENTS: list[dict[str, Any]] = [
     {
         "client_id": "yantra4d-web",
         "name": "yantra4d-web",
-        # TODO(operator): confirm the production host before go-live. Ecosystem
-        # sources disagree: enclii AI_CONTEXT maps the studio app to
-        # `app.yantra4d.com`, while SSO_CRITICAL_PATH Fix 5 references
-        # `4d-app.madfam.io` and seed_core_clients uses `studio.yantra4d.com`.
-        # `app.yantra4d.com` is used here as the most authoritative (enclii
-        # domain registry). Adjust if the deployed host differs.
+        # Host resolved 2026-07-08: `app.yantra4d.com` responds 200 (live),
+        # while the two alternate candidates from stale docs
+        # (`4d-app.madfam.io`, `studio.yantra4d.com`) do not resolve. Matches
+        # the enclii domain registry.
         "description": "Yantra4D studio web app — Sign in with Janua (OIDC/PKCE)",
         "audience": "yantra4d-api",
         "redirect_uris": [
-            "https://app.yantra4d.com/auth/callback",  # TODO(operator): verify host
+            "https://app.yantra4d.com/auth/callback",
             "http://localhost:5173/auth/callback",
         ],
     },
@@ -296,9 +294,8 @@ def _print_mapping() -> None:
             (u for u in client_def["redirect_uris"] if u.startswith("https://")),
             client_def["redirect_uris"][0],
         )
-        todo = "  [TODO: verify host]" if "yantra4d" in client_def["client_id"] else ""
         print(f"  NEXT_PUBLIC_JANUA_CLIENT_ID={client_def['client_id']:<18} "
-              f"-> {prod_uri}{todo}")
+              f"-> {prod_uri}")
     print(f"{'=' * 72}\n")
 
 

--- a/packages/nextjs-sdk/src/app/components.tsx
+++ b/packages/nextjs-sdk/src/app/components.tsx
@@ -28,6 +28,10 @@ export interface SignInFormProps {
   enableSSO?: boolean;
   enableMagicLink?: boolean;
   enableJanuaSSO?: boolean;
+  /** Registered Janua OIDC client_id — required when enableJanuaSSO is true. */
+  januaClientId?: string;
+  /** Redirect URI for the Janua OIDC flow. */
+  januaRedirectUri?: string;
   onMFARequired?: (session: any) => void;
   headerText?: string;
   headerDescription?: string;
@@ -49,6 +53,8 @@ export function SignInForm({
   enableSSO,
   enableMagicLink,
   enableJanuaSSO,
+  januaClientId,
+  januaRedirectUri,
   onMFARequired,
   headerText,
   headerDescription,
@@ -73,6 +79,8 @@ export function SignInForm({
       enableSSO={enableSSO}
       enableMagicLink={enableMagicLink}
       enableJanuaSSO={enableJanuaSSO}
+      januaClientId={januaClientId}
+      januaRedirectUri={januaRedirectUri}
       onMFARequired={onMFARequired}
       headerText={headerText}
       headerDescription={headerDescription}

--- a/packages/nextjs-sdk/src/app/components.tsx
+++ b/packages/nextjs-sdk/src/app/components.tsx
@@ -28,9 +28,16 @@ export interface SignInFormProps {
   enableSSO?: boolean;
   enableMagicLink?: boolean;
   enableJanuaSSO?: boolean;
-  /** Registered Janua OIDC client_id — required when enableJanuaSSO is true. */
+  /**
+   * Registered Janua OIDC client_id — required when enableJanuaSSO is true.
+   * Defaults to `process.env.NEXT_PUBLIC_JANUA_CLIENT_ID` (zero per-app code:
+   * an app just sets that public env var). Explicit prop overrides the env var.
+   */
   januaClientId?: string;
-  /** Redirect URI for the Janua OIDC flow. */
+  /**
+   * Redirect URI for the Janua OIDC flow. Defaults to
+   * `process.env.NEXT_PUBLIC_JANUA_REDIRECT_URI`, then to `${origin}/auth/callback`.
+   */
   januaRedirectUri?: string;
   onMFARequired?: (session: any) => void;
   headerText?: string;
@@ -53,8 +60,11 @@ export function SignInForm({
   enableSSO,
   enableMagicLink,
   enableJanuaSSO,
-  januaClientId,
-  januaRedirectUri,
+  // Env defaults (zero per-app code): an app that sets NEXT_PUBLIC_JANUA_CLIENT_ID
+  // gets a working "Sign in with Janua" button without passing any prop. An
+  // explicit prop overrides the env var; fail-loud applies when both are absent.
+  januaClientId = process.env.NEXT_PUBLIC_JANUA_CLIENT_ID,
+  januaRedirectUri = process.env.NEXT_PUBLIC_JANUA_REDIRECT_URI,
   onMFARequired,
   headerText,
   headerDescription,

--- a/packages/typescript-sdk/src/__tests__/auth/auth-janua-sso.test.ts
+++ b/packages/typescript-sdk/src/__tests__/auth/auth-janua-sso.test.ts
@@ -1,0 +1,246 @@
+/**
+ * Tests for the "Sign in with Janua" OIDC PROVIDER flow.
+ *
+ * These cover the dedicated OIDC methods (getJanuaAuthorizeUrl /
+ * initiateJanuaSSO / handleJanuaSSOCallback) that target Janua's own
+ * authorization server (`/api/v1/oauth/authorize` + `/api/v1/oauth/token`),
+ * NOT the social OAuth proxy path.
+ */
+
+import { webcrypto } from 'crypto';
+import { TextEncoder as NodeTextEncoder } from 'util';
+import { Auth } from '../../auth';
+import { HttpClient } from '../../http-client';
+import { TokenManager } from '../../utils';
+import { clearPKCEParams, retrievePKCEParams, PKCE_STORAGE_KEYS } from '../../utils';
+
+// jsdom does not ship WebCrypto SubtleCrypto; use Node's implementation so
+// generateCodeVerifier / generateCodeChallenge (S256) work in tests.
+beforeAll(() => {
+  if (!globalThis.crypto || !globalThis.crypto.subtle) {
+    Object.defineProperty(globalThis, 'crypto', {
+      value: webcrypto,
+      configurable: true,
+    });
+  }
+  if (typeof (globalThis as any).TextEncoder === 'undefined') {
+    (globalThis as any).TextEncoder = NodeTextEncoder;
+  }
+});
+
+const BASE_URL = 'https://auth.madfam.io';
+
+describe('Auth - Sign in with Janua (OIDC provider flow)', () => {
+  let auth: Auth;
+  let mockHttpClient: jest.Mocked<HttpClient>;
+  let mockTokenManager: jest.Mocked<TokenManager>;
+  let mockOnSignIn: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearPKCEParams();
+
+    mockHttpClient = {
+      get: jest.fn(),
+      post: jest.fn(),
+      put: jest.fn(),
+      delete: jest.fn(),
+      patch: jest.fn(),
+    } as any;
+
+    mockTokenManager = {
+      setTokens: jest.fn(),
+      clearTokens: jest.fn(),
+      getAccessToken: jest.fn(),
+      getRefreshToken: jest.fn(),
+      hasValidTokens: jest.fn(),
+    } as any;
+
+    mockOnSignIn = jest.fn();
+
+    auth = new Auth(mockHttpClient, mockTokenManager, mockOnSignIn, jest.fn(), BASE_URL);
+  });
+
+  describe('getJanuaAuthorizeUrl', () => {
+    it('builds the OIDC provider authorize URL with PKCE and persists verifier + state', async () => {
+      const result = await auth.getJanuaAuthorizeUrl({
+        clientId: 'dhanam-web',
+        redirectUri: 'https://app.dhan.am/auth/callback',
+      });
+
+      const url = new URL(result.url);
+
+      // Correct endpoint — the OIDC PROVIDER path, NOT the social proxy path.
+      expect(url.origin + url.pathname).toBe(`${BASE_URL}/api/v1/oauth/authorize`);
+      expect(url.pathname).not.toContain('/auth/oauth/authorize/janua');
+
+      expect(url.searchParams.get('response_type')).toBe('code');
+      expect(url.searchParams.get('client_id')).toBe('dhanam-web');
+      expect(url.searchParams.get('redirect_uri')).toBe('https://app.dhan.am/auth/callback');
+      expect(url.searchParams.get('scope')).toBe('openid profile email');
+      expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+
+      const challenge = url.searchParams.get('code_challenge');
+      expect(challenge).toBeTruthy();
+      // base64url — no +, /, or = padding
+      expect(challenge).not.toMatch(/[+/=]/);
+
+      const state = url.searchParams.get('state');
+      expect(state).toBe(result.state);
+
+      // Verifier + state persisted for the callback.
+      const persisted = retrievePKCEParams();
+      expect(persisted?.verifier).toBe(result.codeVerifier);
+      expect(persisted?.state).toBe(result.state);
+      expect(sessionStorage.getItem(PKCE_STORAGE_KEYS.codeVerifier)).toBe(result.codeVerifier);
+    });
+
+    it('honors custom scopes, nonce, prompt, and explicit state', async () => {
+      const result = await auth.getJanuaAuthorizeUrl({
+        clientId: 'enclii-dispatch',
+        redirectUri: 'https://admin.enclii.dev/callback',
+        scopes: ['openid', 'email'],
+        nonce: 'n-123',
+        prompt: 'none',
+        state: 'fixed-state',
+      });
+
+      const url = new URL(result.url);
+      expect(url.searchParams.get('scope')).toBe('openid email');
+      expect(url.searchParams.get('nonce')).toBe('n-123');
+      expect(url.searchParams.get('prompt')).toBe('none');
+      expect(url.searchParams.get('state')).toBe('fixed-state');
+      expect(result.state).toBe('fixed-state');
+    });
+
+    it('throws when clientId is missing', async () => {
+      await expect(
+        auth.getJanuaAuthorizeUrl({ clientId: '', redirectUri: 'https://x/cb' })
+      ).rejects.toThrow(/clientId/i);
+    });
+
+    it('throws when redirectUri is missing', async () => {
+      await expect(
+        auth.getJanuaAuthorizeUrl({ clientId: 'x', redirectUri: '' })
+      ).rejects.toThrow(/redirectUri/i);
+    });
+
+    it('throws when no base URL is configured or provided', async () => {
+      const noBaseAuth = new Auth(mockHttpClient, mockTokenManager, mockOnSignIn, jest.fn());
+      await expect(
+        noBaseAuth.getJanuaAuthorizeUrl({ clientId: 'x', redirectUri: 'https://x/cb' })
+      ).rejects.toThrow(/base URL/i);
+    });
+  });
+
+  describe('handleJanuaSSOCallback', () => {
+    beforeEach(() => {
+      (global.fetch as jest.Mock).mockReset();
+    });
+
+    it('exchanges the code at the OIDC token endpoint (form-encoded) and stores tokens', async () => {
+      // Seed a matching state + verifier as if initiation happened.
+      const { state, codeVerifier } = await auth.getJanuaAuthorizeUrl({
+        clientId: 'dhanam-web',
+        redirectUri: 'https://app.dhan.am/auth/callback',
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          access_token: 'oidc_access',
+          refresh_token: 'oidc_refresh',
+          token_type: 'Bearer',
+          expires_in: 3600,
+          id_token: 'oidc_id',
+          scope: 'openid profile email',
+        }),
+      });
+
+      const tokens = await auth.handleJanuaSSOCallback('auth-code-123', state, {
+        clientId: 'dhanam-web',
+        redirectUri: 'https://app.dhan.am/auth/callback',
+      });
+
+      // Correct endpoint + form-encoded body with PKCE verifier.
+      const [calledUrl, init] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(calledUrl).toBe(`${BASE_URL}/api/v1/oauth/token`);
+      expect(init.method).toBe('POST');
+      expect(init.headers['Content-Type']).toBe('application/x-www-form-urlencoded');
+
+      const sent = new URLSearchParams(init.body as string);
+      expect(sent.get('grant_type')).toBe('authorization_code');
+      expect(sent.get('code')).toBe('auth-code-123');
+      expect(sent.get('client_id')).toBe('dhanam-web');
+      expect(sent.get('redirect_uri')).toBe('https://app.dhan.am/auth/callback');
+      expect(sent.get('code_verifier')).toBe(codeVerifier);
+
+      expect(tokens.access_token).toBe('oidc_access');
+      expect(tokens.id_token).toBe('oidc_id');
+
+      expect(mockTokenManager.setTokens).toHaveBeenCalledWith(
+        expect.objectContaining({
+          access_token: 'oidc_access',
+          refresh_token: 'oidc_refresh',
+        })
+      );
+      expect(mockOnSignIn).toHaveBeenCalled();
+
+      // PKCE material cleared after a successful exchange.
+      expect(retrievePKCEParams()).toBeNull();
+    });
+
+    it('rejects a mismatched state (CSRF) without calling the token endpoint', async () => {
+      await auth.getJanuaAuthorizeUrl({
+        clientId: 'dhanam-web',
+        redirectUri: 'https://app.dhan.am/auth/callback',
+      });
+
+      await expect(
+        auth.handleJanuaSSOCallback('code', 'not-the-stored-state', {
+          clientId: 'dhanam-web',
+          redirectUri: 'https://app.dhan.am/auth/callback',
+        })
+      ).rejects.toThrow(/state/i);
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(mockTokenManager.setTokens).not.toHaveBeenCalled();
+    });
+
+    it('surfaces token-endpoint errors and clears PKCE material', async () => {
+      const { state } = await auth.getJanuaAuthorizeUrl({
+        clientId: 'dhanam-web',
+        redirectUri: 'https://app.dhan.am/auth/callback',
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        status: 400,
+        json: async () => ({ detail: 'invalid_grant: PKCE verification failed' }),
+      });
+
+      await expect(
+        auth.handleJanuaSSOCallback('bad-code', state, {
+          clientId: 'dhanam-web',
+          redirectUri: 'https://app.dhan.am/auth/callback',
+        })
+      ).rejects.toThrow(/PKCE verification failed/);
+
+      expect(mockTokenManager.setTokens).not.toHaveBeenCalled();
+      expect(retrievePKCEParams()).toBeNull();
+    });
+
+    it('throws when no PKCE verifier is available', async () => {
+      // Provide a matching state so state-validation passes, but no verifier.
+      sessionStorage.setItem(PKCE_STORAGE_KEYS.state, 'the-state');
+
+      await expect(
+        auth.handleJanuaSSOCallback('code', 'the-state', {
+          clientId: 'dhanam-web',
+          redirectUri: 'https://app.dhan.am/auth/callback',
+        })
+      ).rejects.toThrow(/code_verifier/i);
+    });
+  });
+});

--- a/packages/typescript-sdk/src/auth.ts
+++ b/packages/typescript-sdk/src/auth.ts
@@ -36,6 +36,7 @@ import {
   clearPKCEParams,
   validateState,
   buildJanuaAuthorizeUrl,
+  stripTrailingSlashes,
 } from './utils';
 
 /**
@@ -732,7 +733,7 @@ export class Auth {
       throw new AuthenticationError('Missing PKCE code_verifier for token exchange');
     }
 
-    const baseURL = (options.baseUrl || this.baseUrl).replace(/\/+$/, '');
+    const baseURL = stripTrailingSlashes(options.baseUrl || this.baseUrl);
     if (!baseURL) {
       throw new ValidationError(
         'A Janua base URL is required (configure the SDK client baseURL or pass baseUrl)'

--- a/packages/typescript-sdk/src/auth.ts
+++ b/packages/typescript-sdk/src/auth.ts
@@ -25,7 +25,65 @@ import type {
   PublicKeyCredentialJSON
 } from './types';
 import { AuthenticationError, ValidationError } from './errors';
-import { ValidationUtils, TokenManager } from './utils';
+import {
+  ValidationUtils,
+  TokenManager,
+  generateCodeVerifier,
+  generateCodeChallenge,
+  generateState,
+  storePKCEParams,
+  retrievePKCEParams,
+  clearPKCEParams,
+  validateState,
+  buildJanuaAuthorizeUrl,
+} from './utils';
+
+/**
+ * Options for initiating the "Sign in with Janua" OIDC flow.
+ */
+export interface JanuaSSOOptions {
+  /** Registered OAuth `client_id` for this consuming app (required). */
+  clientId: string;
+  /** Redirect URI registered for `clientId`; where Janua returns `code`+`state`. */
+  redirectUri: string;
+  /** OIDC scopes. Defaults to `['openid', 'profile', 'email']`. */
+  scopes?: string[];
+  /** CSRF state. Auto-generated (and persisted) when omitted. */
+  state?: string;
+  /** OIDC nonce for replay protection of the id_token. */
+  nonce?: string;
+  /** OIDC `prompt` (e.g. `'none'` for silent auth on first-party clients). */
+  prompt?: string;
+  /**
+   * Override the Janua issuer base URL. Defaults to the client's configured
+   * `baseURL`. Only needed when the SDK client points somewhere else.
+   */
+  baseUrl?: string;
+}
+
+/**
+ * Result of building the Janua OIDC authorize URL.
+ */
+export interface JanuaAuthorizeUrlResult {
+  /** Fully-built `GET /api/v1/oauth/authorize` URL to redirect the browser to. */
+  url: string;
+  /** The `state` value persisted for callback validation. */
+  state: string;
+  /** The PKCE `code_verifier` persisted for the token exchange. */
+  codeVerifier: string;
+}
+
+/**
+ * Token response from the Janua OIDC token endpoint.
+ */
+export interface JanuaSSOTokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+  refresh_token?: string;
+  id_token?: string;
+  scope?: string;
+}
 
 /**
  * Authentication operations
@@ -35,7 +93,12 @@ export class Auth {
     private http: HttpClient,
     private tokenManager: TokenManager,
     private onSignIn?: (data?: { user: User }) => void,
-    private onSignOut?: () => void
+    private onSignOut?: () => void,
+    /**
+     * Janua issuer base URL. Required for the OIDC "Sign in with Janua" flow
+     * ({@link initiateJanuaSSO}), which builds absolute redirect/token URLs.
+     */
+    private baseUrl: string = ''
   ) {}
 
   /**
@@ -554,6 +617,172 @@ export class Auth {
       skipAuth: true
     });
     return response.data;
+  }
+
+  // ---------------------------------------------------------------------------
+  // "Sign in with Janua" — OIDC PROVIDER flow
+  //
+  // These target Janua's own OIDC authorization server
+  // (`/api/v1/oauth/authorize` + `/api/v1/oauth/token`), used when an app in the
+  // MADFAM ecosystem treats Janua as its identity provider. This is DISTINCT
+  // from the social `initiateOAuth(...)` methods above, which federate external
+  // IdPs (Google/GitHub/…). `janua` is NOT a valid social `OAuthProvider`, so it
+  // must never be routed through those methods.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Build the Janua OIDC authorization URL with PKCE, persisting the
+   * `code_verifier` + `state` in sessionStorage for the callback exchange.
+   *
+   * Use this when you want to control the redirect yourself (e.g. render a link
+   * or open a popup). Most callers want {@link initiateJanuaSSO}.
+   */
+  async getJanuaAuthorizeUrl(options: JanuaSSOOptions): Promise<JanuaAuthorizeUrlResult> {
+    if (!options?.clientId) {
+      throw new ValidationError('januaClientId (clientId) is required for Sign in with Janua');
+    }
+    if (!options.redirectUri) {
+      throw new ValidationError('redirectUri is required for Sign in with Janua');
+    }
+
+    const baseURL = options.baseUrl || this.baseUrl;
+    if (!baseURL) {
+      throw new ValidationError(
+        'A Janua base URL is required (configure the SDK client baseURL or pass baseUrl)'
+      );
+    }
+
+    const codeVerifier = generateCodeVerifier();
+    const codeChallenge = await generateCodeChallenge(codeVerifier);
+    const state = options.state || generateState();
+
+    // Persist verifier + state so the callback (possibly on another page load)
+    // can validate state and complete the PKCE exchange.
+    storePKCEParams(codeVerifier, state);
+
+    const scopes = (options.scopes && options.scopes.length > 0)
+      ? options.scopes.join(' ')
+      : 'openid profile email';
+
+    const url = buildJanuaAuthorizeUrl({
+      baseURL,
+      clientId: options.clientId,
+      redirectUri: options.redirectUri,
+      codeChallenge,
+      state,
+      scopes,
+      nonce: options.nonce,
+      prompt: options.prompt,
+    });
+
+    return { url, state, codeVerifier };
+  }
+
+  /**
+   * Begin the "Sign in with Janua" OIDC flow by redirecting the browser to
+   * Janua's authorization endpoint. Requires a browser environment.
+   */
+  async initiateJanuaSSO(options: JanuaSSOOptions): Promise<void> {
+    const { url } = await this.getJanuaAuthorizeUrl(options);
+
+    if (typeof window === 'undefined' || !window.location) {
+      throw new AuthenticationError(
+        'initiateJanuaSSO requires a browser environment; use getJanuaAuthorizeUrl on the server'
+      );
+    }
+    window.location.href = url;
+  }
+
+  /**
+   * Complete the "Sign in with Janua" OIDC flow: validate `state`, exchange the
+   * authorization `code` (with the stored PKCE `code_verifier`) at
+   * `POST /api/v1/oauth/token`, and store the resulting tokens.
+   *
+   * The token endpoint is a standard OAuth 2.0 endpoint that consumes
+   * `application/x-www-form-urlencoded`, so this uses a direct form POST rather
+   * than the JSON HTTP client. Intended for public clients (no client secret) —
+   * confidential clients must exchange the code server-side.
+   */
+  async handleJanuaSSOCallback(
+    code: string,
+    state: string,
+    options: {
+      clientId: string;
+      redirectUri: string;
+      /** Explicit PKCE verifier; falls back to the persisted one when omitted. */
+      codeVerifier?: string;
+      /** Override the Janua base URL (defaults to the client's configured baseURL). */
+      baseUrl?: string;
+    }
+  ): Promise<JanuaSSOTokenResponse> {
+    if (!code) {
+      throw new ValidationError('Authorization code is required');
+    }
+    if (!options?.clientId || !options.redirectUri) {
+      throw new ValidationError('clientId and redirectUri are required to complete Sign in with Janua');
+    }
+
+    // CSRF: the returned state must match what we stored at initiation.
+    if (!validateState(state)) {
+      throw new AuthenticationError('Invalid OAuth state — possible CSRF, aborting token exchange');
+    }
+
+    const codeVerifier = options.codeVerifier || retrievePKCEParams()?.verifier;
+    if (!codeVerifier) {
+      throw new AuthenticationError('Missing PKCE code_verifier for token exchange');
+    }
+
+    const baseURL = (options.baseUrl || this.baseUrl).replace(/\/+$/, '');
+    if (!baseURL) {
+      throw new ValidationError(
+        'A Janua base URL is required (configure the SDK client baseURL or pass baseUrl)'
+      );
+    }
+
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: options.redirectUri,
+      client_id: options.clientId,
+      code_verifier: codeVerifier,
+    });
+
+    const response = await fetch(`${baseURL}/api/v1/oauth/token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: body.toString(),
+    });
+
+    if (!response.ok) {
+      let detail = `Token exchange failed (${response.status})`;
+      try {
+        const errData = await response.json();
+        detail = errData?.detail || errData?.error_description || errData?.error || detail;
+      } catch {
+        // non-JSON error body; keep the status-based message
+      }
+      clearPKCEParams();
+      throw new AuthenticationError(detail);
+    }
+
+    const tokens = (await response.json()) as JanuaSSOTokenResponse;
+
+    // One-time material — clear it as soon as the exchange succeeds.
+    clearPKCEParams();
+
+    if (tokens.access_token && tokens.refresh_token) {
+      await this.tokenManager.setTokens({
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+        expires_at: Date.now() + (tokens.expires_in * 1000),
+      });
+    }
+
+    if (this.onSignIn) {
+      this.onSignIn();
+    }
+
+    return tokens;
   }
 
   /**

--- a/packages/typescript-sdk/src/client.ts
+++ b/packages/typescript-sdk/src/client.ts
@@ -89,7 +89,8 @@ export class JanuaClient extends EventEmitter<SdkEventMap> {
       this._httpClient,
       this.tokenManager,
       () => this.emit('auth:signedIn', { user: {} as any }),
-      () => this.emit('auth:signedOut', {})
+      () => this.emit('auth:signedOut', {}),
+      this.config.baseURL
     );
     this.users = new Users(this._httpClient);
     this.sessions = new Sessions(this._httpClient);

--- a/packages/typescript-sdk/src/index.ts
+++ b/packages/typescript-sdk/src/index.ts
@@ -214,6 +214,7 @@ export {
   validateState,
   parseOAuthCallback,
   buildAuthorizationUrl,
+  buildJanuaAuthorizeUrl,
   PKCE_STORAGE_KEYS,
 } from './utils';
 

--- a/packages/typescript-sdk/src/utils.ts
+++ b/packages/typescript-sdk/src/utils.ts
@@ -47,6 +47,7 @@ export {
   parseOAuthCallback,
   buildAuthorizationUrl,
   buildJanuaAuthorizeUrl,
+  stripTrailingSlashes,
   PKCE_STORAGE_KEYS,
 } from './utils/index';
 

--- a/packages/typescript-sdk/src/utils.ts
+++ b/packages/typescript-sdk/src/utils.ts
@@ -46,6 +46,7 @@ export {
   validateState,
   parseOAuthCallback,
   buildAuthorizationUrl,
+  buildJanuaAuthorizeUrl,
   PKCE_STORAGE_KEYS,
 } from './utils/index';
 

--- a/packages/typescript-sdk/src/utils/index.ts
+++ b/packages/typescript-sdk/src/utils/index.ts
@@ -50,6 +50,7 @@ export {
   parseOAuthCallback,
   buildAuthorizationUrl,
   buildJanuaAuthorizeUrl,
+  stripTrailingSlashes,
   PKCE_STORAGE_KEYS,
 } from './pkce-utils';
 

--- a/packages/typescript-sdk/src/utils/index.ts
+++ b/packages/typescript-sdk/src/utils/index.ts
@@ -49,6 +49,7 @@ export {
   validateState,
   parseOAuthCallback,
   buildAuthorizationUrl,
+  buildJanuaAuthorizeUrl,
   PKCE_STORAGE_KEYS,
 } from './pkce-utils';
 

--- a/packages/typescript-sdk/src/utils/pkce-utils.ts
+++ b/packages/typescript-sdk/src/utils/pkce-utils.ts
@@ -129,4 +129,57 @@ export function buildAuthorizationUrl(
   return url.toString();
 }
 
+/**
+ * Build the Janua **OIDC provider** authorization URL (`GET /api/v1/oauth/authorize`).
+ *
+ * This is the "Sign in with Janua" entrypoint for MADFAM ecosystem apps that
+ * treat Janua as their identity provider. It is DISTINCT from
+ * {@link buildAuthorizationUrl}, which targets the social-login proxy path
+ * (`/api/v1/auth/oauth/authorize/{provider}`) used to federate Google/GitHub/etc.
+ *
+ * The endpoint (`oauth_provider.py::authorize_get`) requires:
+ * `response_type=code`, `client_id`, `redirect_uri`, and — for public clients —
+ * PKCE (`code_challenge` + `code_challenge_method=S256`). `scope` defaults to
+ * `openid` server-side; `state` and `nonce` are optional but recommended.
+ */
+export function buildJanuaAuthorizeUrl(params: {
+  baseURL: string;
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  state: string;
+  scopes?: string;
+  nonce?: string;
+  prompt?: string;
+}): string {
+  const {
+    baseURL,
+    clientId,
+    redirectUri,
+    codeChallenge,
+    state,
+    scopes = 'openid profile email',
+    nonce,
+    prompt,
+  } = params;
+
+  // Trim a trailing slash so `${baseURL}/api/...` never double-slashes.
+  const normalizedBase = baseURL.replace(/\/+$/, '');
+  const url = new URL(`${normalizedBase}/api/v1/oauth/authorize`);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('client_id', clientId);
+  url.searchParams.set('redirect_uri', redirectUri);
+  url.searchParams.set('scope', scopes);
+  url.searchParams.set('code_challenge', codeChallenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  url.searchParams.set('state', state);
+  if (nonce) {
+    url.searchParams.set('nonce', nonce);
+  }
+  if (prompt) {
+    url.searchParams.set('prompt', prompt);
+  }
+  return url.toString();
+}
+
 export { PKCE_STORAGE_KEYS };

--- a/packages/typescript-sdk/src/utils/pkce-utils.ts
+++ b/packages/typescript-sdk/src/utils/pkce-utils.ts
@@ -108,6 +108,20 @@ export function parseOAuthCallback(url?: string): {
   };
 }
 
+/**
+ * Strip trailing slashes without a backtracking regex.
+ * `String.replace(/\/+$/, '')` is a polynomial-regex ReDoS risk on
+ * library-supplied input (CodeQL js/polynomial-redos); a linear scan is both
+ * safe and clearer. Shared so the token-exchange path uses the same routine.
+ */
+export function stripTrailingSlashes(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 47 /* '/' */) {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}
+
 /** Build OAuth authorization URL with PKCE parameters */
 export function buildAuthorizationUrl(
   baseURL: string,
@@ -164,7 +178,7 @@ export function buildJanuaAuthorizeUrl(params: {
   } = params;
 
   // Trim a trailing slash so `${baseURL}/api/...` never double-slashes.
-  const normalizedBase = baseURL.replace(/\/+$/, '');
+  const normalizedBase = stripTrailingSlashes(baseURL);
   const url = new URL(`${normalizedBase}/api/v1/oauth/authorize`);
   url.searchParams.set('response_type', 'code');
   url.searchParams.set('client_id', clientId);

--- a/packages/ui/src/components/auth/janua-sso-button.test.tsx
+++ b/packages/ui/src/components/auth/janua-sso-button.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen } from '@/test/test-utils'
 import userEvent from '@testing-library/user-event'
 import { JanuaSSOLoginButton } from './janua-sso-button'
@@ -86,6 +86,70 @@ describe('JanuaSSOLoginButton', () => {
     expect(initiateJanuaSSO).toHaveBeenCalledWith({
       clientId: 'app-client-id',
       redirectUri: 'https://app.example.com/callback',
+    })
+  })
+
+  // Zero per-app code: NEXT_PUBLIC_JANUA_CLIENT_ID alone renders a working button.
+  describe('env-var defaults', () => {
+    const ENV_CLIENT = 'NEXT_PUBLIC_JANUA_CLIENT_ID'
+    const ENV_REDIRECT = 'NEXT_PUBLIC_JANUA_REDIRECT_URI'
+    let savedClient: string | undefined
+    let savedRedirect: string | undefined
+
+    beforeEach(() => {
+      savedClient = process.env[ENV_CLIENT]
+      savedRedirect = process.env[ENV_REDIRECT]
+      delete process.env[ENV_CLIENT]
+      delete process.env[ENV_REDIRECT]
+    })
+
+    afterEach(() => {
+      if (savedClient === undefined) delete process.env[ENV_CLIENT]
+      else process.env[ENV_CLIENT] = savedClient
+      if (savedRedirect === undefined) delete process.env[ENV_REDIRECT]
+      else process.env[ENV_REDIRECT] = savedRedirect
+    })
+
+    it('renders and initiates using NEXT_PUBLIC_JANUA_CLIENT_ID / _REDIRECT_URI when props are absent', async () => {
+      const user = userEvent.setup()
+      const { initiateJanuaSSO, client } = makeClient()
+      process.env[ENV_CLIENT] = 'env-client-id'
+      process.env[ENV_REDIRECT] = 'https://env.example.com/auth/callback'
+
+      render(<JanuaSSOLoginButton januaClient={client} />)
+
+      await user.click(screen.getByRole('button', { name: /sign in with janua/i }))
+
+      expect(initiateJanuaSSO).toHaveBeenCalledWith({
+        clientId: 'env-client-id',
+        redirectUri: 'https://env.example.com/auth/callback',
+      })
+    })
+
+    it('lets an explicit januaClientId prop override the env var', async () => {
+      const user = userEvent.setup()
+      const { initiateJanuaSSO, client } = makeClient()
+      process.env[ENV_CLIENT] = 'env-client-id'
+
+      render(<JanuaSSOLoginButton januaClientId="prop-client-id" januaClient={client} />)
+
+      await user.click(screen.getByRole('button', { name: /sign in with janua/i }))
+
+      expect(initiateJanuaSSO).toHaveBeenCalledWith({
+        clientId: 'prop-client-id',
+        redirectUri: 'http://localhost:3000/auth/callback',
+      })
+    })
+
+    it('fails loud (renders nothing + logs) when both the prop and the env var are absent', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const { client } = makeClient()
+
+      const { container } = render(<JanuaSSOLoginButton januaClient={client} />)
+
+      expect(container.firstChild).toBeNull()
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('requires a januaClientId'))
+      errorSpy.mockRestore()
     })
   })
 })

--- a/packages/ui/src/components/auth/janua-sso-button.test.tsx
+++ b/packages/ui/src/components/auth/janua-sso-button.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@/test/test-utils'
+import userEvent from '@testing-library/user-event'
+import { JanuaSSOLoginButton } from './janua-sso-button'
+
+/**
+ * Regression coverage for the SSO-backbone OIDC rewire.
+ * The button must use Janua's OIDC provider flow (initiateJanuaSSO) and must
+ * fail loud — never silently fall back to the invalid social path.
+ */
+describe('JanuaSSOLoginButton', () => {
+  const makeClient = () => {
+    const initiateJanuaSSO = vi.fn().mockResolvedValue(undefined)
+    return { initiateJanuaSSO, client: { auth: { initiateJanuaSSO } } }
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    delete (window as any).location
+    window.location = { href: '', origin: 'http://localhost:3000' } as any
+  })
+
+  it('renders the button when januaClientId and a capable client are provided', () => {
+    const { client } = makeClient()
+    render(<JanuaSSOLoginButton januaClientId="app-client-id" januaClient={client} />)
+
+    expect(screen.getByRole('button', { name: /sign in with janua/i })).toBeInTheDocument()
+  })
+
+  it('fails loud (renders nothing + logs) when januaClientId is missing', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { client } = makeClient()
+
+    const { container } = render(<JanuaSSOLoginButton januaClient={client} />)
+
+    expect(container.firstChild).toBeNull()
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('requires a januaClientId')
+    )
+    errorSpy.mockRestore()
+  })
+
+  it('fails loud when the client cannot perform the OIDC flow', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    // Legacy/social-only client without initiateJanuaSSO.
+    const { container } = render(
+      <JanuaSSOLoginButton januaClientId="app-client-id" januaClient={{ auth: { initiateOAuth: vi.fn() } }} />
+    )
+
+    expect(container.firstChild).toBeNull()
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('initiateJanuaSSO')
+    )
+    errorSpy.mockRestore()
+  })
+
+  it('initiates the OIDC flow with clientId and default redirectUri on click', async () => {
+    const user = userEvent.setup()
+    const { initiateJanuaSSO, client } = makeClient()
+
+    render(<JanuaSSOLoginButton januaClientId="app-client-id" januaClient={client} />)
+
+    await user.click(screen.getByRole('button', { name: /sign in with janua/i }))
+
+    expect(initiateJanuaSSO).toHaveBeenCalledWith({
+      clientId: 'app-client-id',
+      redirectUri: 'http://localhost:3000/auth/callback',
+    })
+  })
+
+  it('uses an explicit redirectUri when provided', async () => {
+    const user = userEvent.setup()
+    const { initiateJanuaSSO, client } = makeClient()
+
+    render(
+      <JanuaSSOLoginButton
+        januaClientId="app-client-id"
+        redirectUri="https://app.example.com/callback"
+        januaClient={client}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: /sign in with janua/i }))
+
+    expect(initiateJanuaSSO).toHaveBeenCalledWith({
+      clientId: 'app-client-id',
+      redirectUri: 'https://app.example.com/callback',
+    })
+  })
+})

--- a/packages/ui/src/components/auth/janua-sso-button.tsx
+++ b/packages/ui/src/components/auth/janua-sso-button.tsx
@@ -7,9 +7,17 @@ export interface JanuaSSOButtonProps {
    * The button uses Janua's OIDC provider flow (`/api/v1/oauth/authorize`);
    * without a client id there is no valid entrypoint, so the button renders
    * nothing and logs an error (fail-loud).
+   *
+   * Defaults to `process.env.NEXT_PUBLIC_JANUA_CLIENT_ID` when the prop is not
+   * passed (zero per-app code — an app just sets that public env var). An
+   * explicit prop overrides the env var. `client_id` is a public,
+   * PKCE-protected identifier, not a secret.
    */
   januaClientId?: string
-  /** OIDC redirect URI — defaults to `${origin}/auth/callback` */
+  /**
+   * OIDC redirect URI — defaults to `process.env.NEXT_PUBLIC_JANUA_REDIRECT_URI`,
+   * then to `${origin}/auth/callback`.
+   */
   redirectUri?: string
   /** Janua SDK client instance (must expose `auth.initiateJanuaSSO`) */
   januaClient?: any
@@ -30,8 +38,10 @@ export interface JanuaSSOButtonProps {
  * back to the invalid social path.
  */
 export function JanuaSSOLoginButton({
-  januaClientId,
-  redirectUri,
+  // Env defaults (zero per-app code): setting NEXT_PUBLIC_JANUA_CLIENT_ID is
+  // enough to render a working button. Explicit props override the env vars.
+  januaClientId = process.env.NEXT_PUBLIC_JANUA_CLIENT_ID,
+  redirectUri = process.env.NEXT_PUBLIC_JANUA_REDIRECT_URI,
   januaClient,
   disabled,
   className,

--- a/packages/ui/src/components/auth/janua-sso-button.tsx
+++ b/packages/ui/src/components/auth/janua-sso-button.tsx
@@ -2,43 +2,72 @@ import * as React from 'react'
 import { JanuaSSOButton as JanuaSSOButtonBase } from './social-buttons'
 
 export interface JanuaSSOButtonProps {
-  /** OAuth redirect URL — defaults to current origin */
-  redirectUrl?: string
-  /** Janua SDK client instance */
+  /**
+   * Registered Janua OAuth `client_id` for this app (REQUIRED).
+   * The button uses Janua's OIDC provider flow (`/api/v1/oauth/authorize`);
+   * without a client id there is no valid entrypoint, so the button renders
+   * nothing and logs an error (fail-loud).
+   */
+  januaClientId?: string
+  /** OIDC redirect URI — defaults to `${origin}/auth/callback` */
+  redirectUri?: string
+  /** Janua SDK client instance (must expose `auth.initiateJanuaSSO`) */
   januaClient?: any
-  /** API URL fallback */
-  apiUrl?: string
   disabled?: boolean
   className?: string
 }
 
 /**
  * "Sign in with Janua" button for MADFAM ecosystem apps.
- * Initiates OAuth flow against Janua as IdP.
+ *
+ * Initiates the OIDC authorization-code + PKCE flow against Janua as the
+ * identity provider (`GET /api/v1/oauth/authorize`). This is DISTINCT from the
+ * social OAuth path: `janua` is not a valid social provider, so the old
+ * `initiateOAuth('janua')` call returned `400 "Invalid provider: janua"`.
+ *
+ * Fail-loud: if `januaClientId` is missing, or the SDK client can't perform the
+ * OIDC flow, the button is not rendered and an error is logged. It never falls
+ * back to the invalid social path.
  */
 export function JanuaSSOLoginButton({
-  redirectUrl,
+  januaClientId,
+  redirectUri,
   januaClient,
-  apiUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000',
   disabled,
   className,
 }: JanuaSSOButtonProps) {
   const [isLoading, setIsLoading] = React.useState(false)
 
+  if (!januaClientId) {
+    // eslint-disable-next-line no-console
+    console.error(
+      '[janua/ui] JanuaSSOLoginButton requires a januaClientId (registered OIDC ' +
+        'client_id). Button not rendered.'
+    )
+    return null
+  }
+
+  if (!januaClient || !januaClient.auth || typeof januaClient.auth.initiateJanuaSSO !== 'function') {
+    // eslint-disable-next-line no-console
+    console.error(
+      '[janua/ui] JanuaSSOLoginButton requires a januaClient whose auth module ' +
+        'implements initiateJanuaSSO (@janua/typescript-sdk >= OIDC rewire). ' +
+        'Button not rendered.'
+    )
+    return null
+  }
+
   const handleClick = async () => {
     setIsLoading(true)
     try {
-      if (januaClient) {
-        const response = await januaClient.auth.initiateOAuth('janua', {
-          redirectUrl: redirectUrl || window.location.origin,
-        })
-        window.location.href = response.url
-      } else {
-        const target = redirectUrl || window.location.origin
-        const oauthUrl = `${apiUrl}/api/v1/auth/oauth/janua?redirect_url=${encodeURIComponent(target)}`
-        window.location.href = oauthUrl
-      }
-    } catch {
+      await januaClient.auth.initiateJanuaSSO({
+        clientId: januaClientId,
+        redirectUri: redirectUri || `${window.location.origin}/auth/callback`,
+      })
+      // On success the browser navigates away; nothing else to do.
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('[janua/ui] Sign in with Janua failed to initiate:', err)
       setIsLoading(false)
     }
   }

--- a/packages/ui/src/components/auth/sign-in.test.tsx
+++ b/packages/ui/src/components/auth/sign-in.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor } from '@/test/test-utils'
 import userEvent from '@testing-library/user-event'
 import { SignIn } from './sign-in'
@@ -442,6 +442,94 @@ describe('SignIn', () => {
         redirectUri: 'http://localhost:3000/auth/callback',
       })
       expect(initiateOAuth).not.toHaveBeenCalled()
+    })
+  })
+
+  // Zero per-app code: an app that sets NEXT_PUBLIC_JANUA_CLIENT_ID gets a
+  // working "Sign in with Janua" button with no prop. Explicit prop overrides
+  // the env var; fail-loud still applies when both are absent.
+  describe('Janua SSO env-var defaults', () => {
+    const ENV_CLIENT = 'NEXT_PUBLIC_JANUA_CLIENT_ID'
+    const ENV_REDIRECT = 'NEXT_PUBLIC_JANUA_REDIRECT_URI'
+    let savedClient: string | undefined
+    let savedRedirect: string | undefined
+
+    beforeEach(() => {
+      savedClient = process.env[ENV_CLIENT]
+      savedRedirect = process.env[ENV_REDIRECT]
+      delete process.env[ENV_CLIENT]
+      delete process.env[ENV_REDIRECT]
+    })
+
+    afterEach(() => {
+      if (savedClient === undefined) delete process.env[ENV_CLIENT]
+      else process.env[ENV_CLIENT] = savedClient
+      if (savedRedirect === undefined) delete process.env[ENV_REDIRECT]
+      else process.env[ENV_REDIRECT] = savedRedirect
+    })
+
+    it('renders the Janua button from NEXT_PUBLIC_JANUA_CLIENT_ID when the prop is absent', () => {
+      process.env[ENV_CLIENT] = 'env-client-id'
+
+      render(<SignIn enableJanuaSSO={true} socialProviders={{}} />)
+
+      expect(screen.getByRole('button', { name: /enterprise sso/i })).toBeInTheDocument()
+    })
+
+    it('lets an explicit januaClientId prop override the env var', async () => {
+      const user = userEvent.setup()
+      const initiateJanuaSSO = vi.fn().mockResolvedValue(undefined)
+      const januaClient = { auth: { initiateJanuaSSO, initiateOAuth: vi.fn() } }
+      process.env[ENV_CLIENT] = 'env-client-id'
+
+      delete (window as any).location
+      window.location = { href: '', origin: 'http://localhost:3000' } as any
+
+      render(
+        <SignIn
+          enableJanuaSSO={true}
+          januaClientId="prop-client-id"
+          januaClient={januaClient}
+          socialProviders={{}}
+        />
+      )
+
+      await user.click(screen.getByRole('button', { name: /enterprise sso/i }))
+
+      expect(initiateJanuaSSO).toHaveBeenCalledWith(
+        expect.objectContaining({ clientId: 'prop-client-id' })
+      )
+    })
+
+    it('uses NEXT_PUBLIC_JANUA_REDIRECT_URI as the default redirect URI', async () => {
+      const user = userEvent.setup()
+      const initiateJanuaSSO = vi.fn().mockResolvedValue(undefined)
+      const januaClient = { auth: { initiateJanuaSSO, initiateOAuth: vi.fn() } }
+      process.env[ENV_CLIENT] = 'env-client-id'
+      process.env[ENV_REDIRECT] = 'https://env.example.com/auth/callback'
+
+      delete (window as any).location
+      window.location = { href: '', origin: 'http://localhost:3000' } as any
+
+      render(<SignIn enableJanuaSSO={true} januaClient={januaClient} socialProviders={{}} />)
+
+      await user.click(screen.getByRole('button', { name: /enterprise sso/i }))
+
+      expect(initiateJanuaSSO).toHaveBeenCalledWith({
+        clientId: 'env-client-id',
+        redirectUri: 'https://env.example.com/auth/callback',
+      })
+    })
+
+    it('fails loud (no button + error) when both the prop and the env var are absent', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      render(<SignIn enableJanuaSSO={true} socialProviders={{}} />)
+
+      expect(screen.queryByRole('button', { name: /enterprise sso/i })).not.toBeInTheDocument()
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('januaClientId is missing'))
+
+      errorSpy.mockRestore()
     })
   })
 

--- a/packages/ui/src/components/auth/sign-in.test.tsx
+++ b/packages/ui/src/components/auth/sign-in.test.tsx
@@ -395,10 +395,53 @@ describe('SignIn', () => {
       expect(screen.getByText(/email me a sign-in link/i)).toBeInTheDocument()
     })
 
-    it('should render Enterprise SSO button when enableJanuaSSO is true', () => {
-      render(<SignIn enableJanuaSSO={true} />)
+    it('should render Enterprise SSO button when enableJanuaSSO is true and januaClientId is provided', () => {
+      render(<SignIn enableJanuaSSO={true} januaClientId="app-client-id" />)
 
       expect(screen.getByRole('button', { name: /enterprise sso/i })).toBeInTheDocument()
+    })
+
+    // FAIL-LOUD: enableJanuaSSO without a client id must NOT render the button
+    // (it would otherwise hit the invalid social path). It logs an error instead.
+    it('should NOT render Enterprise SSO button when januaClientId is missing, and logs an error', () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      render(<SignIn enableJanuaSSO={true} />)
+
+      expect(screen.queryByRole('button', { name: /enterprise sso/i })).not.toBeInTheDocument()
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('januaClientId is missing')
+      )
+
+      errorSpy.mockRestore()
+    })
+
+    it('should route the Enterprise SSO button through initiateJanuaSSO (OIDC), not initiateOAuth', async () => {
+      const user = userEvent.setup()
+      const initiateJanuaSSO = vi.fn().mockResolvedValue(undefined)
+      const initiateOAuth = vi.fn()
+      const januaClient = { auth: { initiateJanuaSSO, initiateOAuth } }
+
+      delete (window as any).location
+      window.location = { href: '', origin: 'http://localhost:3000' } as any
+
+      render(
+        <SignIn
+          enableJanuaSSO={true}
+          januaClientId="app-client-id"
+          januaRedirectUri="http://localhost:3000/auth/callback"
+          januaClient={januaClient}
+          socialProviders={{}}
+        />
+      )
+
+      await user.click(screen.getByRole('button', { name: /enterprise sso/i }))
+
+      expect(initiateJanuaSSO).toHaveBeenCalledWith({
+        clientId: 'app-client-id',
+        redirectUri: 'http://localhost:3000/auth/callback',
+      })
+      expect(initiateOAuth).not.toHaveBeenCalled()
     })
   })
 
@@ -440,7 +483,7 @@ describe('SignIn', () => {
     })
 
     it('should hide email/password form when showEmailPassword is false', () => {
-      render(<SignIn showEmailPassword={false} enableJanuaSSO={true} />)
+      render(<SignIn showEmailPassword={false} enableJanuaSSO={true} januaClientId="app-client-id" />)
 
       expect(screen.queryByRole('textbox', { name: /email/i })).not.toBeInTheDocument()
       expect(screen.queryByLabelText('Password')).not.toBeInTheDocument()
@@ -449,7 +492,7 @@ describe('SignIn', () => {
     })
 
     it('should still render legal links when email/password is hidden', () => {
-      render(<SignIn showEmailPassword={false} enableJanuaSSO={true} />)
+      render(<SignIn showEmailPassword={false} enableJanuaSSO={true} januaClientId="app-client-id" />)
 
       expect(screen.getByRole('link', { name: /terms of service/i })).toBeInTheDocument()
       expect(screen.getByRole('link', { name: /privacy policy/i })).toBeInTheDocument()
@@ -461,13 +504,16 @@ describe('SignIn', () => {
       expect(screen.queryByText(/or continue with email/i)).not.toBeInTheDocument()
     })
 
-    // Regression: admin.janua.dev fidelity audit AJ-5 (2026-05-02). Mirrors the
-    // exact prop set used by apps/admin/app/login/page.tsx so a future regression
-    // in <SignIn> would fail this test before reaching production.
-    it('should hide email/password with the admin.janua.dev prop combo', () => {
+    // Regression: guards the SSO-only rendering path (showEmailPassword=false +
+    // enableJanuaSSO). NOTE: admin.janua.dev itself migrated to email/password
+    // (SSO_CRITICAL_PATH Fix 8, PR #445) and no longer uses enableJanuaSSO; this
+    // test now covers other ecosystem apps that render the Janua button. A
+    // registered januaClientId is required for the button to render (fail-loud).
+    it('should hide email/password with an SSO-only prop combo', () => {
       render(
         <SignIn
           enableJanuaSSO={true}
+          januaClientId="app-client-id"
           showEmailPassword={false}
           showRememberMe={false}
           socialProviders={{}}

--- a/packages/ui/src/components/auth/sign-in.tsx
+++ b/packages/ui/src/components/auth/sign-in.tsx
@@ -64,9 +64,17 @@ export interface SignInProps {
    * is not rendered and an error is logged (fail-loud), because there is no
    * safe fallback: routing `janua` through the social OAuth path returns
    * `400 Invalid provider: janua`.
+   *
+   * Defaults to `process.env.NEXT_PUBLIC_JANUA_CLIENT_ID` when the prop is not
+   * passed, so any MADFAM app gets a working button with ZERO code change —
+   * it just sets that public env var. An explicit prop overrides the env var.
+   * `client_id` is a public (PKCE-protected) identifier, not a secret.
    */
   januaClientId?: string
-  /** Redirect URI for the Janua OIDC flow. Defaults to `${origin}/auth/callback`. */
+  /**
+   * Redirect URI for the Janua OIDC flow. Defaults to
+   * `process.env.NEXT_PUBLIC_JANUA_REDIRECT_URI`, then to `${origin}/auth/callback`.
+   */
   januaRedirectUri?: string
   /** Callback when API returns MFA challenge */
   onMFARequired?: (session: any) => void
@@ -107,8 +115,12 @@ export function SignIn({
   onSSODetected,
   enableMagicLink = false,
   enableJanuaSSO = false,
-  januaClientId,
-  januaRedirectUri,
+  // Env defaults (zero per-app code): an app that sets NEXT_PUBLIC_JANUA_CLIENT_ID
+  // gets a working "Sign in with Janua" button without passing any prop. An
+  // explicit prop still overrides the env var; fail-loud still applies when both
+  // the prop and the env var are absent.
+  januaClientId = process.env.NEXT_PUBLIC_JANUA_CLIENT_ID,
+  januaRedirectUri = process.env.NEXT_PUBLIC_JANUA_REDIRECT_URI,
   onMFARequired,
   headerText = 'Sign in to your account',
   headerDescription = 'Welcome back! Please enter your details',

--- a/packages/ui/src/components/auth/sign-in.tsx
+++ b/packages/ui/src/components/auth/sign-in.tsx
@@ -57,6 +57,17 @@ export interface SignInProps {
   enableMagicLink?: boolean
   /** Show "Sign in with Janua" button for MADFAM apps */
   enableJanuaSSO?: boolean
+  /**
+   * Registered Janua OAuth `client_id` for this app. REQUIRED when
+   * `enableJanuaSSO` is true — the button uses Janua's OIDC provider flow
+   * (`/api/v1/oauth/authorize`), not the social path. Without it the button
+   * is not rendered and an error is logged (fail-loud), because there is no
+   * safe fallback: routing `janua` through the social OAuth path returns
+   * `400 Invalid provider: janua`.
+   */
+  januaClientId?: string
+  /** Redirect URI for the Janua OIDC flow. Defaults to `${origin}/auth/callback`. */
+  januaRedirectUri?: string
   /** Callback when API returns MFA challenge */
   onMFARequired?: (session: any) => void
   /** Custom header text */
@@ -96,6 +107,8 @@ export function SignIn({
   onSSODetected,
   enableMagicLink = false,
   enableJanuaSSO = false,
+  januaClientId,
+  januaRedirectUri,
   onMFARequired,
   headerText = 'Sign in to your account',
   headerDescription = 'Welcome back! Please enter your details',
@@ -181,6 +194,23 @@ export function SignIn({
   const handleSocialLogin = async (provider: string) => {
     setIsLoading(true)
     try {
+      // "Sign in with Janua" uses Janua's OIDC PROVIDER flow, NOT the social
+      // OAuth path. `janua` is not a valid social provider, so it must be
+      // routed through initiateJanuaSSO with a registered client_id.
+      if (provider === 'janua') {
+        if (!januaClient) {
+          throw new Error('Sign in with Janua requires a januaClient with the OIDC SDK')
+        }
+        await januaClient.auth.initiateJanuaSSO({
+          clientId: januaClientId,
+          redirectUri:
+            januaRedirectUri ||
+            redirectUrl ||
+            `${window.location.origin}/auth/callback`,
+        })
+        return
+      }
+
       if (januaClient) {
         const response = await januaClient.auth.initiateOAuth(provider, {
           redirectUrl: redirectUrl || window.location.origin,
@@ -214,7 +244,22 @@ export function SignIn({
   if (socialProviders.github) socialProviderList.push('github')
   if (socialProviders.microsoft) socialProviderList.push('microsoft')
   if (socialProviders.apple) socialProviderList.push('apple')
-  if (enableJanuaSSO) socialProviderList.push('janua')
+  // FAIL-LOUD: "Sign in with Janua" requires a registered OIDC client_id.
+  // Never silently render a button that would hit the invalid social path
+  // (`initiateOAuth('janua')` → 400 "Invalid provider: janua"). If the app
+  // asked for the button but gave no client id, log an error and skip it.
+  if (enableJanuaSSO) {
+    if (januaClientId) {
+      socialProviderList.push('janua')
+    } else {
+      // eslint-disable-next-line no-console
+      console.error(
+        '[janua/ui] enableJanuaSSO is set but januaClientId is missing. ' +
+          'The "Sign in with Janua" button was not rendered. Pass a registered ' +
+          'januaClientId (OIDC client_id) to enable it.'
+      )
+    }
+  }
 
   const hasSocialProviders = socialProviderList.length > 0
   // Default is `true` when the prop is omitted (see destructuring above).

--- a/packages/ui/src/config/madfam-preset.ts
+++ b/packages/ui/src/config/madfam-preset.ts
@@ -29,10 +29,16 @@ export const madfamAuthConfig: Partial<JanuaAuthConfig> = {
       methods: ['totp', 'sms'],
     },
     enableJanuaSSO: true,
-    // NOTE: `januaClientId` is intentionally NOT set here — it is per-app and
-    // must be supplied by each consuming app (its registered OIDC client_id,
-    // see SSO_CRITICAL_PATH Fix 1). Without it, the "Sign in with Janua" button
+    // `januaClientId` defaults to the per-app PUBLIC env var, so any MADFAM app
+    // gets a working "Sign in with Janua" button with ZERO code change — it just
+    // sets NEXT_PUBLIC_JANUA_CLIENT_ID (its registered OIDC client_id; a public,
+    // PKCE-protected identifier — NOT a secret; see SSO_CRITICAL_PATH Fix 1 / the
+    // OIDC-client seed). An explicit `januaClientId` still overrides this. When
+    // both the prop and the env var are absent, the "Sign in with Janua" button
     // fails loud (not rendered) rather than hitting the invalid social path.
+    januaClientId: process.env.NEXT_PUBLIC_JANUA_CLIENT_ID,
+    // Defaults to NEXT_PUBLIC_JANUA_REDIRECT_URI, then to `${origin}/auth/callback`.
+    januaRedirectUri: process.env.NEXT_PUBLIC_JANUA_REDIRECT_URI,
   },
   flows: {
     signIn: {

--- a/packages/ui/src/config/madfam-preset.ts
+++ b/packages/ui/src/config/madfam-preset.ts
@@ -29,6 +29,10 @@ export const madfamAuthConfig: Partial<JanuaAuthConfig> = {
       methods: ['totp', 'sms'],
     },
     enableJanuaSSO: true,
+    // NOTE: `januaClientId` is intentionally NOT set here — it is per-app and
+    // must be supplied by each consuming app (its registered OIDC client_id,
+    // see SSO_CRITICAL_PATH Fix 1). Without it, the "Sign in with Janua" button
+    // fails loud (not rendered) rather than hitting the invalid social path.
   },
   flows: {
     signIn: {

--- a/packages/ui/src/config/types.ts
+++ b/packages/ui/src/config/types.ts
@@ -45,6 +45,14 @@ export interface JanuaAuthConfig {
     }
     /** Enable "Sign in with Janua" for MADFAM ecosystem */
     enableJanuaSSO?: boolean
+    /**
+     * Registered Janua OIDC `client_id` for this app. REQUIRED when
+     * `enableJanuaSSO` is true — the button uses Janua's OIDC provider flow.
+     * Per-app value (ties into SSO_CRITICAL_PATH Fix 1 client registration).
+     */
+    januaClientId?: string
+    /** Redirect URI for the Janua OIDC flow (defaults to `${origin}/auth/callback`). */
+    januaRedirectUri?: string
   }
   flows: {
     signIn: {


### PR DESCRIPTION
## Description

Rewires the "Sign in with Janua" SSO entrypoint to use Janua's **OIDC provider** authorization flow instead of the invalid **social** OAuth path.

**The bug (re-verified before editing):** both `enableJanuaSSO` (`packages/ui/src/components/auth/sign-in.tsx`) and `JanuaSSOLoginButton` (`packages/ui/src/components/auth/janua-sso-button.tsx`) pushed provider `'janua'` onto the social provider list and called `januaClient.auth.initiateOAuth('janua')`. The SDK's `initiateOAuth` POSTs to `/api/v1/auth/oauth/authorize/{provider}` (the social path). `janua` is **not** a valid social `OAuthProvider` (`google/github/microsoft/apple/discord/twitter/linkedin/slack`), so the API returned `400 "Invalid provider: janua"`. Every app rendering the button had broken "Sign in with Janua". This is the shared-package defect flagged in `SSO_CRITICAL_PATH.md` Fix 8's follow-up warning.

The correct entrypoint is Janua's OIDC provider authorize endpoint `GET /api/v1/oauth/authorize` (`apps/api/app/routers/v1/oauth_provider.py::authorize_get`), with token exchange at `POST /api/v1/oauth/token`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] SDK update (changes to any SDK package)
- [x] Security fix

## Related Issues

Addresses the `@janua/ui` follow-up called out in `SSO_CRITICAL_PATH.md` (Fix 8 warning). Per-app `client_id` registration ties into Fix 1.

## Changes Made

- **@janua/typescript-sdk**
  - New `buildJanuaAuthorizeUrl()` (pkce-utils) targeting `/api/v1/oauth/authorize` — kept distinct from the existing social `buildAuthorizationUrl()` (`/api/v1/auth/oauth/authorize/{provider}`).
  - New `Auth.getJanuaAuthorizeUrl(opts)` — generates PKCE `code_verifier`, derives S256 `code_challenge`, persists verifier + `state` (sessionStorage), returns `{ url, state, codeVerifier }`.
  - New `Auth.initiateJanuaSSO(opts)` — builds the URL and redirects the browser.
  - New `Auth.handleJanuaSSOCallback(code, state, opts)` — validates `state` (CSRF), exchanges the code with the stored verifier at `POST /api/v1/oauth/token` as `application/x-www-form-urlencoded` (public client, no secret), stores tokens. The existing social `handleOAuthCallback` (JSON `/api/v1/auth/oauth/callback`) is untouched.
  - Threaded `baseURL` into `Auth`.
- **@janua/ui**
  - `enableJanuaSSO` + `JanuaSSOLoginButton` now use the OIDC method and require a `januaClientId` (+ optional redirect URI). **Fail-loud**: if `enableJanuaSSO`/the button is used without a client id (or with an SDK that can't do OIDC), nothing renders and `console.error` fires — never a silent fallback to the invalid social path.
  - Social provider buttons (google/github/microsoft/apple) behave exactly as before.
- **@janua/nextjs-sdk** + **@janua/ui config types/preset**: thread `januaClientId`/`januaRedirectUri` through so consumers can supply their per-app client id.
- **apps/admin login is intentionally NOT changed** (email/password per PR #445).

### Exact OIDC params the endpoint accepts (from `oauth_provider.py`)

`authorize_get` (`GET /api/v1/oauth/authorize`): `response_type` (must be `code`), `client_id` (required), `redirect_uri` (required, validated against registered URIs), `scope` (default `openid`), `state` (optional), `nonce` (optional), `code_challenge` / `code_challenge_method` (**S256 only**; PKCE **required for public/non-confidential clients**), `prompt` (only `none` honored, restricted to first-party clients). Token endpoint `POST /api/v1/oauth/token` (form): `grant_type=authorization_code`, `code`, `redirect_uri`, `client_id`, `client_secret` (confidential only), `code_verifier`.

## Testing

### Test Checklist

- [x] TypeScript type checking passes (changed files clean; see note below)
- [ ] Linting passes (`pnpm lint`) — see note
- [x] Unit tests pass (`pnpm test`)
- [x] SDK tests pass (if SDK changes)
- [x] Manual testing completed (unit-level; no staging OIDC client available)

- `pnpm --filter @janua/typescript-sdk test` → all auth suites pass (**157/157**), incl. new `auth-janua-sso.test.ts` (9 tests: URL/PKCE construction, form token exchange, CSRF/state rejection, error paths, missing-verifier).
- `pnpm --filter @janua/ui test` → **496 passed / 20 skipped**, incl. new `janua-sso-button.test.tsx` (5) and updated `sign-in.test.tsx` (40, incl. fail-loud + OIDC-routing assertions).
- `tsc --noEmit` clean for all changed files. Pre-existing UI typecheck errors in `payments/`, `scim/`, and `*.stories.tsx` reproduce identically on clean `main` (unbuilt `@janua/typescript-sdk` / missing `@storybook/react`) and are unrelated.
- `pnpm --filter @janua/typescript-sdk lint` currently fails to start due to a pre-existing monorepo ESLint conflict ("couldn't determine the plugin @typescript-eslint uniquely" — duplicate installs across ESLint 8/9), not from this change.

### SDK Impact

- [x] TypeScript SDK affected
- [x] Next.js SDK affected
- [ ] React SDK affected
- [ ] Vue SDK affected
- [ ] Python SDK affected
- [ ] Go SDK affected

## Security Considerations

- [x] Security review requested (touches SSO backbone)
- [x] No sensitive data exposed (secret names only; no values)
- [x] Input validation added (required `clientId`/`redirectUri`; `state` CSRF check; PKCE S256)
- [ ] Rate limiting considered (unchanged; enforced server-side)

Browser flow uses a **public client + PKCE** (no client secret in the browser). Confidential clients must exchange the code server-side.

## Database Changes

- [x] No database changes

## Reviewer Notes

**Apps that render the button and thus benefit from this fix** (grep of `enableJanuaSSO`/`JanuaSSOLoginButton` usage): the shared `@janua/ui` `SignIn` + `JanuaSSOLoginButton`, surfaced via the `@janua/nextjs-sdk` `SignInForm` wrapper and the `madfamAuthConfig` preset (`enableJanuaSSO: true`) consumed by MADFAM ecosystem apps (Dhanam, Enclii Switchyard/Dispatch, Yantra4D, Tezca). `apps/admin` does **not** render it (email/password, PR #445) and is unchanged.

**Open owner decision:** each consuming app must now pass its own registered `januaClientId`. The preset deliberately does not hardcode one (per-app value). This depends on the OAuth client registration in `SSO_CRITICAL_PATH.md` **Fix 1** (seed script + prod seed run). Until an app supplies a valid `client_id`, its button now **fails loud** (renders nothing + logs) rather than silently 400-ing — an intentional, safer default. Owner to confirm the per-app `client_id` distribution mechanism (env var name, e.g. `NEXT_PUBLIC_JANUA_CLIENT_ID`, vs. config fetch).

Drafted for SSO-backbone review — **do not merge** until reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEe6hJdoiS92fdcyxbSn2s

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEe6hJdoiS92fdcyxbSn2s)_