### PR TITLE
feat(signup): wire self-serve /auth/signup and fix dead pricing CTAs

### DIFF
--- a/apps/api/app/routers/v1/auth.py
+++ b/apps/api/app/routers/v1/auth.py
@@ -1089,6 +1089,19 @@ async def login_form(
     return response
 
 
+# Alias for /signup (the TypeScript SDK and @janua/ui components post to /register)
+@router.post("/register", response_model=SignInResponse)
+@limiter.limit("3/minute")  # Same strict rate limiting as /signup
+async def register(
+    request: Request,
+    signup_data: SignUpRequest,
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+):
+    """Create a new user account (alias for /signup)"""
+    return await sign_up(request, signup_data, background_tasks, db)
+
+
 # Alias for /signin (tests expect /login)
 @router.post("/login", response_model=SignInResponse)
 @limiter.limit("5/minute")

--- a/apps/api/tests/unit/routers/test_auth_router.py
+++ b/apps/api/tests/unit/routers/test_auth_router.py
@@ -450,6 +450,7 @@ class TestRouterConfiguration:
         # Check for core auth routes (routes include /auth prefix)
         required_routes = [
             "/auth/signup",
+            "/auth/register",
             "/auth/signin",
             "/auth/login",
             "/auth/logout",

--- a/apps/dashboard/app/auth/signup/page.tsx
+++ b/apps/dashboard/app/auth/signup/page.tsx
@@ -1,0 +1,323 @@
+'use client'
+
+import { Suspense, useCallback, useEffect, useRef, useState, type FormEvent } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import {
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+  SignUp,
+} from '@janua/ui'
+import { Building2, Loader2, Shield, Sparkles } from 'lucide-react'
+import { januaClient } from '@/lib/janua-client'
+import { useAuth } from '@/lib/auth'
+
+// Storage keys - must match auth.tsx
+const STORAGE_KEYS = {
+  ACCESS_TOKEN: 'janua_access_token',
+  USER: 'janua_user',
+  COOKIE: 'janua_access_token',
+} as const
+
+// Carries the plan selected on the pricing page through the signup flow.
+// sessionStorage (not only the query param) because the OAuth round-trip
+// strips query params when it returns to this page.
+const PLAN_STORAGE_KEY = 'janua_signup_plan'
+
+const PAID_PLANS = ['pro', 'scale'] as const
+type PaidPlan = (typeof PAID_PLANS)[number]
+
+const PLAN_LABELS: Record<PaidPlan, string> = {
+  pro: 'Pro',
+  scale: 'Scale',
+}
+
+function parsePlan(value: string | null): PaidPlan | null {
+  return value && (PAID_PLANS as readonly string[]).includes(value) ? (value as PaidPlan) : null
+}
+
+/** Derives a URL-safe slug from an organization name (mirrors the API's slug rules). */
+function slugifyOrgName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 100)
+}
+
+type SignupPhase = 'account' | 'organization' | 'plan'
+
+function SignupFlow() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const { isAuthenticated, isLoading } = useAuth()
+
+  const [phase, setPhase] = useState<SignupPhase>('account')
+  const [plan, setPlan] = useState<PaidPlan | null>(null)
+  const [checkingAccount, setCheckingAccount] = useState(false)
+
+  const [orgName, setOrgName] = useState('')
+  const [orgError, setOrgError] = useState<string | null>(null)
+  const [orgSubmitting, setOrgSubmitting] = useState(false)
+
+  const orgSlug = slugifyOrgName(orgName)
+
+  // Resolve plan intent from the query param first, then sessionStorage.
+  useEffect(() => {
+    const fromQuery = parsePlan(searchParams.get('plan'))
+    if (fromQuery) {
+      sessionStorage.setItem(PLAN_STORAGE_KEY, fromQuery)
+      setPlan(fromQuery)
+    } else {
+      setPlan(parsePlan(sessionStorage.getItem(PLAN_STORAGE_KEY)))
+    }
+  }, [searchParams])
+
+  const finishSignup = useCallback(
+    (selectedPlan: PaidPlan | null) => {
+      if (selectedPlan) {
+        setPhase('plan')
+      } else {
+        sessionStorage.removeItem(PLAN_STORAGE_KEY)
+        router.replace('/')
+      }
+    },
+    [router]
+  )
+
+  // Once the session is live (post email signup or OAuth return), move past
+  // the account step: brand-new accounts get the organization step, accounts
+  // that already belong to an organization skip ahead.
+  const advancedRef = useRef(false)
+  useEffect(() => {
+    if (isLoading || !isAuthenticated || phase !== 'account' || advancedRef.current) return
+    advancedRef.current = true
+    setCheckingAccount(true)
+
+    let cancelled = false
+    ;(async () => {
+      let hasOrganization = false
+      try {
+        const data = await januaClient.organizations.listOrganizations()
+        const organizations = Array.isArray(data)
+          ? data
+          : ((data as any)?.organizations ?? (data as any)?.items ?? [])
+        hasOrganization = organizations.length > 0
+      } catch {
+        // Lookup failure: fall through to the (skippable) organization step.
+      }
+      if (cancelled) return
+      setCheckingAccount(false)
+      if (hasOrganization) {
+        finishSignup(plan)
+      } else {
+        setPhase('organization')
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [isAuthenticated, isLoading, phase, plan, finishSignup])
+
+  // Mirrors handleAfterSignIn on /login: sync the token cookie for the
+  // middleware and persist the user for the dashboard shell. The SignUp
+  // component then navigates to `redirectUrl` (this page) and the
+  // authenticated re-entry above advances the flow.
+  const handleAfterSignUp = (user: unknown) => {
+    const token = localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)
+    if (token) {
+      const cookieDomain = window.location.hostname.includes('janua.dev') ? '; domain=.janua.dev' : ''
+      document.cookie = `${STORAGE_KEYS.COOKIE}=${token}; path=/${cookieDomain}; secure; samesite=lax`
+    }
+    if (user) {
+      localStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(user))
+    }
+  }
+
+  const handleCreateOrganization = async (event: FormEvent) => {
+    event.preventDefault()
+    if (!orgSlug) {
+      setOrgError('Please enter an organization name.')
+      return
+    }
+    setOrgError(null)
+    setOrgSubmitting(true)
+    try {
+      await januaClient.organizations.createOrganization({ name: orgName.trim(), slug: orgSlug })
+      finishSignup(plan)
+    } catch (err) {
+      setOrgError(
+        err instanceof Error && err.message
+          ? err.message
+          : 'Could not create the organization. Try a different name.'
+      )
+      setOrgSubmitting(false)
+    }
+  }
+
+  // While the provider restores the session (e.g. right after the OAuth
+  // return) show a neutral loading card instead of flashing the form.
+  if (isLoading || checkingAccount) {
+    return <SignupFallback />
+  }
+
+  if (phase === 'organization') {
+    return (
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="mb-2 flex justify-center">
+            <Building2 className="text-primary size-10" />
+          </div>
+          <CardTitle className="text-2xl">Name your organization</CardTitle>
+          <CardDescription>
+            Organizations group your team, applications, and settings. You can rename it later.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleCreateOrganization} className="space-y-4">
+            {orgError && (
+              <div className="bg-destructive/15 text-destructive text-sm p-3 rounded-md">
+                {orgError}
+              </div>
+            )}
+            <div className="space-y-2">
+              <Label htmlFor="signup-org-name">Organization name</Label>
+              <Input
+                id="signup-org-name"
+                type="text"
+                placeholder="Acme Inc."
+                value={orgName}
+                onChange={(e) => setOrgName(e.target.value)}
+                disabled={orgSubmitting}
+              />
+              {orgSlug && (
+                <p className="text-muted-foreground text-xs">URL identifier: {orgSlug}</p>
+              )}
+            </div>
+            <Button type="submit" className="w-full" disabled={orgSubmitting || !orgSlug}>
+              {orgSubmitting ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                  Creating organization...
+                </>
+              ) : (
+                'Create organization'
+              )}
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              className="w-full"
+              disabled={orgSubmitting}
+              onClick={() => finishSignup(plan)}
+            >
+              Skip for now
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  if (phase === 'plan' && plan) {
+    return (
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="mb-2 flex justify-center">
+            <Sparkles className="text-primary size-10" />
+          </div>
+          <CardTitle className="text-2xl">You selected the {PLAN_LABELS[plan]} plan</CardTitle>
+          <CardDescription>
+            Your account starts on the free Community tier. Continue to billing to start your{' '}
+            {PLAN_LABELS[plan]} upgrade.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <Button
+            className="w-full"
+            onClick={() => {
+              sessionStorage.removeItem(PLAN_STORAGE_KEY)
+              router.push('/settings/billing')
+            }}
+          >
+            Continue to billing
+          </Button>
+          <Button
+            variant="ghost"
+            className="w-full"
+            onClick={() => {
+              sessionStorage.removeItem(PLAN_STORAGE_KEY)
+              router.push('/')
+            }}
+          >
+            Go to dashboard
+          </Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <div className="w-full max-w-md">
+      <div className="mb-6 flex justify-center">
+        <Shield className="text-primary size-12" />
+      </div>
+
+      {plan && (
+        <div className="border-primary/30 bg-primary/10 mb-4 flex items-start gap-2 rounded-md border p-3">
+          <Sparkles className="text-primary mt-0.5 size-5 shrink-0" />
+          <p className="text-sm">
+            You selected the <span className="font-semibold">{PLAN_LABELS[plan]}</span> plan.
+            Create your account first — you can start the upgrade right after.
+          </p>
+        </div>
+      )}
+
+      <SignUp
+        januaClient={januaClient}
+        afterSignUp={handleAfterSignUp}
+        redirectUrl={plan ? `/auth/signup?plan=${plan}` : '/auth/signup'}
+        signInUrl="/login"
+        requireEmailVerification={false}
+        socialProviders={{ google: true, github: true, microsoft: true, apple: true }}
+        termsUrl="https://janua.dev/legal/terms"
+        privacyUrl="https://janua.dev/legal/privacy"
+      />
+    </div>
+  )
+}
+
+function SignupFallback() {
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader className="text-center">
+        <div className="mb-4 flex justify-center">
+          <Shield className="text-primary size-12" />
+        </div>
+        <CardTitle className="text-2xl">Create your Janua account</CardTitle>
+        <CardDescription>Loading...</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex justify-center py-8">
+          <Loader2 className="text-primary size-8 animate-spin" />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default function SignupPage() {
+  return (
+    <div className="bg-background flex min-h-screen items-center justify-center p-4">
+      <Suspense fallback={<SignupFallback />}>
+        <SignupFlow />
+      </Suspense>
+    </div>
+  )
+}

--- a/apps/dashboard/app/login/page.tsx
+++ b/apps/dashboard/app/login/page.tsx
@@ -101,8 +101,8 @@ function LoginForm() {
 
       <div className="text-muted-foreground text-center text-sm mt-4">
         Don&apos;t have an account?{' '}
-        <a href="#" className="text-primary hover:underline">
-          Contact support
+        <a href="/auth/signup" className="text-primary hover:underline">
+          Sign up
         </a>
       </div>
     </div>

--- a/apps/dashboard/middleware.ts
+++ b/apps/dashboard/middleware.ts
@@ -32,6 +32,7 @@ function isValidTokenStructure(token: string | null | undefined): boolean {
 // Routes that don't require authentication
 const PUBLIC_ROUTES = [
   '/login',
+  '/auth/signup',
   '/api/',
   '/_next/',
   '/favicon.ico',

--- a/apps/website/components/sections/honest-pricing.tsx
+++ b/apps/website/components/sections/honest-pricing.tsx
@@ -354,7 +354,17 @@ export function HonestPricing() {
                 className="w-full"
                 asChild
               >
-                <Link href={tier.price === 'Custom' ? '/contact' : '/signup'}>
+                <Link
+                  href={
+                    tier.price === 'Custom'
+                      ? '/contact'
+                      : `https://app.janua.dev/auth/signup${
+                          tier.name === 'Pro' || tier.name === 'Scale'
+                            ? `?plan=${tier.name.toLowerCase()}`
+                            : ''
+                        }`
+                  }
+                >
                   {tier.price === 'Custom' ? 'Contact Sales' : 'Get Started'}
                 </Link>
               </Button>

--- a/apps/website/components/sections/pricing.tsx
+++ b/apps/website/components/sections/pricing.tsx
@@ -97,7 +97,7 @@ export function PricingSection() {
       price: { monthly: 'Custom', annual: 'Custom' },
       featured: false,
       cta: 'Contact Sales',
-      href: 'https://app.janua.dev/contact-sales',
+      href: '/contact',
       features: [
         'Unlimited MAU',
         'Everything in Scale',

--- a/packages/ui/src/components/auth/sign-up.test.tsx
+++ b/packages/ui/src/components/auth/sign-up.test.tsx
@@ -295,8 +295,8 @@ describe('SignUp', () => {
         const callArgs = (global.fetch as any).mock.calls[0]
         const body = JSON.parse(callArgs[1].body)
         expect(body).toEqual(expect.objectContaining({
-          firstName: 'John',
-          lastName: 'Doe',
+          first_name: 'John',
+          last_name: 'Doe',
           email: 'john@example.com',
           password: 'VeryStrongPassword123!',
         }))

--- a/packages/ui/src/components/auth/sign-up.tsx
+++ b/packages/ui/src/components/auth/sign-up.tsx
@@ -109,8 +109,8 @@ export function SignUp({
         const response = await januaClient.auth.signUp({
           email,
           password,
-          firstName,
-          lastName,
+          first_name: firstName,
+          last_name: lastName,
         })
 
         if (requireEmailVerification) {
@@ -129,8 +129,8 @@ export function SignUp({
           body: JSON.stringify({
             email,
             password,
-            firstName,
-            lastName,
+            first_name: firstName,
+            last_name: lastName,
           }),
         })
 


### PR DESCRIPTION
## Problem

Every pricing CTA was a dead link. `apps/website/components/sections/pricing.tsx` sent visitors to `https://app.janua.dev/auth/signup` (+ `?plan=pro|scale`) and `honest-pricing.tsx` linked a relative `/signup` — but the dashboard only had `/login`. No signup route existed anywhere, so Lane 2.1 (self-serve signup) had no path at all. Meanwhile the pieces already existed: `POST /api/v1/auth/signup` and the `@janua/ui` `SignUp` component.

## What was wired

**`apps/dashboard/app/auth/signup/page.tsx` (new)** — public route (added to middleware `PUBLIC_ROUTES`), following the `/login` page's conventions (Suspense wrapper, shared `januaClient`, manual token-cookie sync for the middleware). Three phases:

1. **Account** — `@janua/ui` `SignUp` (email/password + Google/GitHub/Microsoft/Apple, same set as `/login`). Terms/Privacy point at the website's real `/legal/terms` + `/legal/privacy` pages.
2. **Organization** — signup does **not** create an org, but `POST /api/v1/organizations` exists and is usable, so a minimal, skippable "Name your organization" step creates one (auto-slug from the name, owner becomes admin). Accounts that already have an org skip this step automatically.
3. **Plan affordance** — a `?plan=pro|scale` param is carried through the whole flow (query param + `sessionStorage`, so it survives the OAuth round-trip which strips query params). After completion the user sees "You selected the {Pro|Scale} plan — continue to billing" pointing at the existing `/settings/billing` page (where the `POST /api/v1/checkout/dhanam` upgrade path lives). No new billing UI was built.

**`apps/api/app/routers/v1/auth.py`** — added `POST /api/v1/auth/register` as a thin alias of `/signup` (same handler, same strict 3/min rate limit). *Why the API change was needed:* the TypeScript SDK's `auth.signUp()` — and therefore the `@janua/ui` SignUp component — has always posted to `/api/v1/auth/register`, which did not exist (404). This mirrors the existing `/login` → `/signin` alias precedent and makes signup work for every SDK consumer, not just the dashboard. Covered by the router test (`/auth/register` added to required routes); `test_auth_router.py` passes 87/87.

**`packages/ui/src/components/auth/sign-up.tsx`** — the component sent camelCase `firstName`/`lastName`; the API's `SignUpRequest` expects snake_case, so pydantic silently dropped the names. Now sends `first_name`/`last_name` (component test updated to assert the snake_case payload).

**Website CTAs** — `honest-pricing.tsx` "Get Started" now points at `https://app.janua.dev/auth/signup` with `?plan=pro|scale` preserved for paid tiers (`/contact` for Enterprise verified to exist and left alone). `pricing.tsx` CTAs already pointed at the now-real route and needed no change, except the Enterprise CTA which pointed at nonexistent `app.janua.dev/contact-sales` — now the website's own `/contact`. The dashboard login page's dead "Contact support" (`href="#"`) under "Don't have an account?" is now a real "Sign up" link.

## What signup now does end-to-end

The API's `/signup` creates the user as `ACTIVE`, returns tokens immediately (auto-login), and sends the verification email in the background without gating access — so the flow goes straight into the product, honestly matching the API's behavior (no fake "check your email" wall).

**Screenshots in words:**
- *Visitor clicks "Start 14-day trial" (Pro) on janua.dev/pricing* → lands on `app.janua.dev/auth/signup?plan=pro` → shield logo, a banner "You selected the **Pro** plan. Create your account first — you can start the upgrade right after." above the standard Create-your-account card (name/email/password + strength meter + ToS checkbox, social buttons on top).
- *Submits the form* → account created, session live, token cookie synced → page re-enters authenticated → brief loading card → **"Name your organization"** card (Building2 icon, name input with live "URL identifier: acme-inc" preview, Create + "Skip for now").
- *Creates or skips* → **"You selected the Pro plan"** card (Sparkles icon): "Your account starts on the free Community tier. Continue to billing to start your Pro upgrade." → [Continue to billing] → `/settings/billing`, or [Go to dashboard] → `/`.
- *No plan param* → same flow, no banners; after the org step the user is redirected straight to the dashboard.
- *OAuth signup* → returns to `/auth/signup` (plan restored from sessionStorage) and resumes at the org step. Existing signed-in users hitting the page skip ahead: with a plan → plan card; without → dashboard.

## Org-creation status

**Wired** (not a gap): optional post-signup step using the existing `POST /api/v1/organizations` — no new API surface. Skipping is allowed; note there is currently no org-create UI elsewhere in the dashboard, so skippers have no later self-serve way to create one (small follow-up candidate).

## Validation

| Workspace | Result |
|---|---|
| `apps/api` | `tests/unit/routers/test_auth_router.py` **87/87 pass** (incl. new `/auth/register` assertion). Full unit suite: remaining failures identical on `origin/main` (pre-existing local xmlsec/env issues in SSO/webhooks/oauth suites) |
| `packages/ui` | vitest **503 passed** (sign-up.test.tsx 31/31). `tsc` errors: 688 = 688 on main (pre-existing, none in touched files) |
| `apps/dashboard` | `tsc --noEmit` **clean**; production build **green**, `/auth/signup` route present. `next lint` is broken repo-wide on Next 16 (pre-existing) |
| `apps/website` | production build **green**; jest 3 failures + 40 `tsc` errors identical on main (pre-existing, none in touched files) |

## Gaps / follow-ups (out of scope, noted honestly)

- **Billing checkout under-sends:** `apps/dashboard/lib/api.ts` `createCheckout` posts only `plan_id`, but `POST /api/v1/checkout/dhanam` requires `organization_id`, `success_url`, `cancel_url` — the existing `/settings/billing` upgrade button will 422. Pre-existing; the new flow stops honestly at the billing page.
- `apps/website/app/demo/page.tsx` links `app.janua.dev/signup` (missing `/auth`) — still dead, one-line follow-up.
- No dashboard-side org-create UI for users who skip the signup org step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)