### PR TITLE
fix(checkout): relay to dhanam's real checkout contract — unbreak upgrade redirect

### DIFF
--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -221,6 +221,21 @@ class Settings(BaseSettings):
         default=None,
         description="Dhanam billing service URL for checkout redirects. Set via DHANAM_URL env var.",
     )
+    DHANAM_FEDERATION_URL: Optional[str] = Field(
+        default=None,
+        description=(
+            "Dhanam federation API origin (e.g. https://api.dhan.am) used by the checkout "
+            "relay (/v1/customers/resolve + /v1/customers/{id}/checkout). "
+            "Set via DHANAM_FEDERATION_URL env var."
+        ),
+    )
+    FEDERATION_API_TOKEN: Optional[str] = Field(
+        default=None,
+        description=(
+            "Shared bearer token for Dhanam customer-federation calls "
+            "(ecosystem-standard name, same as the RouteCraft/Avala consumers)."
+        ),
+    )
 
     # Email aliases for easier access
     FROM_EMAIL: Optional[str] = Field(default=None)
@@ -649,6 +664,7 @@ class Settings(BaseSettings):
             "OAUTH_DISCORD_CLIENT_SECRET", "OAUTH_TWITTER_CLIENT_SECRET",
             "OAUTH_LINKEDIN_CLIENT_SECRET", "OAUTH_SLACK_CLIENT_SECRET",
             "CONEKTA_WEBHOOK_SECRET", "STRIPE_WEBHOOK_SECRET", "DHANAM_WEBHOOK_SECRET",
+            "FEDERATION_API_TOKEN",
             "CLOUDFLARE_TURNSTILE_SECRET", "CLOUDFLARE_R2_SECRET_KEY", "R2_SECRET_ACCESS_KEY",
             "MONITORING_API_KEY", "SMTP_PASSWORD",
         ]

--- a/apps/api/app/routers/v1/checkout_dhanam.py
+++ b/apps/api/app/routers/v1/checkout_dhanam.py
@@ -1,26 +1,40 @@
 """
-Dhanam Checkout Integration - Creates checkout sessions for ecosystem billing
+Dhanam Checkout Relay - federates checkout creation to Dhanam's billing API
 
-This endpoint is called when a user initiates an upgrade from any MADFAM
-application (Enclii, Tezca, Yantra4D, Dhanam) through Dhanam billing service.
+Janua is identity-only (decision 2026-07-09, internal-devops
+decisions/2026-07-09-avala-billing-gateway-alignment.md): checkout, PSP keys,
+and the ledger belong to Dhanam. This endpoint is therefore a thin relay to
+Dhanam's customer-federation API — the same pattern RouteCraft and Avala use:
 
-Flow:
-1. User hits tier limit in any product
-2. Product app redirects to Dhanam with org context and product plan_id
-3. Dhanam calls this endpoint to get checkout session
-4. User completes payment on Dhanam/payment provider
-5. Dhanam sends webhook to /api/v1/webhooks/dhanam/subscription
-6. Janua updates organization.product_tiers[product] = tier
-7. User's next JWT has per-product tier claims
+1. User initiates an upgrade (Janua dashboard, or any MADFAM product that
+   deep-links into Janua with a "{product}_{tier}" plan id).
+2. Janua validates the organization + caller permissions.
+3. Janua resolves/creates the Dhanam billing customer:
+       POST {DHANAM_FEDERATION_URL}/v1/customers/resolve
+       {"email": ..., "januaSub": ..., "name": ...} -> {"externalId", "created"}
+4. Janua opens the checkout session:
+       POST {DHANAM_FEDERATION_URL}/v1/customers/{externalId}/checkout
+       {"planId": "janua_pro", "successUrl", "cancelUrl", "metadata"}
+       -> {"checkoutUrl", "sessionId"}
+   Both calls authenticate with `Authorization: Bearer {FEDERATION_API_TOKEN}`.
+5. The client is redirected to Dhanam's ACTUAL hosted checkout URL (the PSP
+   session URL) — not a synthetic Dhanam-frontend path.
+6. After payment, Dhanam webhooks /api/v1/webhooks/dhanam/subscription and
+   Janua updates organization.product_tiers[product] for JWT tier claims.
+
+A local CheckoutSession row is kept as an audit record of the relay,
+storing Dhanam's session/customer references.
 """
 
+import json
 import uuid as uuid_mod
 from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
+import httpx
 import structlog
-from fastapi import APIRouter, Depends, HTTPException, Request, status
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -30,18 +44,39 @@ from app.core.database import get_db
 from app.dependencies import get_current_user
 from app.models import CheckoutSession, Organization, OrganizationMember, User
 
+# Re-use the ecosystem plan grammar from the webhooks module
+from app.routers.v1.webhooks_dhanam import VALID_TIERS, parse_product_plan
+
 logger = structlog.get_logger(__name__)
 router = APIRouter(prefix="/checkout", tags=["billing"])
 
+# Product slug for plans initiated from Janua's own dashboard. Bare tier ids
+# ("pro") are qualified with this so Dhanam's PriceResolver resolves the
+# janua/{tier} catalog entry instead of defaulting to the dhanam product.
+JANUA_PRODUCT_SLUG = "janua"
 
-# Re-use the product plan parser from webhooks module
-from app.routers.v1.webhooks_dhanam import parse_product_plan, VALID_TIERS
+# Billing period suffixes understood by both parse_product_plan() and Dhanam's
+# PriceResolver.parseCatalogTier — preserved on the outbound catalog plan id.
+BILLING_PERIOD_SUFFIXES = ("_monthly", "_annual", "_yearly")
+
+# Per-request timeout for Dhanam federation calls (RouteCraft uses 8s).
+DHANAM_FEDERATION_TIMEOUT_SECONDS = 10.0
+
+
+class DhanamFederationError(Exception):
+    """A Dhanam federation call failed (transport error or non-2xx response)."""
+
+    def __init__(self, path: str, status_code: Optional[int], detail: str):
+        self.path = path
+        self.status_code = status_code
+        self.detail = detail
+        super().__init__(f"Dhanam federation {path} failed ({status_code}): {detail}")
 
 
 class CreateCheckoutRequest(BaseModel):
     """Request to create a checkout session for Dhanam billing integration."""
 
-    plan_id: str = Field(..., description="Dhanam plan ID (e.g., 'enclii_sovereign', 'pro')")
+    plan_id: str = Field(..., description="Plan ID (e.g., 'enclii_pro', 'pro' for janua/pro)")
     organization_id: UUID = Field(..., description="Janua organization ID to upgrade")
     success_url: str = Field(..., description="URL to redirect after successful payment")
     cancel_url: str = Field(..., description="URL to redirect if payment is cancelled")
@@ -50,54 +85,148 @@ class CreateCheckoutRequest(BaseModel):
 class CheckoutSessionResponse(BaseModel):
     """Response with checkout session details."""
 
-    checkout_url: str = Field(..., description="URL to redirect user for payment")
-    session_id: str = Field(..., description="Checkout session ID")
-    customer_id: Optional[str] = Field(None, description="Billing customer ID linked to organization")
-    provider: str = Field(..., description="Payment provider hint (conekta for MX, polar for intl)")
+    checkout_url: str = Field(..., description="Dhanam-hosted checkout URL to redirect the user to")
+    session_id: str = Field(..., description="Checkout session ID (Dhanam's session reference)")
+    customer_id: Optional[str] = Field(
+        None, description="Dhanam billing customer id (externalId) the checkout was created for"
+    )
+    provider: str = Field(
+        ..., description="Billing gateway ('dhanam'; PSP selection happens in Dhanam)"
+    )
     organization_id: str = Field(..., description="Organization ID being upgraded")
-    plan_id: str = Field(..., description="Plan ID for the checkout")
-    product: str = Field(..., description="Product being upgraded (enclii, tezca, yantra4d, dhanam)")
+    plan_id: str = Field(..., description="Fully-qualified catalog plan ID sent to Dhanam")
+    product: str = Field(..., description="Product being upgraded (janua, enclii, tezca, ...)")
     janua_tier: str = Field(..., description="Corresponding tier")
 
 
-def determine_provider_hint(email: str) -> str:
+def _strip_billing_period(plan_id: str) -> tuple[str, str]:
+    """Split a lowercased plan id into (core, billing-period suffix)."""
+    normalized = plan_id.lower()
+    for suffix in BILLING_PERIOD_SUFFIXES:
+        if normalized.endswith(suffix):
+            return normalized[: -len(suffix)], suffix
+    return normalized, ""
+
+
+def build_catalog_plan_id(plan_id: str) -> tuple[str, Optional[str], str]:
+    """Resolve (product, tier, dhanam_catalog_plan_id) for a checkout request.
+
+    parse_product_plan() implements the ecosystem-wide plan grammar, but its
+    bare-tier default (product="dhanam") is a webhook-side convention. A
+    checkout reaching Janua's own API with an unqualified tier ("pro") was
+    initiated from Janua's dashboard for the janua product, so bare tiers are
+    qualified as "janua_{tier}" — the id Dhanam's PriceResolver parses back
+    into (product="janua", tier). Billing-period suffixes are preserved so
+    Dhanam still resolves the monthly/yearly interval.
     """
-    Simple provider hint based on email domain TLD.
-    Actual provider selection happens in Dhanam.
+    product, tier = parse_product_plan(plan_id)
+    if tier is None:
+        return product, None, ""
+    core, suffix = _strip_billing_period(plan_id)
+    if core in VALID_TIERS:
+        product = JANUA_PRODUCT_SLUG
+    return product, tier, f"{product}_{tier}{suffix}"
+
+
+def _federation_configured() -> bool:
+    return bool(settings.DHANAM_FEDERATION_URL and settings.FEDERATION_API_TOKEN)
+
+
+async def _dhanam_federation_post(path: str, payload: dict) -> dict:
+    """POST to a Dhanam federation endpoint with the shared bearer token.
+
+    Raises DhanamFederationError on transport failure, non-2xx status, or a
+    non-JSON body. Request payloads are not logged (they carry identity data).
     """
-    # Default to polar for international
-    if email.endswith(".mx") or "mexico" in email.lower():
-        return "conekta"
-    return "polar"
+    base_url = (settings.DHANAM_FEDERATION_URL or "").rstrip("/")
+    try:
+        async with httpx.AsyncClient(timeout=DHANAM_FEDERATION_TIMEOUT_SECONDS) as client:
+            response = await client.post(
+                f"{base_url}{path}",
+                json=payload,
+                headers={"Authorization": f"Bearer {settings.FEDERATION_API_TOKEN}"},
+            )
+    except httpx.HTTPError as e:
+        logger.error("Dhanam federation call failed", path=path, error=str(e))
+        raise DhanamFederationError(path, None, str(e)) from e
+
+    if response.status_code >= 400:
+        logger.error(
+            "Dhanam federation call rejected",
+            path=path,
+            status_code=response.status_code,
+        )
+        raise DhanamFederationError(path, response.status_code, response.text[:300])
+
+    try:
+        return response.json()
+    except ValueError as e:
+        logger.error("Dhanam federation returned non-JSON body", path=path)
+        raise DhanamFederationError(path, response.status_code, "invalid JSON response") from e
+
+
+def _map_resolve_error(error: DhanamFederationError) -> HTTPException:
+    """Map a failed /v1/customers/resolve call to a client-facing error."""
+    if error.status_code == status.HTTP_409_CONFLICT:
+        return HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "This account's email is already linked to a different billing identity. "
+                "Contact support to resolve the conflict."
+            ),
+        )
+    if error.status_code == status.HTTP_403_FORBIDDEN:
+        # Dhanam has FEDERATION_CUSTOMER_PROVISIONING_ENABLED off and no
+        # existing customer matched — billing is not activated for this user.
+        return HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Billing customer provisioning is not enabled yet. Please try again later.",
+        )
+    return _map_transport_error(error)
+
+
+def _map_transport_error(error: DhanamFederationError) -> HTTPException:
+    """Map a transport failure / unexpected status to a client-facing error."""
+    if error.status_code is None:
+        return HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Billing service is unreachable. Please try again later.",
+        )
+    return HTTPException(
+        status_code=status.HTTP_502_BAD_GATEWAY,
+        detail="Billing service rejected the checkout request. Please try again later.",
+    )
 
 
 @router.post("/dhanam", response_model=CheckoutSessionResponse)
 async def create_dhanam_checkout(
     request_data: CreateCheckoutRequest,
-    request: Request,
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(get_current_user),
 ):
     """
-    Create a checkout session for Dhanam billing integration.
+    Create a checkout session by relaying to Dhanam's federation API.
 
     This endpoint:
-    1. Validates the organization and user permissions
-    2. Creates a checkout session record
-    3. Links billing_customer_id to the organization (if not already)
-    4. Returns checkout URL for Dhanam to process payment
+    1. Validates the plan, organization, and user permissions
+    2. Resolves (or provisions) the Dhanam billing customer for the caller
+    3. Creates the checkout session via Dhanam and returns Dhanam's actual
+       hosted checkout URL
+    4. Records a local CheckoutSession row for audit
 
-    The checkout URL pattern: https://dhanam.madfam.io/checkout/session/{session_id}
-    Dhanam will handle the actual payment provider integration.
+    Fails closed with 503 when the federation relay is not configured
+    (DHANAM_FEDERATION_URL / FEDERATION_API_TOKEN).
     """
-    # Parse product and tier from plan_id
-    product, tier = parse_product_plan(request_data.plan_id)
+    # Parse product and tier from plan_id; qualify bare tiers as janua/{tier}
+    product, tier, catalog_plan_id = build_catalog_plan_id(request_data.plan_id)
     if not tier:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Invalid plan_id: {request_data.plan_id}. Expected format: '{{product}}_{{tier}}' where tier is one of {sorted(VALID_TIERS)}",
+            detail=(
+                f"Invalid plan_id: {request_data.plan_id}. Expected format: "
+                f"'{{product}}_{{tier}}' where tier is one of {sorted(VALID_TIERS)}"
+            ),
         )
-    janua_tier = tier  # For response compat
 
     # Get the organization
     result = await db.execute(
@@ -130,54 +259,133 @@ async def create_dhanam_checkout(
                 detail="Only organization owners and admins can initiate billing changes",
             )
 
-    # Generate unique session ID
-    session_id = f"checkout_{uuid_mod.uuid4().hex[:16]}"
+    # Fail closed when the Dhanam relay is not configured — a synthetic
+    # redirect would dead-end (Dhanam serves no /checkout/session/{id} route).
+    if not _federation_configured():
+        logger.error(
+            "Dhanam federation relay not configured",
+            missing_url=not settings.DHANAM_FEDERATION_URL,
+            missing_token=not settings.FEDERATION_API_TOKEN,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Billing is not configured. Please contact support.",
+        )
 
-    # Determine provider hint (actual selection happens in Dhanam)
-    provider_hint = determine_provider_hint(current_user.email or "")
+    # 1) Resolve — or provision — the Dhanam billing customer for the caller.
+    #    Keyed on the Janua subject (JWT `sub` = user id) with email fallback.
+    resolve_payload: dict = {
+        "email": current_user.email,
+        "januaSub": str(current_user.id),
+    }
+    if current_user.name:
+        resolve_payload["name"] = current_user.name
 
-    # Create checkout session record
-    checkout_session = CheckoutSession(
-        session_id=session_id,
-        organization_id=organization.id,
-        user_id=current_user.id,
-        price_id=request_data.plan_id,
-        provider=provider_hint,
-        status="pending",
-        session_metadata=str({
-            "success_url": request_data.success_url,
-            "cancel_url": request_data.cancel_url,
-            "janua_tier": janua_tier,
+    try:
+        resolved = await _dhanam_federation_post("/v1/customers/resolve", resolve_payload)
+    except DhanamFederationError as e:
+        raise _map_resolve_error(e) from e
+
+    external_id = resolved.get("externalId")
+    if not external_id or not isinstance(external_id, str):
+        logger.error("Dhanam resolve returned no externalId")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Billing service returned an invalid customer reference.",
+        )
+
+    # 2) Create the checkout session for the resolved customer. The metadata
+    #    bag is threaded into the PSP session and flows back on Dhanam's
+    #    webhooks, letting the org be credited (orgId is the key Dhanam's
+    #    webhook processor reads; organization_id is Janua's webhook fallback).
+    checkout_payload = {
+        "planId": catalog_plan_id,
+        "successUrl": request_data.success_url,
+        "cancelUrl": request_data.cancel_url,
+        "metadata": {
+            "orgId": str(organization.id),
+            "organization_id": str(organization.id),
             "organization_slug": organization.slug,
-            "user_email": current_user.email,
-        }),
-    )
-    db.add(checkout_session)
-    await db.commit()
+            "product": product,
+            "janua_tier": tier,
+        },
+    }
 
-    # Construct Dhanam checkout URL
-    checkout_url = f"{settings.DHANAM_URL}/checkout/session/{session_id}"
+    try:
+        checkout = await _dhanam_federation_post(
+            f"/v1/customers/{external_id}/checkout", checkout_payload
+        )
+    except DhanamFederationError as e:
+        raise _map_transport_error(e) from e
+
+    checkout_url = checkout.get("checkoutUrl")
+    if not checkout_url or not isinstance(checkout_url, str):
+        logger.error("Dhanam checkout returned no checkoutUrl")
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Billing service did not return a checkout URL.",
+        )
+
+    # Dhanam may return an empty sessionId on some provider paths; keep a
+    # local reference either way so the audit row has a unique key.
+    dhanam_session_id = checkout.get("sessionId") or ""
+    session_id = dhanam_session_id or f"checkout_{uuid_mod.uuid4().hex[:16]}"
+
+    # 3) Record the relay for audit. Best-effort: the Dhanam session already
+    #    exists, so a local persistence hiccup must not block the payment flow.
+    try:
+        checkout_session = CheckoutSession(
+            session_id=session_id,
+            organization_id=organization.id,
+            user_id=current_user.id,
+            price_id=catalog_plan_id,
+            provider="dhanam",
+            status="pending",
+            session_metadata=json.dumps(
+                {
+                    "dhanam_customer_id": external_id,
+                    "dhanam_session_id": dhanam_session_id,
+                    "requested_plan_id": request_data.plan_id,
+                    "product": product,
+                    "janua_tier": tier,
+                    "organization_slug": organization.slug,
+                    "success_url": request_data.success_url,
+                    "cancel_url": request_data.cancel_url,
+                }
+            ),
+        )
+        db.add(checkout_session)
+        await db.commit()
+    except Exception as e:
+        await db.rollback()
+        logger.error(
+            "Failed to persist checkout session audit row",
+            session_id=session_id,
+            organization_id=str(organization.id),
+            error=str(e),
+        )
 
     logger.info(
-        "Created Dhanam checkout session",
+        "Created Dhanam federated checkout",
         session_id=session_id,
         organization_id=str(organization.id),
         organization_slug=organization.slug,
-        plan_id=request_data.plan_id,
-        janua_tier=janua_tier,
-        provider_hint=provider_hint,
-        user_email=current_user.email,
+        requested_plan_id=request_data.plan_id,
+        catalog_plan_id=catalog_plan_id,
+        product=product,
+        janua_tier=tier,
+        dhanam_customer_created=bool(resolved.get("created")),
     )
 
     return CheckoutSessionResponse(
         checkout_url=checkout_url,
         session_id=session_id,
-        customer_id=organization.billing_customer_id,
-        provider=provider_hint,
+        customer_id=external_id,
+        provider="dhanam",
         organization_id=str(organization.id),
-        plan_id=request_data.plan_id,
+        plan_id=catalog_plan_id,
         product=product,
-        janua_tier=janua_tier,
+        janua_tier=tier,
     )
 
 
@@ -229,7 +437,9 @@ async def get_checkout_session(
         "price_id": checkout_session.price_id,
         "provider": checkout_session.provider,
         "status": checkout_session.status,
-        "created_at": checkout_session.created_at.isoformat() if checkout_session.created_at else None,
+        "created_at": (
+            checkout_session.created_at.isoformat() if checkout_session.created_at else None
+        ),
     }
 
 

--- a/apps/api/tests/unit/routers/test_checkout_dhanam.py
+++ b/apps/api/tests/unit/routers/test_checkout_dhanam.py
@@ -1,0 +1,509 @@
+"""
+Unit tests for POST /api/v1/checkout/dhanam — the Dhanam federation relay.
+
+The endpoint must relay checkout creation to Dhanam's real federation API
+(resolve -> checkout, Bearer FEDERATION_API_TOKEN), return Dhanam's actual
+hosted checkout URL, qualify bare plan ids as janua/{tier}, fail closed with
+503 when unconfigured, and keep a local CheckoutSession audit row.
+
+Dhanam HTTP is mocked with respx; the contract mirrored here is
+dhanam apps/api/src/modules/billing/customer-federation.controller.ts:
+- POST /v1/customers/resolve {email, januaSub?, name?} -> {externalId, created}
+- POST /v1/customers/{externalId}/checkout {planId, successUrl, cancelUrl,
+  metadata} -> {checkoutUrl, sessionId}
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+
+import httpx
+import pytest
+import pytest_asyncio
+import respx
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.config import settings
+from app.core.database import get_db
+from app.dependencies import get_current_user
+from app.main import app
+from app.models import (
+    Base,
+    CheckoutSession,
+    Organization,
+    OrganizationMember,
+    User,
+    UserStatus,
+)
+from app.routers.v1.checkout_dhanam import build_catalog_plan_id
+
+# Only the tables these tests touch. Creating the full Base.metadata is
+# order-dependent in the full suite: other test modules import optional model
+# modules that register PostgreSQL-only column types on the shared Base,
+# which breaks metadata-wide create_all on SQLite once they are loaded.
+CHECKOUT_TABLES = [
+    User.__table__,
+    Organization.__table__,
+    OrganizationMember.__table__,
+    CheckoutSession.__table__,
+]
+
+CHECKOUT_URL = "/api/v1/checkout/dhanam"
+DHANAM_BASE = "https://dhanam-api.test"
+FEDERATION_TOKEN = "test-federation-token"
+RESOLVE_URL = f"{DHANAM_BASE}/v1/customers/resolve"
+
+
+class CheckoutEnv:
+    """Bundle of the app client plus seeded identities for a test."""
+
+    def __init__(self, client, session_factory, owner, plain_member, admin_member, org, current):
+        self.client = client
+        self.session_factory = session_factory
+        self.owner = owner
+        self.plain_member = plain_member
+        self.admin_member = admin_member
+        self.org = org
+        self._current = current
+
+    def act_as(self, user: User) -> None:
+        self._current["user"] = user
+
+
+@pytest_asyncio.fixture
+async def checkout_env():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=CHECKOUT_TABLES)
+        )
+
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with session_factory() as session:
+            yield session
+
+    owner = User(
+        id=uuid.uuid4(),
+        email="owner@janua.test",
+        first_name="Olive",
+        last_name="Owner",
+        email_verified=True,
+        status=UserStatus.ACTIVE,
+        is_active=True,
+    )
+    plain_member = User(
+        id=uuid.uuid4(),
+        email="member@janua.test",
+        email_verified=True,
+        status=UserStatus.ACTIVE,
+        is_active=True,
+    )
+    admin_member = User(
+        id=uuid.uuid4(),
+        email="admin@janua.test",
+        email_verified=True,
+        status=UserStatus.ACTIVE,
+        is_active=True,
+    )
+    org = Organization(id=uuid.uuid4(), name="Acme", slug="acme", owner_id=owner.id)
+
+    async with session_factory() as session:
+        session.add_all(
+            [
+                owner,
+                plain_member,
+                admin_member,
+                org,
+                OrganizationMember(organization_id=org.id, user_id=plain_member.id, role="member"),
+                OrganizationMember(organization_id=org.id, user_id=admin_member.id, role="admin"),
+            ]
+        )
+        await session.commit()
+
+    current = {"user": owner}
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user] = lambda: current["user"]
+
+    settings.DHANAM_FEDERATION_URL = DHANAM_BASE
+    settings.FEDERATION_API_TOKEN = FEDERATION_TOKEN
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield CheckoutEnv(client, session_factory, owner, plain_member, admin_member, org, current)
+
+    app.dependency_overrides.clear()
+    settings.DHANAM_FEDERATION_URL = None
+    settings.FEDERATION_API_TOKEN = None
+    await engine.dispose()
+
+
+def _checkout_payload(env: CheckoutEnv, plan_id: str = "pro") -> dict:
+    return {
+        "plan_id": plan_id,
+        "organization_id": str(env.org.id),
+        "success_url": "https://app.janua.dev/settings/billing?checkout=success",
+        "cancel_url": "https://app.janua.dev/settings/billing?checkout=cancelled",
+    }
+
+
+def _mock_dhanam(
+    external_id: str = "dhanam-user-1",
+    checkout_url: str = "https://checkout.stripe.com/c/pay/cs_test_123",
+    session_id: str = "cs_test_123",
+    created: bool = True,
+):
+    resolve_route = respx.post(RESOLVE_URL).mock(
+        return_value=httpx.Response(200, json={"externalId": external_id, "created": created})
+    )
+    checkout_route = respx.post(f"{DHANAM_BASE}/v1/customers/{external_id}/checkout").mock(
+        return_value=httpx.Response(
+            201, json={"checkoutUrl": checkout_url, "sessionId": session_id}
+        )
+    )
+    return resolve_route, checkout_route
+
+
+# ---------------------------------------------------------------------------
+# Plan id -> Dhanam catalog plan id resolution
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCatalogPlanId:
+    @pytest.mark.parametrize(
+        "plan_id, expected",
+        [
+            # Bare tiers come from Janua's own dashboard -> janua product
+            ("pro", ("janua", "pro", "janua_pro")),
+            ("PRO", ("janua", "pro", "janua_pro")),
+            ("essentials", ("janua", "essentials", "janua_essentials")),
+            ("madfam", ("janua", "madfam", "janua_madfam")),
+            # Billing period suffixes survive so Dhanam resolves the interval
+            ("pro_yearly", ("janua", "pro", "janua_pro_yearly")),
+            ("pro_monthly", ("janua", "pro", "janua_pro_monthly")),
+            ("pro_annual", ("janua", "pro", "janua_pro_annual")),
+            # Qualified ids pass through untouched
+            ("enclii_pro", ("enclii", "pro", "enclii_pro")),
+            ("tezca_essentials_monthly", ("tezca", "essentials", "tezca_essentials_monthly")),
+            ("karafiel_pro", ("karafiel", "pro", "karafiel_pro")),
+            # Legacy names keep their historical product mapping
+            ("sovereign", ("enclii", "pro", "enclii_pro")),
+            ("sovereign_yearly", ("enclii", "pro", "enclii_pro_yearly")),
+            ("scale", ("dhanam", "pro", "dhanam_pro")),
+            ("enterprise", ("dhanam", "madfam", "dhanam_madfam")),
+        ],
+    )
+    def test_catalog_plan_ids(self, plan_id: str, expected: tuple):
+        assert build_catalog_plan_id(plan_id) == expected
+
+    @pytest.mark.parametrize("plan_id", ["free", "community", "trial", ""])
+    def test_cancel_tiers_have_no_catalog_id(self, plan_id: str):
+        _, tier, catalog_id = build_catalog_plan_id(plan_id)
+        assert tier is None
+        assert catalog_id == ""
+
+
+# ---------------------------------------------------------------------------
+# Relay happy path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_relays_resolve_then_checkout_and_returns_dhanam_url(checkout_env: CheckoutEnv):
+    resolve_route, checkout_route = _mock_dhanam()
+
+    response = await checkout_env.client.post(CHECKOUT_URL, json=_checkout_payload(checkout_env))
+
+    assert response.status_code == 200
+    body = response.json()
+    # Dhanam's ACTUAL hosted checkout URL is passed through, not a synthetic
+    # {DHANAM_URL}/checkout/session/{id} path (which dhanam does not serve).
+    assert body["checkout_url"] == "https://checkout.stripe.com/c/pay/cs_test_123"
+    assert body["session_id"] == "cs_test_123"
+    assert body["customer_id"] == "dhanam-user-1"
+    assert body["provider"] == "dhanam"
+    assert body["plan_id"] == "janua_pro"
+    assert body["product"] == "janua"
+    assert body["janua_tier"] == "pro"
+    assert body["organization_id"] == str(checkout_env.org.id)
+
+    # Call sequence: resolve first, then checkout for the resolved customer
+    assert resolve_route.called and checkout_route.called
+    assert respx.calls[0].request.url.path == "/v1/customers/resolve"
+    assert respx.calls[1].request.url.path == "/v1/customers/dhanam-user-1/checkout"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_resolve_payload_carries_janua_identity_and_bearer_token(
+    checkout_env: CheckoutEnv,
+):
+    resolve_route, _ = _mock_dhanam()
+
+    await checkout_env.client.post(CHECKOUT_URL, json=_checkout_payload(checkout_env))
+
+    request = resolve_route.calls[0].request
+    assert request.headers["authorization"] == f"Bearer {FEDERATION_TOKEN}"
+    assert json.loads(request.content) == {
+        "email": "owner@janua.test",
+        "januaSub": str(checkout_env.owner.id),
+        "name": "Olive Owner",
+    }
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_checkout_payload_sends_qualified_plan_and_org_metadata(
+    checkout_env: CheckoutEnv,
+):
+    _, checkout_route = _mock_dhanam()
+    payload = _checkout_payload(checkout_env, plan_id="pro")
+
+    await checkout_env.client.post(CHECKOUT_URL, json=payload)
+
+    request = checkout_route.calls[0].request
+    assert request.headers["authorization"] == f"Bearer {FEDERATION_TOKEN}"
+    body = json.loads(request.content)
+    assert body["planId"] == "janua_pro"
+    assert body["successUrl"] == payload["success_url"]
+    assert body["cancelUrl"] == payload["cancel_url"]
+    # metadata threads the org through the PSP session and back on webhooks:
+    # orgId is what Dhanam's webhook processor reads; organization_id is the
+    # fallback key Janua's own webhook handler resolves organizations by.
+    assert body["metadata"]["orgId"] == str(checkout_env.org.id)
+    assert body["metadata"]["organization_id"] == str(checkout_env.org.id)
+    assert body["metadata"]["organization_slug"] == "acme"
+    assert body["metadata"]["product"] == "janua"
+    assert body["metadata"]["janua_tier"] == "pro"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_prefixed_plan_id_passes_through_for_other_products(checkout_env: CheckoutEnv):
+    _, checkout_route = _mock_dhanam()
+
+    response = await checkout_env.client.post(
+        CHECKOUT_URL, json=_checkout_payload(checkout_env, plan_id="enclii_pro")
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["plan_id"] == "enclii_pro"
+    assert body["product"] == "enclii"
+    sent = json.loads(checkout_route.calls[0].request.content)
+    assert sent["planId"] == "enclii_pro"
+    assert sent["metadata"]["product"] == "enclii"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_yearly_suffix_is_preserved_on_the_catalog_plan_id(checkout_env: CheckoutEnv):
+    _, checkout_route = _mock_dhanam()
+
+    response = await checkout_env.client.post(
+        CHECKOUT_URL, json=_checkout_payload(checkout_env, plan_id="pro_yearly")
+    )
+
+    assert response.status_code == 200
+    sent = json.loads(checkout_route.calls[0].request.content)
+    assert sent["planId"] == "janua_pro_yearly"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_admin_member_can_initiate_checkout(checkout_env: CheckoutEnv):
+    _mock_dhanam()
+    checkout_env.act_as(checkout_env.admin_member)
+
+    response = await checkout_env.client.post(CHECKOUT_URL, json=_checkout_payload(checkout_env))
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_audit_row_records_dhanam_session_reference(checkout_env: CheckoutEnv):
+    _mock_dhanam()
+
+    response = await checkout_env.client.post(CHECKOUT_URL, json=_checkout_payload(checkout_env))
+    assert response.status_code == 200
+
+    async with checkout_env.session_factory() as session:
+        result = await session.execute(
+            select(CheckoutSession).where(CheckoutSession.session_id == "cs_test_123")
+        )
+        row = result.scalar_one()
+
+    assert row.organization_id == checkout_env.org.id
+    assert row.user_id == checkout_env.owner.id
+    assert row.price_id == "janua_pro"
+    assert row.provider == "dhanam"
+    assert row.status == "pending"
+    stored = json.loads(row.session_metadata)
+    assert stored["dhanam_customer_id"] == "dhanam-user-1"
+    assert stored["dhanam_session_id"] == "cs_test_123"
+    assert stored["requested_plan_id"] == "pro"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_empty_dhanam_session_id_gets_local_audit_reference(checkout_env: CheckoutEnv):
+    _mock_dhanam(session_id="")
+
+    response = await checkout_env.client.post(CHECKOUT_URL, json=_checkout_payload(checkout_env))
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["session_id"].startswith("checkout_")
+    async with checkout_env.session_factory() as session:
+        result = await session.execute(
+            select(CheckoutSession).where(CheckoutSession.session_id == body["session_id"])
+        )
+        row = result.scalar_one()
+    assert json.loads(row.session_metadata)["dhanam_session_id"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Validation and permission errors (no Dhanam traffic)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_invalid_plan_id_returns_400_without_calling_dhanam(checkout_env: CheckoutEnv):
+    response = await checkout_env.client.post(
+        CHECKOUT_URL, json=_checkout_payload(checkout_env, plan_id="free")
+    )
+
+    assert response.status_code == 400
+    assert not respx.calls
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_unknown_organization_returns_404(checkout_env: CheckoutEnv):
+    payload = _checkout_payload(checkout_env)
+    payload["organization_id"] = str(uuid.uuid4())
+
+    response = await checkout_env.client.post(CHECKOUT_URL, json=payload)
+
+    assert response.status_code == 404
+    assert not respx.calls
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_plain_member_gets_403_without_calling_dhanam(checkout_env: CheckoutEnv):
+    checkout_env.act_as(checkout_env.plain_member)
+
+    response = await checkout_env.client.post(CHECKOUT_URL, json=_checkout_payload(checkout_env))
+
+    assert response.status_code == 403
+    assert not respx.calls
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed configuration gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+@pytest.mark.parametrize("missing", ["url", "token", "both"])
+async def test_missing_federation_config_returns_503(checkout_env: CheckoutEnv, missing: str):
+    if missing in ("url", "both"):
+        settings.DHANAM_FEDERATION_URL = None
+    if missing in ("token", "both"):
+        settings.FEDERATION_API_TOKEN = None
+
+    response = await checkout_env.client.post(CHECKOUT_URL, json=_checkout_payload(checkout_env))
+
+    assert response.status_code == 503
+    assert not respx.calls
+
+
+# ---------------------------------------------------------------------------
+# Dhanam-side failures map to clear client errors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_resolve_conflict_maps_to_409(checkout_env: CheckoutEnv):
+    respx.post(RESOLVE_URL).mock(
+        return_value=httpx.Response(
+            409, json={"message": "Email is already linked to a different Janua identity"}
+        )
+    )
+
+    response = await checkout_env.client.post(CHECKOUT_URL, json=_checkout_payload(checkout_env))
+
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_resolve_provisioning_disabled_maps_to_503(checkout_env: CheckoutEnv):
+    respx.post(RESOLVE_URL).mock(
+        return_value=httpx.Response(403, json={"message": "provisioning is disabled"})
+    )
+
+    response = await checkout_env.client.post(CHECKOUT_URL, json=_checkout_payload(checkout_env))
+
+    assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_dhanam_unreachable_maps_to_503(checkout_env: CheckoutEnv):
+    respx.post(RESOLVE_URL).mock(side_effect=httpx.ConnectError("connection refused"))
+
+    response = await checkout_env.client.post(CHECKOUT_URL, json=_checkout_payload(checkout_env))
+
+    assert response.status_code == 503
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_checkout_call_failure_maps_to_502(checkout_env: CheckoutEnv):
+    respx.post(RESOLVE_URL).mock(
+        return_value=httpx.Response(200, json={"externalId": "dhanam-user-1", "created": False})
+    )
+    respx.post(f"{DHANAM_BASE}/v1/customers/dhanam-user-1/checkout").mock(
+        return_value=httpx.Response(500, json={"message": "boom"})
+    )
+
+    response = await checkout_env.client.post(CHECKOUT_URL, json=_checkout_payload(checkout_env))
+
+    assert response.status_code == 502
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_missing_checkout_url_maps_to_502(checkout_env: CheckoutEnv):
+    _mock_dhanam(checkout_url="")
+
+    response = await checkout_env.client.post(CHECKOUT_URL, json=_checkout_payload(checkout_env))
+
+    assert response.status_code == 502
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_resolve_without_external_id_maps_to_502(checkout_env: CheckoutEnv):
+    respx.post(RESOLVE_URL).mock(return_value=httpx.Response(200, json={"created": True}))
+
+    response = await checkout_env.client.post(CHECKOUT_URL, json=_checkout_payload(checkout_env))
+
+    assert response.status_code == 502


### PR DESCRIPTION
## The dead-end bug

`POST /api/v1/checkout/dhanam` created a local `CheckoutSession` row and told the browser to open `{DHANAM_URL}/checkout/session/{session_id}` — **dhanam serves no such route**, so after #450 fixed the dashboard contract, every upgrade click resolved into a dhanam 404. On top of that, janua forwarded bare plan ids (`'pro'`): dhanam's catalog parser (`parseCatalogTier`) resolves an unprefixed tier to the **dhanam** product, so even a working redirect would have priced the wrong product instead of `janua/pro`.

Policy anchor: internal-devops `decisions/2026-07-09-avala-billing-gateway-alignment.md` — products integrate billing via **Dhanam-direct federation**; Janua stays identity-only. This PR makes janua's checkout endpoint a thin relay to dhanam's real API, the same pattern RouteCraft ships (`routecraft packages/payments/src/dhanam-checkout.ts`) and avala adopted.

## Dhanam contract findings (verified against dhanam `origin/main` source)

| Aspect | Finding | Source (dhanam repo) |
|---|---|---|
| Base path | Global URL prefix is `v1` | `apps/api/src/main.ts` (`app.setGlobalPrefix('v1')`) |
| Resolve | `POST /v1/customers/resolve` body `{email (required), januaSub?, name?}` → `200 {externalId, created}`; keyed on `User.januaSub` with email link/backfill; provisioning of new customers gated by `FEDERATION_CUSTOMER_PROVISIONING_ENABLED` (403 when off + no match); 409 when the email is linked to a different subject | `apps/api/src/modules/billing/customer-federation.controller.ts`, `dto/resolve-customer.dto.ts`, `services/customer-federation.service.ts` (dhanam #624) |
| Checkout | `POST /v1/customers/{externalId}/checkout` body `{planId, successUrl?, cancelUrl?, metadata?}` → `201 {checkoutUrl, sessionId}`; `checkoutUrl` is the **actual hosted checkout** (PSP session URL, e.g. Stripe MX `session.url`; janua-relay/hybrid paths likewise return the provider URL). `sessionId` can be empty on some provider paths | `customer-federation.controller.ts`, `services/subscription-lifecycle.service.ts` (`createFederatedCheckout`) |
| Auth | `Authorization: Bearer FEDERATION_API_TOKEN` (shared secret, constant-time compare); 60 req/min per IP | `guards/federation-auth.guard.ts` |
| Plan id | `planId` must be self-qualified: the federated path calls `resolveStripePriceId(planId, undefined, ...)` with no product param, and `parseCatalogTier('janua_pro')` → product `janua`, tier `pro`; bare `pro` → product `dhanam`. Billing-period suffixes (`_monthly|_annual|_yearly`) select the interval | `services/price-resolver.service.ts`, `services/checkout-routing-policy.service.ts` (`normalizeCatalogPlanId`) |
| Metadata | The checkout `metadata` bag is threaded into the PSP session and flows back on dhanam's webhooks (dhanam #622); dhanam's webhook processor credits the org via `metadata.orgId` | `subscription-lifecycle.service.ts`, `services/webhook-processor.service.ts` |
| Catalog | The priced `janua/pro` tier ("Managed", USD $29/mo) ships with the dhanam #627 catalog work (branch `claude/enclii-janua-priced-skus`, GA packaging ratification 2026-07-11) — explicitly documented there as resolvable via `plan janua_pro / plan=pro&product=janua` | `catalog.yaml` on that branch |

## What janua now sends / receives

1. Validates plan + org + owner/admin permission (unchanged), then **fails closed with 503** if the relay is unconfigured — no more synthetic redirects.
2. `POST {DHANAM_FEDERATION_URL}/v1/customers/resolve` with `{email, januaSub: str(user.id), name?}` → `{externalId, created}`. Error mapping: dhanam 409 → 409 (email linked to different billing identity), dhanam 403 → 503 (provisioning not enabled), transport → 503, other → 502.
3. `POST {DHANAM_FEDERATION_URL}/v1/customers/{externalId}/checkout` with `planId` fully qualified (`pro` → `janua_pro`, `pro_yearly` → `janua_pro_yearly`; `enclii_pro` etc. pass through; legacy names keep their historical mapping) plus `metadata: {orgId, organization_id, organization_slug, product, janua_tier}` so the entitlement webhook can resolve the org (`orgId` is dhanam's key; `organization_id` is `webhooks_dhanam.find_organization`'s fallback key).
4. Returns dhanam's **actual** `checkoutUrl` to the client (`checkout_url` — the field the dashboard redirects to), with `provider: "dhanam"`, `customer_id`: dhanam externalId, `plan_id`: the catalog id sent.
5. Keeps the local `CheckoutSession` row for audit (session_id = dhanam's session ref, `price_id` = catalog plan id, JSON metadata with dhanam customer/session refs). Best-effort: a local persistence hiccup doesn't block the payment flow.
6. `webhooks_dhanam.py` (subscription webhook) untouched.

## Config needed in prod (names only, values via Enclii secrets)

- `DHANAM_FEDERATION_URL` — dhanam API origin (e.g. the api.dhan.am origin; **not** `DHANAM_URL`, which points at the web frontend)
- `FEDERATION_API_TOKEN` — shared federation bearer token (ecosystem-standard name, same as RouteCraft/avala); added to the Vault-overridable secret fields in `config.py`

Activation dependencies on the dhanam side (operator, tracked elsewhere): provision a federation token for janua; enable `FEDERATION_CUSTOMER_PROVISIONING_ENABLED` for the janua flow (dhanam #624); land the priced `janua/pro` catalog tier (dhanam #627); register janua in `PRODUCT_WEBHOOK_URLS` for the entitlement round-trip.

## Tests

- `apps/api/tests/unit/routers/test_checkout_dhanam.py` — 38 tests: resolve→checkout call sequence + bearer header, plan-id qualification matrix, checkout URL passthrough, org metadata, audit row contents, empty-sessionId fallback, 400/403/404 gates (no dhanam traffic), 503 fail-closed config gate, and dhanam-side 409/403/5xx/unreachable error mapping (respx HTTP mocks).
- `pytest tests/unit/routers/ --no-cov`: **395 passed** (357 baseline + 38 new), 13 skipped — the 1 pre-existing failure + 19 pre-existing setup errors reproduce identically on the base commit (`c670a600`) and are ordering flakes in other files, unrelated to this change.
- `ruff check` clean on touched files; new files black-formatted (config.py's pre-existing black drift left alone to keep the diff reviewable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
