### PR TITLE
deploy(prod): promote janua-website #454 (/pricing $29)

### DIFF
--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -32,4 +32,4 @@ images:
     digest: sha256:0c4373cd8c879680a6f49da55171696660f677d26dd4e4d06521c2e6fa533bb3
   - name: ghcr.io/madfam-org/janua-website
     newName: ghcr.io/madfam-org/janua-website
-    digest: sha256:506404e72f4553461bee651cc508e50e24b881b2993511d52f583e5b24dde85f
+    digest: sha256:e0bbb5aa4e37a3f5561bf8b4279f0839364762d49e0c47048df111d38fcf8c7c


### PR DESCRIPTION
Manual website promote via the PP.3b workflow-gap path (same as #452). Advances the prod `janua-website` digest to the latest main build (20b88a4e = #454), which fixes /pricing to render with the ratified **$29 Managed** tier (prod currently serves the older #449/#451 build). Digest `e0bbb5aa` resolved from `ghcr.io/madfam-org/janua-website:main`. ArgoCD syncs on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)