### PR TITLE
feat(k8s): wire Dhanam federation relay env into janua-api (Gate A env side)

### DIFF
--- a/k8s/base/deployments/janua-api.yaml
+++ b/k8s/base/deployments/janua-api.yaml
@@ -98,6 +98,19 @@ spec:
                 secretKeyRef:
                   name: janua-secrets
                   key: dhanam-webhook-secret
+            # Dhanam customer-federation checkout relay (#453). The relay
+            # fails closed (503 "Billing is not configured") unless BOTH
+            # DHANAM_FEDERATION_URL and FEDERATION_API_TOKEN resolve
+            # (_federation_configured in checkout_dhanam.py), so the optional
+            # token ref is crash-safe in envs the operator hasn't provisioned.
+            - name: DHANAM_FEDERATION_URL
+              value: 'https://api.dhan.am'
+            - name: FEDERATION_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: janua-secrets
+                  key: federation-api-token
+                  optional: true
             - name: JANUA_SERVICE_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/k8s/overlays/staging/env-patch-api.yaml
+++ b/k8s/overlays/staging/env-patch-api.yaml
@@ -70,6 +70,11 @@ spec:
                   name: janua-staging-secrets
                   key: metrics-token
                   optional: true
+            # Keep the Dhanam federation relay hard-off in staging: an empty
+            # URL fails _federation_configured() regardless of any token, so
+            # staging can never provision customers against prod Dhanam.
+            - name: DHANAM_FEDERATION_URL
+              value: ''
             - name: RESEND_API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## What
- `janua-api` base deployment: add `DHANAM_FEDERATION_URL=https://api.dhan.am` + `FEDERATION_API_TOKEN` as an **optional** ref to `janua-secrets/federation-api-token` (crash-safe: relay keeps failing closed 503 until the key exists).
- Staging overlay: pin `DHANAM_FEDERATION_URL: ""` so `_federation_configured()` can never pass in staging — staging cannot provision customers against prod Dhanam.

## Why
The #453 checkout relay is dead in prod: neither env reaches the pod, so every `/v1/checkout/dhanam` call 503s ('Billing is not configured'). This is the env half of Gate A from the internal-devops 2026-07-11 enclii+janua GA operator runbook.

## Operator companion (not in this PR — secret-store change)
`janua-secrets` (ns `janua`) needs key `federation-api-token` set to the canonical value held in `dhanam-secrets/FEDERATION_API_TOKEN`. Note: the `janua-secrets` ExternalSecret is currently in SecretSyncedError (pre-existing), so the live secret is effectively operator-managed; the durable home for the value is Vault `secret/janua`.

## Verified
- `kustomize build` clean for `k8s/overlays/production` and `k8s/overlays/staging`
- Staging render shows the empty-URL override winning
- Relay gating confirmed in code: `_federation_configured()` requires both vars (apps/api/app/routers/v1/checkout_dhanam.py:131-132)

🤖 Generated with [Claude Code](https://claude.com/claude-code)