### PR TITLE
deploy(prod): promote website digest 506404e (manual PP.3b-gap path)

### DIFF
--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -32,4 +32,4 @@ images:
     digest: sha256:0c4373cd8c879680a6f49da55171696660f677d26dd4e4d06521c2e6fa533bb3
   - name: ghcr.io/madfam-org/janua-website
     newName: ghcr.io/madfam-org/janua-website
-    digest: sha256:92a73b80bcf2896b4166910104e60fb05cae7e3b4fb6d29c8911b9276f7efa7e
+    digest: sha256:506404e72f4553461bee651cc508e50e24b881b2993511d52f583e5b24dde85f


### PR DESCRIPTION
Manual equivalent of `promote-to-prod component=website`, which fails on a PP.3b file-path bug while api/admin/dashboard promotes succeeded (runs 29163278083, 29163339150, 29163391260). Same file, same edit shape as the bot's commits. Carries #449 CTA fixes + #451 truth copy to janua.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)