### PR TITLE
fix(billing+auth): correct verify-email URL + align Pro pricing to $29/MX$499

### DIFF
--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -49,7 +49,11 @@ class Settings(BaseSettings):
     )
     DOMAIN: str = Field(default="localhost")
     UPLOAD_DIR: str = Field(default="/tmp/uploads")
-    FRONTEND_URL: Optional[str] = Field(default="http://localhost:3000")
+    # Dashboard app URL (app.janua.dev), used for verification/invitation/security
+    # links. Matches the fallback already used in app/services/email/notifications.py
+    # — a localhost default here would break those links in any deployment that
+    # forgets to set FRONTEND_URL explicitly.
+    FRONTEND_URL: Optional[str] = Field(default="https://app.janua.dev")
 
     # Database
     DATABASE_URL: str = Field(

--- a/apps/api/app/services/billing_service.py
+++ b/apps/api/app/services/billing_service.py
@@ -29,8 +29,10 @@ PRICING_TIERS = {
         "features": ["basic_auth", "email_support", "standard_integrations"],
     },
     "pro": {
-        "price_mxn": 1380,  # ~$69 USD at 20 MXN/USD
-        "price_usd": 69,
+        # Ratified packaging (internal-devops decisions/2026-07-11): janua
+        # Managed (Pro) = $29/mo (MX$499 gross), flat per-org.
+        "price_mxn": 499,
+        "price_usd": 29,
         "mau_limit": 10000,
         "features": ["everything_community", "advanced_rbac", "custom_domains", "webhooks", "sso"],
     },

--- a/apps/api/app/services/email_service.py
+++ b/apps/api/app/services/email_service.py
@@ -63,8 +63,11 @@ class EmailService:
                 token_key, 24 * 60 * 60, json.dumps(token_data)
             )  # 24 hours
 
-        # Generate verification URL
-        verification_url = f"{settings.BASE_URL}/auth/verify-email?token={verification_token}"
+        # Generate verification URL. This must point at the dashboard app
+        # (FRONTEND_URL, app.janua.dev), which serves /auth/verify-email —
+        # not BASE_URL (janua.dev), the marketing site, which has no such
+        # route and 404s.
+        verification_url = f"{settings.FRONTEND_URL}/auth/verify-email?token={verification_token}"
 
         # Prepare email content
         template_data = {

--- a/apps/api/tests/unit/services/test_billing_service.py
+++ b/apps/api/tests/unit/services/test_billing_service.py
@@ -42,9 +42,9 @@ class TestPricingTiers:
         assert PRICING_TIERS["community"]["price_usd"] == 0
 
     def test_pro_tier_pricing(self):
-        """Test pro tier pricing."""
-        assert PRICING_TIERS["pro"]["price_mxn"] == 1380
-        assert PRICING_TIERS["pro"]["price_usd"] == 69
+        """Test pro tier pricing (ratified: $29 / MX$499)."""
+        assert PRICING_TIERS["pro"]["price_mxn"] == 499
+        assert PRICING_TIERS["pro"]["price_usd"] == 29
 
     def test_scale_tier_pricing(self):
         """Test scale tier pricing."""

--- a/apps/api/tests/unit/services/test_billing_service_comprehensive.py
+++ b/apps/api/tests/unit/services/test_billing_service_comprehensive.py
@@ -41,10 +41,10 @@ class TestBillingServiceInitialization:
         assert community["mau_limit"] == 2000
         assert "basic_auth" in community["features"]
 
-        # Validate pro tier
+        # Validate pro tier (ratified: $29 / MX$499)
         pro = PRICING_TIERS["pro"]
-        assert pro["price_mxn"] == 1380
-        assert pro["price_usd"] == 69
+        assert pro["price_mxn"] == 499
+        assert pro["price_usd"] == 29
         assert pro["mau_limit"] == 10000
 
 
@@ -264,7 +264,7 @@ class TestPricingAndValidation:
         assert "scale" in pricing["tiers"]
         assert "enterprise" in pricing["tiers"]
         assert pricing["tiers"]["community"]["price"] == 0
-        assert pricing["tiers"]["pro"]["price"] == 1380
+        assert pricing["tiers"]["pro"]["price"] == 499
         assert pricing["tiers"]["scale"]["price"] == 5980
         assert pricing["currency"] == "MXN"
         assert pricing["provider"] == "conekta"
@@ -279,7 +279,7 @@ class TestPricingAndValidation:
         assert "scale" in pricing["tiers"]
         assert "enterprise" in pricing["tiers"]
         assert pricing["tiers"]["community"]["price"] == 0
-        assert pricing["tiers"]["pro"]["price"] == 69
+        assert pricing["tiers"]["pro"]["price"] == 29
         assert pricing["tiers"]["scale"]["price"] == 299
         assert pricing["currency"] == "USD"
         assert pricing["provider"] == "polar"

--- a/apps/api/tests/unit/services/test_email_service.py
+++ b/apps/api/tests/unit/services/test_email_service.py
@@ -280,6 +280,26 @@ class TestSendVerificationEmail:
 
         assert "Failed to send verification email" in str(exc_info.value)
 
+    async def test_send_verification_url_points_to_dashboard_app(self, service):
+        """Verification link must target FRONTEND_URL (app.janua.dev, which
+        serves /auth/verify-email) — not BASE_URL (janua.dev, the marketing
+        site with no such route, which 404s)."""
+        with patch("app.services.email_service.settings") as mock_settings:
+            mock_settings.FRONTEND_URL = "https://app.janua.dev"
+            mock_settings.BASE_URL = "https://janua.dev"
+            mock_settings.SUPPORT_EMAIL = None
+
+            with patch.object(service, "_send_email", return_value=True):
+                with patch.object(
+                    service, "_render_template", return_value="content"
+                ) as mock_render:
+                    token = await service.send_verification_email(email="test@example.com")
+
+        rendered_data = mock_render.call_args_list[0].args[1]
+        assert rendered_data["verification_url"] == (
+            f"https://app.janua.dev/auth/verify-email?token={token}"
+        )
+
 
 class TestVerifyEmailToken:
     """Test email token verification."""

--- a/apps/dashboard/app/auth/verify-email/page.test.tsx
+++ b/apps/dashboard/app/auth/verify-email/page.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+
+const mockVerifyEmail = jest.fn()
+
+// Mock next/navigation
+const mockSearchParams = new URLSearchParams()
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => mockSearchParams,
+}))
+
+jest.mock('next/link', () => {
+  return ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  )
+})
+
+// Mock @janua/ui
+jest.mock('@janua/ui', () => ({
+  Card: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  Button: ({ children, asChild, ...props }: any) =>
+    asChild ? children : <button {...props}>{children}</button>,
+}))
+
+jest.mock('@/lib/janua-client', () => ({
+  januaClient: {
+    auth: {
+      verifyEmail: (...args: unknown[]) => mockVerifyEmail(...args),
+    },
+  },
+}))
+
+import VerifyEmailPage from './page'
+
+describe('VerifyEmailPage', () => {
+  beforeEach(() => {
+    mockVerifyEmail.mockReset()
+    mockSearchParams.forEach((_, key) => mockSearchParams.delete(key))
+  })
+
+  it('shows an error state when no token is present in the URL', async () => {
+    render(<VerifyEmailPage />)
+
+    expect(await screen.findByText('Verification failed')).toBeInTheDocument()
+    expect(mockVerifyEmail).not.toHaveBeenCalled()
+  })
+
+  it('verifies the token from the URL and shows success', async () => {
+    mockSearchParams.set('token', 'valid-token')
+    mockVerifyEmail.mockResolvedValue({ message: 'Email successfully verified' })
+
+    render(<VerifyEmailPage />)
+
+    await waitFor(() => expect(mockVerifyEmail).toHaveBeenCalledWith('valid-token'))
+    expect(await screen.findByText('Email verified')).toBeInTheDocument()
+  })
+
+  it('shows an error state when verification fails', async () => {
+    mockSearchParams.set('token', 'expired-token')
+    mockVerifyEmail.mockRejectedValue(new Error('Invalid or expired verification token'))
+
+    render(<VerifyEmailPage />)
+
+    expect(await screen.findByText('Invalid or expired verification token')).toBeInTheDocument()
+  })
+})

--- a/apps/dashboard/app/auth/verify-email/page.tsx
+++ b/apps/dashboard/app/auth/verify-email/page.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import { Suspense, useEffect, useState } from 'react'
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+import { Button, Card, CardContent, CardDescription, CardHeader, CardTitle } from '@janua/ui'
+import { CheckCircle2, Loader2, ShieldAlert, ShieldCheck } from 'lucide-react'
+import { januaClient } from '@/lib/janua-client'
+
+type VerifyStatus = 'verifying' | 'success' | 'error' | 'missing-token'
+
+// Target of the link sent by POST /api/v1/auth/signup (see
+// apps/api/app/services/email_service.py send_verification_email). Public
+// route (see middleware.ts PUBLIC_ROUTES) — verification must work for a
+// signed-out visitor who opened the email link in a fresh browser/session.
+function VerifyEmailFlow() {
+  const searchParams = useSearchParams()
+  const token = searchParams.get('token')
+
+  const [status, setStatus] = useState<VerifyStatus>(token ? 'verifying' : 'missing-token')
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!token) return
+
+    let cancelled = false
+    januaClient.auth
+      .verifyEmail(token)
+      .then(() => {
+        if (!cancelled) setStatus('success')
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return
+        setError(
+          err instanceof Error && err.message
+            ? err.message
+            : 'The verification link is invalid or has expired.'
+        )
+        setStatus('error')
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [token])
+
+  if (status === 'verifying') {
+    return (
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="mb-2 flex justify-center">
+            <Loader2 className="text-primary size-10 animate-spin" />
+          </div>
+          <CardTitle className="text-2xl">Verifying your email</CardTitle>
+          <CardDescription>Hang on while we confirm your verification link...</CardDescription>
+        </CardHeader>
+      </Card>
+    )
+  }
+
+  if (status === 'success') {
+    return (
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="mb-2 flex justify-center">
+            <CheckCircle2 className="size-10 text-green-600 dark:text-green-400" />
+          </div>
+          <CardTitle className="text-2xl">Email verified</CardTitle>
+          <CardDescription>Your email address has been successfully verified.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button className="w-full" asChild>
+            <Link href="/">Continue to dashboard</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  // 'error' | 'missing-token'
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader className="text-center">
+        <div className="mb-2 flex justify-center">
+          <ShieldAlert className="text-destructive size-10" />
+        </div>
+        <CardTitle className="text-2xl">Verification failed</CardTitle>
+        <CardDescription>
+          {status === 'missing-token'
+            ? 'This verification link is missing its token. Please use the link from your email.'
+            : error || 'The verification link is invalid or has expired.'}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Button className="w-full" asChild>
+          <Link href="/login">Continue to sign in</Link>
+        </Button>
+        <p className="text-muted-foreground text-center text-xs">
+          You can request a new verification email from your account settings after signing in.
+        </p>
+      </CardContent>
+    </Card>
+  )
+}
+
+function VerifyEmailFallback() {
+  return (
+    <Card className="w-full max-w-md">
+      <CardHeader className="text-center">
+        <div className="mb-2 flex justify-center">
+          <ShieldCheck className="text-primary size-10" />
+        </div>
+        <CardTitle className="text-2xl">Verify your email</CardTitle>
+        <CardDescription>Loading...</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="flex justify-center py-8">
+          <Loader2 className="text-primary size-8 animate-spin" />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default function VerifyEmailPage() {
+  return (
+    <div className="bg-background flex min-h-screen items-center justify-center p-4">
+      <Suspense fallback={<VerifyEmailFallback />}>
+        <VerifyEmailFlow />
+      </Suspense>
+    </div>
+  )
+}

--- a/apps/dashboard/app/settings/billing/page.tsx
+++ b/apps/dashboard/app/settings/billing/page.tsx
@@ -94,7 +94,7 @@ interface PlanDetails {
 // Source of truth for prices and MAU caps:
 //   apps/api/app/services/billing_service.py → PRICING_TIERS
 // Community: free, 2,000 MAU
-// Pro:       $69 / 1,380 MXN, 10,000 MAU
+// Pro:       $29 / MX$499, 10,000 MAU (ratified internal-devops decisions/2026-07-11)
 // Scale:     $299 / 5,980 MXN, 50,000 MAU
 // Enterprise: custom
 //
@@ -121,7 +121,7 @@ const plans: PlanDetails[] = [
   {
     id: 'pro',
     name: 'Pro',
-    price: '$69',
+    price: '$29',
     period: '/month',
     description: 'For growing teams that need more power and flexibility.',
     features: [

--- a/apps/dashboard/middleware.ts
+++ b/apps/dashboard/middleware.ts
@@ -33,6 +33,7 @@ function isValidTokenStructure(token: string | null | undefined): boolean {
 const PUBLIC_ROUTES = [
   '/login',
   '/auth/signup',
+  '/auth/verify-email',
   '/api/',
   '/_next/',
   '/favicon.ico',


### PR DESCRIPTION
## What
Two paid-funnel fixes: correct the email-verification link target, and align every displayed Pro price to the ratified $29 / MX$499.

## Changes
- Fix the verification URL in the mounted auth router to a served page.
- Align dashboard billing + pricing constants to $29 / MX$499. (Note: `app/auth/router.py`/`router_completed.py` carry a similar pattern but are not mounted in `main.py` — confirmed dead code, left untouched.)

## Verified
tests adjusted where present. **Reviewable PR — do not merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
