### PR TITLE
fix(website): janua /pricing renders + shows ratified $29 Managed tier

### DIFF
--- a/apps/website/components/sections/accurate-comparison.tsx
+++ b/apps/website/components/sections/accurate-comparison.tsx
@@ -135,7 +135,7 @@ const rows: Row[] = [
   },
   {
     feature: 'Paid entry tier (per month)',
-    janua: '$69 / 10k MAU',
+    janua: '$29 / 10k MAU',
     auth0: '$240+',
     clerk: '$25 + per-MAU',
     keycloak: 'Self-operate',
@@ -256,7 +256,7 @@ export function AccurateComparison() {
             </h3>
             <ul className="space-y-2 text-sm text-slate-600 dark:text-slate-400">
               <li>You keep the user table. Self-host on Postgres you operate.</li>
-              <li>One bill at $69/$299, not per-MAU metered SaaS pricing.</li>
+              <li>One flat bill at $29/$149, not per-MAU metered SaaS pricing.</li>
               <li>SCIM v2 + audit retention without an enterprise upsell.</li>
               <li>9 client SDKs in the same monorepo as the API.</li>
             </ul>

--- a/apps/website/components/sections/comparison.tsx
+++ b/apps/website/components/sections/comparison.tsx
@@ -86,16 +86,19 @@ export function ComparisonSection() {
           supabase: '50,000'
         },
         {
-          // Pro = $69/mo per PRICING_TIERS (apps/api). Includes 10,000 MAU.
-          metric: 'Pro Tier Price',
-          janua: '$69/mo',
+          // Managed (Pro) = $29/mo per the ratified packaging decision
+          // (internal-devops decisions/2026-07-11). Flat per project, up to
+          // 10,000 MAU under fair use.
+          metric: 'Paid Entry Price',
+          janua: '$29/mo',
           clerk: '$99/mo',
           auth0: '$240/mo',
           supabase: '$25/mo'
         },
         {
+          // Janua Pro is flat per-org, NOT per-MAU metered (ratified model).
           metric: 'Overage Cost/1k MAU',
-          janua: '$10',
+          janua: 'Flat, no meter',
           clerk: '$20',
           auth0: '$28',
           supabase: '$0.00325'

--- a/apps/website/components/sections/honest-pricing.tsx
+++ b/apps/website/components/sections/honest-pricing.tsx
@@ -18,14 +18,14 @@ interface PricingTier {
   honestNote?: string
 }
 
-// Pricing aligned with the canonical billing service tiers
-// (apps/api/app/services/billing_service.py PRICING_TIERS) and the
-// /pricing page (apps/website/components/sections/pricing.tsx).
+// Pricing aligned with the ratified enclii+janua packaging decision
+// (internal-devops decisions/2026-07-11-enclii-janua-packaging-ratification.md)
+// and the /pricing page (apps/website/components/sections/pricing.tsx).
 //
-// Community: Free, 2,000 MAU
-// Pro: $69/mo, 10,000 MAU
-// Scale: $299/mo, 50,000 MAU
-// Enterprise: Custom, Unlimited
+// Community (Open Source): Free, self-host, 2,000 MAU on managed
+// Pro (Managed):           $29/mo flat per project, up to 10,000 MAU (fair use)
+// Business (SSO):          $149/mo — design-partner / contract, NOT self-serve
+// Enterprise:              Custom, Unlimited
 const pricingTiers: PricingTier[] = [
   {
     name: 'Community',
@@ -51,9 +51,9 @@ const pricingTiers: PricingTier[] = [
   },
   {
     name: 'Pro',
-    price: '$69',
-    description: 'For growing startups and teams',
-    mau: '10,000 MAU',
+    price: '$29',
+    description: 'Managed hosting for growing startups and teams',
+    mau: 'Up to 10,000 MAU (flat, fair use)',
     badge: 'Most Popular',
     features: [
       'Everything in Community',
@@ -74,10 +74,11 @@ const pricingTiers: PricingTier[] = [
     honestNote: 'Scales with you as you find product-market fit'
   },
   {
-    name: 'Scale',
-    price: '$299',
-    description: 'For scale-ups with compliance needs',
-    mau: '50,000 MAU',
+    name: 'Business',
+    price: '$149',
+    description: 'SSO/SAML for compliance-driven teams',
+    mau: 'Higher volume',
+    badge: 'Design partner',
     features: [
       'Everything in Pro',
       'SSO/SAML',
@@ -93,7 +94,7 @@ const pricingTiers: PricingTier[] = [
       'No custom contracts',
       'No dedicated support'
     ],
-    honestNote: 'Enterprise-class security without enterprise pricing'
+    honestNote: 'Early access via our design-partner program — talk to us'
   },
   {
     name: 'Enterprise',
@@ -102,7 +103,7 @@ const pricingTiers: PricingTier[] = [
     mau: 'Unlimited',
     badge: 'Full Support',
     features: [
-      'Everything in Scale',
+      'Everything in Business',
       'SCIM provisioning',
       'Custom contracts & SLAs',
       'Dedicated support',
@@ -126,7 +127,7 @@ interface ComparisonRow {
   feature: string
   community: boolean | string
   pro: boolean | string
-  scale: boolean | string
+  business: boolean | string
   enterprise: boolean | string
 }
 
@@ -135,49 +136,49 @@ const detailedComparison: ComparisonRow[] = [
     feature: 'Monthly Active Users',
     community: '2,000',
     pro: '10,000',
-    scale: '50,000',
+    business: '50,000',
     enterprise: 'Unlimited'
   },
   {
     feature: 'Passkeys (WebAuthn)',
     community: true,
     pro: true,
-    scale: true,
+    business: true,
     enterprise: true
   },
   {
     feature: 'MFA/TOTP',
     community: false,
     pro: true,
-    scale: true,
+    business: true,
     enterprise: true
   },
   {
     feature: 'OAuth Providers',
     community: 'Email/password only',
     pro: 'Social (OAuth)',
-    scale: 'All',
+    business: 'All',
     enterprise: 'All + Custom'
   },
   {
     feature: 'Edge Response Time',
     community: '<30ms*',
     pro: '<30ms*',
-    scale: '<30ms*',
+    business: '<30ms*',
     enterprise: '<30ms*'
   },
   {
     feature: 'Support',
     community: 'Community',
     pro: 'Email',
-    scale: 'Priority',
+    business: 'Priority',
     enterprise: 'Dedicated'
   },
   {
     feature: 'SLA',
     community: false,
     pro: false,
-    scale: false,
+    business: false,
     // SLA is only offered at the Enterprise tier and is negotiated per
     // contract. No public uptime percentage until SRE on-call + SLO
     // definitions are in place.
@@ -187,14 +188,14 @@ const detailedComparison: ComparisonRow[] = [
     feature: 'SAML SSO',
     community: false,
     pro: false,
-    scale: true,
+    business: true,
     enterprise: true
   },
   {
     feature: 'Audit Log Retention',
     community: false,
     pro: '30 days',
-    scale: '90 days',
+    business: '90 days',
     enterprise: 'Unlimited'
   }
 ]
@@ -205,19 +206,27 @@ export function HonestPricing() {
 
   const yearlyDiscount = 0.2 // 20% off
 
-  const getPrice = (price: string) => {
+  // Business (SSO) is a design-partner / contract tier — not self-serve — so
+  // it is shown with its flat monthly price but no self-serve yearly discount.
+  const isContactTier = (tier: PricingTier) =>
+    tier.name === 'Business' || tier.price === 'Custom'
+
+  const getPrice = (tier: PricingTier) => {
+    const { price } = tier
     if (price === 'Free' || price === 'Custom') return price
     const numPrice = parseInt(price.replace('$', ''))
-    if (billingCycle === 'yearly') {
+    if (billingCycle === 'yearly' && !isContactTier(tier)) {
       const yearlyPrice = Math.round(numPrice * (1 - yearlyDiscount))
       return `$${yearlyPrice}`
     }
     return price
   }
 
-  const getPriceLabel = (price: string) => {
+  const getPriceLabel = (tier: PricingTier) => {
+    const { price } = tier
     if (price === 'Free') return ''
     if (price === 'Custom') return 'Contact us'
+    if (tier.name === 'Business') return '/mo · contact sales'
     return billingCycle === 'monthly' ? '/month' : '/month (billed annually)'
   }
 
@@ -304,10 +313,10 @@ export function HonestPricing() {
               <div className="mb-6">
                 <div className="flex items-baseline gap-1">
                   <span className="text-3xl font-bold text-slate-900 dark:text-white">
-                    {getPrice(tier.price)}
+                    {getPrice(tier)}
                   </span>
                   <span className="text-sm text-slate-600 dark:text-slate-400">
-                    {getPriceLabel(tier.price)}
+                    {getPriceLabel(tier)}
                   </span>
                 </div>
                 <p className="text-sm font-medium text-slate-700 dark:text-slate-300 mt-2">
@@ -356,16 +365,18 @@ export function HonestPricing() {
               >
                 <Link
                   href={
-                    tier.price === 'Custom'
+                    isContactTier(tier)
                       ? '/contact'
                       : `https://app.janua.dev/auth/signup${
-                          tier.name === 'Pro' || tier.name === 'Scale'
-                            ? `?plan=${tier.name.toLowerCase()}`
-                            : ''
+                          tier.name === 'Pro' ? '?plan=pro' : ''
                         }`
                   }
                 >
-                  {tier.price === 'Custom' ? 'Contact Sales' : 'Get Started'}
+                  {tier.price === 'Custom'
+                    ? 'Contact Sales'
+                    : tier.name === 'Business'
+                      ? 'Contact us'
+                      : 'Get Started'}
                 </Link>
               </Button>
             </motion.div>
@@ -402,7 +413,7 @@ export function HonestPricing() {
                     Pro
                   </th>
                   <th className="text-center p-4 font-semibold text-slate-900 dark:text-white">
-                    Scale
+                    Business
                   </th>
                   <th className="text-center p-4 font-semibold text-slate-900 dark:text-white">
                     Enterprise
@@ -445,15 +456,15 @@ export function HonestPricing() {
                       )}
                     </td>
                     <td className="p-4 text-center">
-                      {typeof row.scale === 'boolean' ? (
-                        row.scale ? (
+                      {typeof row.business === 'boolean' ? (
+                        row.business ? (
                           <Check className="w-4 h-4 text-green-600 mx-auto" />
                         ) : (
                           <X className="w-4 h-4 text-slate-400 mx-auto" />
                         )
                       ) : (
                         <span className="text-sm text-slate-600 dark:text-slate-400">
-                          {row.scale}
+                          {row.business}
                         </span>
                       )}
                     </td>
@@ -501,11 +512,12 @@ export function HonestPricing() {
 
             <div>
               <h4 className="font-medium text-slate-700 dark:text-slate-300 mb-2">
-                What happens if I exceed my MAU limit?
+                What happens if I exceed the 10,000 MAU fair-use cap?
               </h4>
               <p className="text-sm text-slate-600 dark:text-slate-400">
-                We'll notify you at 80% usage and help you upgrade. We never cut off authentication - your
-                users won't be affected. Overages are billed at standard rates with no penalties.
+                Pro is flat per project, not per-MAU metered. If you consistently run past the
+                fair-use cap we&apos;ll reach out to move you to Business or a custom plan. We never cut off
+                authentication - your users won&apos;t be affected.
               </p>
             </div>
 

--- a/apps/website/components/sections/pain-points.tsx
+++ b/apps/website/components/sections/pain-points.tsx
@@ -38,7 +38,7 @@ const pains = [
     pain_detail:
       'You don\'t want your identity layer behind a usage-based meter on someone else\'s database.',
     answer:
-      'Self-host under AGPL-3.0. User table stays in your Postgres. Free up to 2,000 MAU, $69 Pro, $299 Scale, custom Enterprise on the managed plan.',
+      'Self-host under AGPL-3.0. User table stays in your Postgres. Free up to 2,000 MAU, $29 Managed (Pro), $149 Business, custom Enterprise on the managed plan.',
   },
 ]
 

--- a/apps/website/components/sections/pricing.test.tsx
+++ b/apps/website/components/sections/pricing.test.tsx
@@ -11,8 +11,19 @@ describe('PricingSection', () => {
     render(<PricingSection />)
     expect(screen.getByText('Community')).toBeInTheDocument()
     expect(screen.getByText('Pro')).toBeInTheDocument()
-    expect(screen.getByText('Scale')).toBeInTheDocument()
+    expect(screen.getByText('Business')).toBeInTheDocument()
     expect(screen.getByText('Enterprise')).toBeInTheDocument()
+  })
+
+  it('should show the ratified Managed (Pro) $29 price', () => {
+    render(<PricingSection />)
+    expect(screen.getAllByText('$29').length).toBeGreaterThan(0)
+  })
+
+  it('should not show the retired $69 / $299 prices', () => {
+    render(<PricingSection />)
+    expect(screen.queryByText('$69')).not.toBeInTheDocument()
+    expect(screen.queryByText('$299')).not.toBeInTheDocument()
   })
 
   it('should show annual/monthly toggle', () => {

--- a/apps/website/components/sections/pricing.tsx
+++ b/apps/website/components/sections/pricing.tsx
@@ -2,15 +2,27 @@
 
 import { useState } from 'react'
 import { motion } from 'framer-motion'
-import { Check, X, ArrowRight } from 'lucide-react'
+import { Check, X, ArrowRight, AlertCircle } from 'lucide-react'
 import { Button } from '@janua/ui'
 import Link from 'next/link'
 import { cn } from '@/lib/utils'
 
+type Plan = {
+  name: string
+  description: string
+  price: { monthly: number | string; annual: number | string }
+  featured: boolean
+  cta: string
+  href: string
+  note?: string
+  features: string[]
+  limitations: string[]
+}
+
 export function PricingSection() {
   const [isAnnual, setIsAnnual] = useState(false)
 
-  const plans = [
+  const plans: Plan[] = [
     {
       name: 'Community',
       description: 'Perfect for side projects and MVPs',
@@ -36,13 +48,16 @@ export function PricingSection() {
     },
     {
       name: 'Pro',
-      description: 'For growing startups and teams',
-      price: { monthly: 69, annual: 59 },
+      description: 'Managed hosting for growing startups and teams',
+      // Ratified packaging (internal-devops decisions/2026-07-11): janua
+      // Managed (Pro) = $29/mo (MX$499 gross). Flat per-org, NOT per-MAU —
+      // up to 10,000 MAU under fair use. Yearly ≈ 2 months free.
+      price: { monthly: 29, annual: 24 },
       featured: true,
-      cta: 'Start 14-day trial',
+      cta: 'Get started',
       href: 'https://app.janua.dev/auth/signup?plan=pro',
       features: [
-        '10,000 monthly active users',
+        'Up to 10,000 MAU (flat, fair use)',
         'Everything in Community',
         'Social logins (OAuth)',
         'Organizations & RBAC',
@@ -65,14 +80,17 @@ export function PricingSection() {
       ]
     },
     {
-      name: 'Scale',
-      description: 'For scale-ups with compliance needs',
-      price: { monthly: 299, annual: 249 },
+      name: 'Business',
+      description: 'SSO/SAML for compliance-driven teams',
+      // Ratified packaging (internal-devops decisions/2026-07-11): janua
+      // Business (SSO) = $149/mo, deferred to phase 2 — design-partner /
+      // contract motion first, NOT self-serve. CTA routes to /contact.
+      price: { monthly: 149, annual: 149 },
       featured: false,
-      cta: 'Start 14-day trial',
-      href: 'https://app.janua.dev/auth/signup?plan=scale',
+      cta: 'Contact us',
+      href: '/contact',
+      note: 'Early access via our design-partner program.',
       features: [
-        '50,000 monthly active users',
         'Everything in Pro',
         'SSO/SAML',
         'Advanced security policies',
@@ -100,7 +118,7 @@ export function PricingSection() {
       href: '/contact',
       features: [
         'Unlimited MAU',
-        'Everything in Scale',
+        'Everything in Business',
         'SCIM provisioning',
         'Custom contracts & SLAs',
         'Dedicated support',
@@ -130,10 +148,16 @@ export function PricingSection() {
           <h1 className="text-5xl font-bold text-gray-900 dark:text-white mb-4">
             Simple, transparent pricing
           </h1>
-          <p className="text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto mb-8">
+          <p className="text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto mb-4">
             Start free with 2,000 MAU. No credit card required.
-            Scale as you grow with predictable pricing.
+            Flat, per-project pricing as you grow — not per-user metering.
           </p>
+
+          {/* Honest positioning — mirrors the home page HonestPricing note. */}
+          <div className="mb-8 inline-flex items-center gap-2 text-sm text-amber-600 dark:text-amber-400">
+            <AlertCircle className="w-4 h-4" />
+            <span>Currently in Private Alpha. Managed billing is rolling out — self-host stays free.</span>
+          </div>
 
           {/* Billing toggle */}
           <div className="flex items-center justify-center gap-4">
@@ -208,7 +232,7 @@ export function PricingSection() {
                   <span className="text-gray-600 dark:text-gray-400 ml-2">
                     /month
                   </span>
-                  {isAnnual && typeof plan.price.monthly === 'number' && plan.price.monthly > 0 && typeof plan.price.annual === 'number' && (
+                  {isAnnual && typeof plan.price.monthly === 'number' && plan.price.monthly > 0 && typeof plan.price.annual === 'number' && plan.price.annual < plan.price.monthly && (
                     <div className="text-sm text-gray-500 mt-1">
                       <span className="line-through">${plan.price.monthly * 12}</span>
                       <span className="ml-2 text-green-600 dark:text-green-400">
@@ -221,6 +245,11 @@ export function PricingSection() {
                 <span className="text-3xl font-bold text-gray-900 dark:text-white">
                   {plan.price.monthly}
                 </span>
+              )}
+              {plan.note && (
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+                  {plan.note}
+                </p>
               )}
             </div>
 
@@ -269,40 +298,40 @@ export function PricingSection() {
         className="mt-16 p-8 bg-gray-50 dark:bg-gray-900 rounded-2xl"
       >
         <h3 className="text-2xl font-bold text-gray-900 dark:text-white mb-6 text-center">
-          Overage Pricing
+          Flat pricing, no per-user meter
         </h3>
         <div className="grid md:grid-cols-3 gap-8">
           <div className="text-center">
             <div className="text-3xl font-bold text-blue-600 dark:text-blue-400 mb-2">
-              $10
+              $0
             </div>
             <div className="text-sm text-gray-600 dark:text-gray-400">
-              per 1,000 additional MAU
+              Self-host under AGPL-3.0
             </div>
             <div className="text-xs text-gray-500 mt-1">
-              Pro tier
+              Any scale, forever
             </div>
           </div>
           <div className="text-center">
             <div className="text-3xl font-bold text-blue-600 dark:text-blue-400 mb-2">
-              $8
+              $29
             </div>
             <div className="text-sm text-gray-600 dark:text-gray-400">
-              per 1,000 additional MAU
+              Flat per project, up to 10,000 MAU (fair use)
             </div>
             <div className="text-xs text-gray-500 mt-1">
-              Scale tier
+              Managed (Pro) tier
             </div>
           </div>
           <div className="text-center">
             <div className="text-3xl font-bold text-blue-600 dark:text-blue-400 mb-2">
-              Custom
+              Talk to us
             </div>
             <div className="text-sm text-gray-600 dark:text-gray-400">
-              Volume discounts available
+              Higher volume or SSO/SAML needs
             </div>
             <div className="text-xs text-gray-500 mt-1">
-              Enterprise tier
+              Business &amp; Enterprise
             </div>
           </div>
         </div>
@@ -339,11 +368,11 @@ export function PricingSection() {
           </div>
           <div>
             <h4 className="font-semibold text-gray-900 dark:text-white mb-2">
-              Do you offer startup discounts?
+              Do you offer startup or design-partner discounts?
             </h4>
             <p className="text-sm text-gray-600 dark:text-gray-400">
-              Yes! Startups in accelerators or with less than $1M funding can get 
-              50% off Pro tier for the first year. Contact us for details.
+              Yes. While we&apos;re in Private Alpha we run a design-partner program:
+              a reduced rate on Managed (Pro) in exchange for feedback. Contact us for details.
             </p>
           </div>
           <div>


### PR DESCRIPTION
## Summary

Two confirmed prod bugs on `janua.dev/pricing`, fixed in `apps/website` only (scope-limited — no changes to `apps/api`, `apps/dashboard`, or `packages/ui`).

### 1. `/pricing` 404 root cause → **deploy-lag, not a code/build error**

The route `app/(marketing)/pricing/page.tsx` exists on `origin/main`, imports resolve, and it builds cleanly. `pnpm --filter @janua/website build` prerenders it:

```
├ ○ /pricing
```

So the prod 404 is **deployment lag**: production runs an older `janua-website` image that predates the pricing route. The production overlay (`k8s/overlays/production/kustomization.yaml`) pins a `janua-website` digest that is only advanced by `promote-to-prod.yml`. **A website re-promote is required** to actually serve `/pricing` in prod — no code change can fix that from this repo. This PR still corrects the price numbers so the promoted image is correct.

### 2. Hardcoded `$69` / `$299` → ratified packaging

Aligned every live price surface to `internal-devops decisions/2026-07-11-enclii-janua-packaging-ratification.md`:

| Tier | Before | After |
|------|--------|-------|
| Open Source / Community | $0 | $0 (unchanged) |
| **Managed (Pro)** | **$69/mo** | **$29/mo** — flat per project, up to 10,000 MAU (fair use), **not** per-MAU metered |
| **Business (SSO)** | Scale **$299/mo** self-serve | **$149/mo** — design-partner / contract, CTA routes to `/contact` (**not** self-serve signup) |
| Enterprise | Custom | Custom (unchanged) |

### CTA plan intent

The paid Pro CTA carries `?plan=pro` to `https://app.janua.dev/auth/signup` (the self-serve signup route that now exists). Business & Enterprise route to `/contact`.

## What changed

- `components/sections/pricing.tsx` — the `/pricing` page. Pro $69→$29 (annual 59→24, ≈2 months free), Scale→Business $299→$149 with `Contact us` CTA to `/contact`, added the "Private Alpha" honest note, replaced the now-inaccurate per-MAU overage grid with flat/fair-use messaging, softened the startup-discount FAQ to the design-partner program.
- `components/sections/honest-pricing.tsx` — the home page. Same price/tier corrections; Business treated as a contact/design-partner tier (no self-serve yearly discount); comparison table `Scale`→`Business`.
- `components/sections/comparison.tsx`, `accurate-comparison.tsx`, `pain-points.tsx` — swept remaining `$69`/`$299` copy and per-MAU claims to the flat $29/$149 model.
- `components/sections/pricing.test.tsx` — `Scale`→`Business`; asserts `$29` present and `$69`/`$299` absent.

## Validation

- `pnpm --filter @janua/website build` — green; `/pricing` prerendered; TypeScript passed.
- `pricing.test.tsx` + `comparison.test.tsx` — 8/8 pass. (Other pre-existing failing suites — Playwright specs in `tests-e2e/` picked up by jest, and demo-component tests — are untouched by this PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)