### PR TITLE
fix(dashboard): send full checkout contract — unbreak /settings/billing upgrade (422)

### DIFF
--- a/apps/dashboard/app/settings/billing/page.test.tsx
+++ b/apps/dashboard/app/settings/billing/page.test.tsx
@@ -1,0 +1,161 @@
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import BillingPage from './page'
+
+jest.mock('@/lib/api', () => ({
+  getBillingCurrent: jest.fn(),
+  getInvoices: jest.fn(),
+  getPaymentMethods: jest.fn(),
+  createCheckout: jest.fn(),
+}))
+
+jest.mock('@/lib/auth', () => ({
+  useAuth: jest.fn(() => ({ user: { is_admin: false } })),
+}))
+
+jest.mock('@/lib/janua-client', () => ({
+  januaClient: {
+    organizations: {
+      listOrganizations: jest.fn(),
+    },
+  },
+}))
+
+const { getBillingCurrent, getInvoices, getPaymentMethods, createCheckout } =
+  jest.requireMock('@/lib/api')
+const { januaClient } = jest.requireMock('@/lib/janua-client')
+
+// Replace jsdom's Location so the page can read origin/search and assign href
+// without triggering jsdom's "Not implemented: navigation".
+const locationStub = {
+  origin: 'http://localhost',
+  pathname: '/settings/billing',
+  search: '',
+  href: 'http://localhost/settings/billing',
+}
+const originalLocation = window.location
+
+beforeAll(() => {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: locationStub,
+  })
+})
+
+afterAll(() => {
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: originalLocation,
+  })
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  locationStub.search = ''
+  locationStub.href = 'http://localhost/settings/billing'
+
+  // No billing data yet — page falls back to the default community plan
+  getBillingCurrent.mockRejectedValue(new Error('no subscription'))
+  getInvoices.mockResolvedValue([])
+  getPaymentMethods.mockResolvedValue([])
+})
+
+describe('BillingPage checkout contract', () => {
+  it('sends the full contract (plan, org, success/cancel URLs) and redirects to Dhanam', async () => {
+    januaClient.organizations.listOrganizations.mockResolvedValue([
+      { id: 'org-123', name: 'Acme', is_owner: true, user_role: 'owner' },
+    ])
+    createCheckout.mockResolvedValue({
+      checkout_url: 'https://dhanam.madfam.io/checkout/session/checkout_test123',
+      session_id: 'checkout_test123',
+      customer_id: null,
+      provider: 'polar',
+      organization_id: 'org-123',
+      plan_id: 'pro',
+      product: 'dhanam',
+      janua_tier: 'pro',
+    })
+
+    render(<BillingPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /upgrade to pro/i }))
+
+    await waitFor(() => {
+      expect(createCheckout).toHaveBeenCalledWith({
+        plan_id: 'pro',
+        organization_id: 'org-123',
+        success_url: 'http://localhost/settings/billing?checkout=success',
+        cancel_url: 'http://localhost/settings/billing?checkout=cancelled',
+      })
+    })
+
+    await waitFor(() => {
+      expect(locationStub.href).toBe(
+        'https://dhanam.madfam.io/checkout/session/checkout_test123'
+      )
+    })
+  })
+
+  it('picks the first org where the user is owner or admin', async () => {
+    januaClient.organizations.listOrganizations.mockResolvedValue([
+      { id: 'org-member', name: 'Other', is_owner: false, user_role: 'member' },
+      { id: 'org-admin', name: 'Mine', is_owner: false, user_role: 'admin' },
+    ])
+    createCheckout.mockResolvedValue({
+      checkout_url: 'https://dhanam.madfam.io/checkout/session/checkout_abc',
+    })
+
+    render(<BillingPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /upgrade to scale/i }))
+
+    await waitFor(() => {
+      expect(createCheckout).toHaveBeenCalledWith(
+        expect.objectContaining({ plan_id: 'scale', organization_id: 'org-admin' })
+      )
+    })
+  })
+
+  it('shows an error and does not call checkout when the user has no billable org', async () => {
+    januaClient.organizations.listOrganizations.mockResolvedValue([
+      { id: 'org-member', name: 'Other', is_owner: false, user_role: 'member' },
+    ])
+
+    render(<BillingPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /upgrade to pro/i }))
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/no organization found where you are an owner or admin/i)
+      ).toBeInTheDocument()
+    })
+    expect(createCheckout).not.toHaveBeenCalled()
+  })
+})
+
+describe('BillingPage checkout return states', () => {
+  it('shows a success notice when returning with ?checkout=success', async () => {
+    locationStub.search = '?checkout=success'
+
+    render(<BillingPage />)
+
+    expect(await screen.findByTestId('billing-success-notice')).toBeInTheDocument()
+    expect(
+      screen.getByText(/your plan will update once payment is confirmed/i)
+    ).toBeInTheDocument()
+  })
+
+  it('shows a neutral notice when returning with ?checkout=cancelled', async () => {
+    locationStub.search = '?checkout=cancelled'
+
+    render(<BillingPage />)
+
+    expect(await screen.findByTestId('billing-checkout-notice')).toBeInTheDocument()
+    expect(
+      screen.getByText(/checkout was cancelled\. your plan has not changed/i)
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/dashboard/app/settings/billing/page.tsx
+++ b/apps/dashboard/app/settings/billing/page.tsx
@@ -21,8 +21,27 @@ import {
   Star,
 } from 'lucide-react'
 import { getBillingCurrent, getInvoices, getPaymentMethods, createCheckout } from '@/lib/api'
-import { TOAST_DISMISS_MS } from '@/lib/constants'
 import { useAuth } from '@/lib/auth'
+import { januaClient } from '@/lib/janua-client'
+
+/** Roles allowed to initiate billing changes (mirrors the checkout API's owner/admin check). */
+const BILLING_ROLES: string[] = ['owner', 'admin']
+
+/**
+ * Resolve the organization to bill: the first org where the current user is
+ * owner or admin (POST /api/v1/checkout/dhanam rejects anyone else with 403).
+ * The dashboard has no persistent "active org" store — pages resolve org
+ * context ad hoc (see settings/branding, settings/scim); billing needs an org
+ * the user can actually upgrade, so we pick from the user's org memberships.
+ */
+async function resolveBillableOrganizationId(): Promise<string | null> {
+  const orgs = await januaClient.organizations.listOrganizations()
+  if (!Array.isArray(orgs) || orgs.length === 0) return null
+  const billable = orgs.find(
+    (org) => org.is_owner || (org.user_role && BILLING_ROLES.includes(org.user_role))
+  )
+  return billable?.id ?? null
+}
 
 /** Format an ISO date string, returning a dash for null/undefined/invalid values. */
 function formatBillingDate(value: string | null | undefined): string {
@@ -192,10 +211,29 @@ export default function BillingPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [success, setSuccess] = useState<string | null>(null)
+  const [notice, setNotice] = useState<string | null>(null)
   const [upgrading, setUpgrading] = useState<string | null>(null)
 
   useEffect(() => {
     fetchBillingData()
+  }, [])
+
+  // Handle return from Dhanam checkout (?checkout=success|cancelled)
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const checkoutState = new URLSearchParams(window.location.search).get('checkout')
+    if (!checkoutState) return
+
+    if (checkoutState === 'success') {
+      setSuccess(
+        'Checkout complete. Your plan will update once payment is confirmed — this may take a moment.'
+      )
+    } else if (checkoutState === 'cancelled') {
+      setNotice('Checkout was cancelled. Your plan has not changed.')
+    }
+
+    // Drop the query param so a refresh does not re-show the notice
+    window.history.replaceState(null, '', window.location.pathname)
   }, [])
 
   const fetchBillingData = async () => {
@@ -251,15 +289,32 @@ export default function BillingPage() {
     try {
       setUpgrading(planId)
       setError(null)
+      setNotice(null)
 
-      const data = await createCheckout({ plan_id: planId })
+      const organizationId = await resolveBillableOrganizationId()
+      if (!organizationId) {
+        setError(
+          'No organization found where you are an owner or admin. Create an organization before upgrading.'
+        )
+        return
+      }
+
+      // POST /api/v1/checkout/dhanam requires organization_id, success_url and
+      // cancel_url alongside plan_id; the API answers with a Dhanam-hosted
+      // checkout URL we redirect to (Janua stays identity-only — no billing UI).
+      const returnUrl = `${window.location.origin}/settings/billing`
+      const data = await createCheckout({
+        plan_id: planId,
+        organization_id: organizationId,
+        success_url: `${returnUrl}?checkout=success`,
+        cancel_url: `${returnUrl}?checkout=cancelled`,
+      })
 
       if (data.checkout_url) {
         window.location.href = data.checkout_url
       } else {
-        setSuccess(`Successfully switched to ${planId} plan`)
-        setTimeout(() => setSuccess(null), TOAST_DISMISS_MS)
-        fetchBillingData()
+        // Contract violation guard — the API always returns checkout_url
+        setError('Checkout could not be started. Please try again.')
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to process upgrade')
@@ -321,11 +376,22 @@ export default function BillingPage() {
         )}
 
         {success && (
-          <Card className="border-green-500">
+          <Card className="border-green-500" data-testid="billing-success-notice">
             <CardContent className="pt-6">
               <div className="flex items-center gap-2 text-green-600 dark:text-green-400">
                 <CheckCircle2 className="size-5" />
                 <span>{success}</span>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {notice && (
+          <Card data-testid="billing-checkout-notice">
+            <CardContent className="pt-6">
+              <div className="text-muted-foreground flex items-center gap-2">
+                <AlertCircle className="size-5" />
+                <span>{notice}</span>
               </div>
             </CardContent>
           </Card>

--- a/apps/dashboard/lib/api.ts
+++ b/apps/dashboard/lib/api.ts
@@ -241,8 +241,32 @@ export async function getPaymentMethods(): Promise<PaymentMethod[]> {
   return response.data
 }
 
-export async function createCheckout(data: { plan_id: string; provider?: string }): Promise<{ checkout_url: string }> {
-  const response = await januaClient.http.post<{ checkout_url: string }>('/api/v1/checkout/dhanam', data)
+/**
+ * Full request contract for POST /api/v1/checkout/dhanam
+ * (apps/api/app/routers/v1/checkout_dhanam.py → CreateCheckoutRequest).
+ * All four fields are required — omitting any of them is a 422.
+ */
+export interface CreateCheckoutRequest {
+  plan_id: string
+  organization_id: string
+  success_url: string
+  cancel_url: string
+}
+
+/** Response contract (CheckoutSessionResponse). */
+export interface CheckoutSessionResponse {
+  checkout_url: string
+  session_id: string
+  customer_id: string | null
+  provider: string
+  organization_id: string
+  plan_id: string
+  product: string
+  janua_tier: string
+}
+
+export async function createCheckout(data: CreateCheckoutRequest): Promise<CheckoutSessionResponse> {
+  const response = await januaClient.http.post<CheckoutSessionResponse>('/api/v1/checkout/dhanam', data)
   return response.data
 }
 

--- a/apps/website/app/demo/page.tsx
+++ b/apps/website/app/demo/page.tsx
@@ -139,7 +139,7 @@ export default function DemoHubPage() {
         </p>
         <div className="flex justify-center gap-4">
           <Link
-            href="https://app.janua.dev/signup"
+            href="https://app.janua.dev/auth/signup"
             className="px-6 py-3 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition-colors"
           >
             Start Building Free


### PR DESCRIPTION
## The bug (money path, pre-existing — surfaced during #449 review)

`POST /api/v1/checkout/dhanam` (`apps/api/app/routers/v1/checkout_dhanam.py`, `CreateCheckoutRequest`) requires **four** fields:

| field | type | purpose |
|---|---|---|
| `plan_id` | str | e.g. `pro`, `scale` (parsed by `parse_product_plan`) |
| `organization_id` | UUID | org to upgrade; caller must be owner/admin |
| `success_url` | str | redirect after payment |
| `cancel_url` | str | redirect on cancel |

The dashboard's `createCheckout` (`apps/dashboard/lib/api.ts`) posted only `{ plan_id }`, so every upgrade/downgrade click on `/settings/billing` 422'd before a checkout session was ever created. The API contract is fine — the client was under-sending. **No `apps/api` changes.**

## The fix

- **`lib/api.ts`** — `createCheckout` now takes the full `CreateCheckoutRequest` and returns the router's `CheckoutSessionResponse` (`checkout_url`, `session_id`, `provider`, `product`, `janua_tier`, …). The unused `provider` request field (never part of the contract; the server derives its own hint) is gone.
- **`app/settings/billing/page.tsx`**
  - Resolves the billable org via `januaClient.organizations.listOrganizations()` — first org where the user is **owner or admin**, mirroring the router's 403 check. (The dashboard has no persistent active-org store; pages resolve org context ad hoc — the branding/scim pages' `current_organization_id` fallback reads a field `/auth/me` never returns, so memberships are the reliable source.) Honest error if the user has no billable org.
  - Sends `success_url`/`cancel_url` pointing back to `/settings/billing?checkout=success|cancelled` and redirects to the returned Dhanam `checkout_url` (identity-only: checkout stays on Dhanam, no billing UI added).
  - Removed the dead "Successfully switched to {plan}" branch — `checkout_url` is always returned per contract, and claiming a plan switch without payment was dishonest. A missing URL now shows an error.

## Return-state handling

On mount, `?checkout=success` shows the existing green success card ("plan will update once payment is confirmed" — honest: the tier flips via the Dhanam webhook, not the redirect); `?checkout=cancelled` shows a neutral notice card ("your plan has not changed"). The query param is stripped via `history.replaceState` so refreshes don't re-show it. Follows the page's existing Card notice patterns; nothing else added.

## Demo-link fix (same PR, not touched by #449 — verified)

`apps/website/app/demo/page.tsx` linked `app.janua.dev/signup` (404 — route registered at `/auth/signup` by #449). Fixed to `/auth/signup`; it was the last stray link in the repo missing the `/auth` prefix (nav, pricing, CTA, solutions pages already use it).

## Tests & validation

- New `apps/dashboard/app/settings/billing/page.test.tsx` (5 tests, all pass): exact full-contract payload + redirect to Dhanam URL, owner/admin org selection, no-billable-org error (no API call), and both return-state notices.
- `pnpm --filter @janua/dashboard typecheck` ✓, `build` ✓; `pnpm --filter @janua/website build` ✓.
- Full dashboard jest run: 18/18 executed tests pass (was 17). The 7 suites that fail to boot (`layout`, `health/route`, `organization-list`, …) fail identically on clean `origin/main` — pre-existing, untouched. Website `tsc --noEmit` also fails on `main` in unrelated test specs (missing jest-dom types) — pre-existing, untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)