### PR TITLE
fix(auth): allow crm.madfam.io portal hosts as safe redirect origins

### DIFF
--- a/k8s/base/deployments/janua-api.yaml
+++ b/k8s/base/deployments/janua-api.yaml
@@ -153,7 +153,7 @@ spec:
             # CORS - All allowed frontend origins
             - name: CORS_ORIGINS
               # Non-core app origins auto-derived from OAuth client redirect_uris via DynamicCORSMiddleware
-              value: "https://admin.janua.dev,https://app.janua.dev,https://api.enclii.dev,https://app.enclii.dev,https://admin.enclii.dev,https://auth.madfam.io,https://tezca.mx,https://admin.tezca.mx,https://www.tezca.mx,https://madfam.io,https://www.madfam.io,https://dhanam.madfam.io,https://forgesight.madfam.io,https://forgesight.quest,https://www.forgesight.quest,https://app.forgesight.quest,https://admin.forgesight.quest,https://pravara.madfam.io,https://dhan.am,https://app.dhan.am,https://rondel.io,https://fortuna.tube,https://selva.town,https://ceq.lol"
+              value: "https://admin.janua.dev,https://app.janua.dev,https://api.enclii.dev,https://app.enclii.dev,https://admin.enclii.dev,https://auth.madfam.io,https://tezca.mx,https://admin.tezca.mx,https://www.tezca.mx,https://madfam.io,https://www.madfam.io,https://dhanam.madfam.io,https://forgesight.madfam.io,https://forgesight.quest,https://www.forgesight.quest,https://app.forgesight.quest,https://admin.forgesight.quest,https://pravara.madfam.io,https://dhan.am,https://app.dhan.am,https://rondel.io,https://fortuna.tube,https://selva.town,https://ceq.lol,https://crm.madfam.io,https://staging-crm.madfam.io"
             # Cookie domain for cross-subdomain SSO (*.madfam.io for auth.madfam.io)
             - name: COOKIE_DOMAIN
               value: ".madfam.io"


### PR DESCRIPTION
## What
Adds `https://crm.madfam.io` and `https://staging-crm.madfam.io` to `CORS_ORIGINS` in the base janua-api deployment.

## Why
`is_safe_redirect_url()` builds its allowed-redirect-host set from `CORS_ORIGINS` (`get_allowed_redirect_hosts`, `app/core/url_security.py`). The PhyndCRM client-portal magic-link flow redirects to `crm.madfam.io/portal/verify`, which was **not** in the list — so Janua rejected the redirect and the portal magic-link login was blocked in production. Both added hosts are trusted MADFAM origins, so there's no open-redirect exposure.

## Verified
Diagnosed + confirmed by `phynd-crm/scripts/verify-janua-portal-redirect.mjs` (returned FAIL for both origins pre-fix). `kustomize build` clean. I'll re-run that verification after this deploys to confirm PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)