### PR TITLE
fix(admin): verify access token in session bridge (close cookie-spoof edge-gate bypass)

### DIFF
--- a/apps/admin/app/api/auth/session/route.test.ts
+++ b/apps/admin/app/api/auth/session/route.test.ts
@@ -3,6 +3,7 @@
  */
 
 import { POST, DELETE } from './route'
+import { jwtVerify } from 'jose'
 
 // Capture every cookies().set() call so we can assert flags.
 type CookieCall = {
@@ -42,6 +43,25 @@ jest.mock('next/server', () => {
   return { NextResponse: FakeNextResponse }
 })
 
+// Stub jose so tests never hit a network JWKS. `jwtVerify` is the seam: the
+// route trusts ONLY what this returns, never the request body's email/roles.
+jest.mock('jose', () => ({
+  createRemoteJWKSet: jest.fn(() => jest.fn()),
+  jwtVerify: jest.fn(),
+}))
+
+const mockJwtVerify = jwtVerify as unknown as jest.Mock
+
+/** Make jwtVerify resolve with the given verified claims. */
+function verifiedClaims(claims: Record<string, unknown>) {
+  mockJwtVerify.mockResolvedValueOnce({ payload: claims, protectedHeader: { alg: 'RS256' } })
+}
+
+/** Make jwtVerify reject as if the token were forged/expired. */
+function rejectVerification(message = 'signature verification failed') {
+  mockJwtVerify.mockRejectedValueOnce(new Error(message))
+}
+
 function makeRequest(body: unknown, opts: { malformed?: boolean } = {}): any {
   return {
     json: jest.fn(async () => {
@@ -54,20 +74,19 @@ function makeRequest(body: unknown, opts: { malformed?: boolean } = {}): any {
 describe('POST /api/auth/session', () => {
   beforeEach(() => {
     cookieCalls.length = 0
+    mockJwtVerify.mockReset()
     delete (process.env as any).NODE_ENV
   })
 
-  it('sets HttpOnly, Lax, path=/ cookies for access token, email, and roles', async () => {
+  it('sets HttpOnly, Lax, path=/ cookies from VERIFIED token claims', async () => {
     ;(process.env as any).NODE_ENV = 'production'
-    const future = Math.floor(Date.now() / 1000) + 3600
+    const exp = Math.floor(Date.now() / 1000) + 3600
+    verifiedClaims({ email: 'ops@janua.dev', roles: ['superadmin', 'admin'], exp })
 
     const res: any = await POST(
       makeRequest({
         access_token: 'jwt-abc',
         refresh_token: 'refresh-xyz',
-        email: 'ops@janua.dev',
-        roles: ['superadmin', 'admin'],
-        expires_at: future,
       })
     )
 
@@ -87,35 +106,57 @@ describe('POST /api/auth/session', () => {
     expect(byName.janua_access_token.options.maxAge).toBeLessThanOrEqual(3600)
 
     expect(byName.janua_admin_email.value).toBe('ops@janua.dev')
-    expect(byName.janua_admin_email.options).toMatchObject({
-      httpOnly: true,
-      secure: true,
-      sameSite: 'lax',
-      path: '/',
-    })
-
     expect(byName.janua_admin_roles.value).toBe('superadmin,admin')
-    expect(byName.janua_admin_roles.options).toMatchObject({
-      httpOnly: true,
-      secure: true,
-      sameSite: 'lax',
-      path: '/',
-    })
-
     expect(byName.janua_refresh_token.value).toBe('refresh-xyz')
     expect(byName.janua_refresh_token.options.httpOnly).toBe(true)
   })
 
-  it('marks Secure=false outside production so dev http://localhost works', async () => {
-    ;(process.env as any).NODE_ENV = 'development'
+  it('IGNORES spoofed email/roles in the body — trusts only the verified token', async () => {
+    verifiedClaims({ email: 'realuser@janua.dev', roles: ['viewer'], exp: Math.floor(Date.now() / 1000) + 3600 })
 
-    await POST(
+    const res: any = await POST(
       makeRequest({
         access_token: 'jwt-abc',
-        email: 'ops@janua.dev',
-        roles: ['admin'],
+        // Attacker-supplied escalation attempt — must be discarded.
+        email: 'attacker@evil.example',
+        roles: ['superadmin'],
       })
     )
+
+    expect(res.status).toBe(200)
+    const byName = Object.fromEntries(cookieCalls.map((c) => [c.name, c]))
+    expect(byName.janua_admin_email.value).toBe('realuser@janua.dev')
+    expect(byName.janua_admin_roles.value).toBe('viewer')
+  })
+
+  it('rejects a forged/expired token with 401 and sets no cookies (fail-closed)', async () => {
+    rejectVerification()
+
+    const res: any = await POST(
+      makeRequest({
+        access_token: 'forged',
+        email: 'ops@janua.dev',
+        roles: ['superadmin'],
+      })
+    )
+
+    expect(res.status).toBe(401)
+    expect(cookieCalls).toHaveLength(0)
+  })
+
+  it('rejects a verified token missing an email claim with 401', async () => {
+    verifiedClaims({ roles: ['admin'], exp: Math.floor(Date.now() / 1000) + 3600 })
+
+    const res: any = await POST(makeRequest({ access_token: 'jwt-no-email' }))
+    expect(res.status).toBe(401)
+    expect(cookieCalls).toHaveLength(0)
+  })
+
+  it('marks Secure=false outside production so dev http://localhost works', async () => {
+    ;(process.env as any).NODE_ENV = 'development'
+    verifiedClaims({ email: 'ops@janua.dev', roles: ['admin'], exp: Math.floor(Date.now() / 1000) + 3600 })
+
+    await POST(makeRequest({ access_token: 'jwt-abc' }))
 
     const access = cookieCalls.find((c) => c.name === 'janua_access_token')!
     expect(access.options.secure).toBe(false)
@@ -123,59 +164,58 @@ describe('POST /api/auth/session', () => {
     expect(access.options.sameSite).toBe('lax')
   })
 
-  it('accepts comma-separated roles string and trims whitespace', async () => {
-    await POST(
-      makeRequest({
-        access_token: 'jwt',
-        email: 'ops@janua.dev',
-        roles: ' superadmin , admin ',
-      })
-    )
+  it('normalizes an array roles claim into a comma-separated cookie', async () => {
+    verifiedClaims({ email: 'ops@janua.dev', roles: [' superadmin ', 'admin', ''], exp: Math.floor(Date.now() / 1000) + 3600 })
+
+    await POST(makeRequest({ access_token: 'jwt' }))
 
     const roles = cookieCalls.find((c) => c.name === 'janua_admin_roles')!
-    expect(roles.value).toBe('superadmin , admin')
+    expect(roles.value).toBe('superadmin,admin')
+  })
+
+  it('falls back to the admin role when the verified token is is_admin with empty roles', async () => {
+    verifiedClaims({ email: 'ops@janua.dev', roles: [], is_admin: true, exp: Math.floor(Date.now() / 1000) + 3600 })
+
+    await POST(makeRequest({ access_token: 'jwt' }))
+
+    const roles = cookieCalls.find((c) => c.name === 'janua_admin_roles')!
+    expect(roles.value).toBe('admin')
+  })
+
+  it('does NOT invent an admin role when is_admin is absent/false', async () => {
+    verifiedClaims({ email: 'ops@janua.dev', roles: [], is_admin: false, exp: Math.floor(Date.now() / 1000) + 3600 })
+
+    await POST(makeRequest({ access_token: 'jwt' }))
+
+    const roles = cookieCalls.find((c) => c.name === 'janua_admin_roles')!
+    expect(roles.value).toBe('')
   })
 
   it('omits the refresh-token cookie when no refresh_token is supplied', async () => {
-    await POST(
-      makeRequest({
-        access_token: 'jwt',
-        email: 'ops@janua.dev',
-        roles: ['admin'],
-      })
-    )
+    verifiedClaims({ email: 'ops@janua.dev', roles: ['admin'], exp: Math.floor(Date.now() / 1000) + 3600 })
+
+    await POST(makeRequest({ access_token: 'jwt' }))
 
     expect(cookieCalls.find((c) => c.name === 'janua_refresh_token')).toBeUndefined()
   })
 
-  it('rejects requests missing access_token', async () => {
-    const res: any = await POST(
-      makeRequest({ email: 'ops@janua.dev', roles: ['admin'] })
-    )
+  it('rejects requests missing access_token with 400 (before any verification)', async () => {
+    const res: any = await POST(makeRequest({ email: 'ops@janua.dev', roles: ['admin'] }))
     expect(res.status).toBe(400)
     expect(cookieCalls).toHaveLength(0)
+    expect(mockJwtVerify).not.toHaveBeenCalled()
   })
 
-  it('rejects requests missing email', async () => {
-    const res: any = await POST(makeRequest({ access_token: 'jwt' }))
-    expect(res.status).toBe(400)
-    expect(cookieCalls).toHaveLength(0)
-  })
-
-  it('rejects malformed JSON bodies', async () => {
+  it('rejects malformed JSON bodies with 400', async () => {
     const res: any = await POST(makeRequest(undefined, { malformed: true }))
     expect(res.status).toBe(400)
     expect(cookieCalls).toHaveLength(0)
   })
 
-  it('falls back to a 1-day maxAge when expires_at is missing', async () => {
-    await POST(
-      makeRequest({
-        access_token: 'jwt',
-        email: 'ops@janua.dev',
-        roles: ['admin'],
-      })
-    )
+  it('falls back to a 1-day maxAge when the token has no exp', async () => {
+    verifiedClaims({ email: 'ops@janua.dev', roles: ['admin'] })
+
+    await POST(makeRequest({ access_token: 'jwt' }))
 
     const access = cookieCalls.find((c) => c.name === 'janua_access_token')!
     expect(access.options.maxAge).toBe(60 * 60 * 24)

--- a/apps/admin/app/api/auth/session/route.ts
+++ b/apps/admin/app/api/auth/session/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
+import { createRemoteJWKSet, jwtVerify, type JWTPayload } from 'jose'
 
 /**
  * Janua Admin — Session Cookie Bridge
@@ -19,7 +20,23 @@ import { cookies } from 'next/headers'
  * successful sign-in (from the `afterSignIn` callback) and DELETE on
  * logout.
  *
- * Security:
+ * SECURITY — why the token is verified here:
+ *   The middleware makes its allow/deny decision on `janua_admin_email` and
+ *   `janua_admin_roles`. If those were trusted straight from the POST body,
+ *   anyone able to reach this route could mint cookies claiming
+ *   `email=ops@madfam.io, roles=superadmin` and pass the edge gate without a
+ *   valid session. So we verify the access token's RS256 signature against
+ *   Janua's JWKS and derive email + roles from the *verified* claims,
+ *   ignoring whatever the client body asserts for them. Verification is
+ *   fail-closed: an unsigned/forged/expired token yields 401 and no cookies.
+ *
+ *   Signature + expiry are the security-critical checks (a forged token
+ *   cannot be signed by Janua's private key). Audience/issuer are
+ *   intentionally NOT pinned here — the console accepts tokens for its own
+ *   per-client audience, and the upstream data plane independently enforces
+ *   audience on every API call.
+ *
+ * Cookie flags:
  *   - HttpOnly  — JS cannot read the access token (mitigates XSS exfil)
  *   - Secure    — only sent over TLS in production
  *   - SameSite=Lax — protects against CSRF on top-level navigations while
@@ -30,20 +47,55 @@ import { cookies } from 'next/headers'
 interface SessionPayload {
   access_token: string
   refresh_token?: string
-  email: string
+  // email / roles / expires_at may be present in the body for backwards
+  // compatibility, but they are NOT trusted — the authoritative values come
+  // from the verified token claims below.
+  email?: string
   roles?: string[] | string
   expires_at?: number | string
 }
 
 const ONE_DAY_SECONDS = 60 * 60 * 24
 
-function normalizeRoles(roles: SessionPayload['roles']): string {
+/**
+ * Janua JWKS endpoint. Defaults to the public API's well-known path; operators
+ * can override with JANUA_JWKS_URL for private/self-hosted deployments.
+ */
+function jwksUrl(): string {
+  if (process.env.JANUA_JWKS_URL) return process.env.JANUA_JWKS_URL
+  const apiBase = process.env.NEXT_PUBLIC_JANUA_API_URL || 'https://api.janua.dev'
+  return `${apiBase.replace(/\/$/, '')}/.well-known/jwks.json`
+}
+
+// Module-scoped remote key set: jose caches the fetched keys internally with a
+// cooldown, so we build it once per JWKS URL rather than per request.
+let jwks: ReturnType<typeof createRemoteJWKSet> | null = null
+let jwksSource = ''
+function getJwks(): ReturnType<typeof createRemoteJWKSet> {
+  const url = jwksUrl()
+  if (!jwks || jwksSource !== url) {
+    jwks = createRemoteJWKSet(new URL(url))
+    jwksSource = url
+  }
+  return jwks
+}
+
+/**
+ * Verify the RS256 signature and expiry of a Janua access token and return its
+ * claims. Throws if the token is malformed, unsigned, tampered, or expired.
+ */
+async function verifyAccessToken(token: string): Promise<JWTPayload> {
+  const { payload } = await jwtVerify(token, getJwks(), { clockTolerance: 30 })
+  return payload
+}
+
+function normalizeRoles(roles: unknown): string {
   if (!roles) return ''
   if (Array.isArray(roles)) return roles.map((r) => String(r).trim()).filter(Boolean).join(',')
   return String(roles).trim()
 }
 
-function deriveMaxAge(expiresAt: SessionPayload['expires_at']): number {
+function deriveMaxAge(expiresAt: number | string | undefined): number {
   if (expiresAt === undefined || expiresAt === null) return ONE_DAY_SECONDS
   const expiresMs = typeof expiresAt === 'string' ? Date.parse(expiresAt) : Number(expiresAt) * 1000
   if (!Number.isFinite(expiresMs)) return ONE_DAY_SECONDS
@@ -62,17 +114,41 @@ export async function POST(request: NextRequest) {
   }
 
   const accessToken = typeof payload.access_token === 'string' ? payload.access_token.trim() : ''
-  const email = typeof payload.email === 'string' ? payload.email.trim() : ''
+  if (!accessToken) {
+    return NextResponse.json({ error: 'access_token is required' }, { status: 400 })
+  }
 
-  if (!accessToken || !email) {
+  // Fail-closed: derive the trusted identity from the token's own claims, not
+  // from the client-supplied body. A forged or expired token gets no cookies.
+  let claims: JWTPayload
+  try {
+    claims = await verifyAccessToken(accessToken)
+  } catch {
     return NextResponse.json(
-      { error: 'access_token and email are required' },
-      { status: 400 }
+      { error: 'Invalid or expired access token' },
+      { status: 401 }
     )
   }
 
-  const roles = normalizeRoles(payload.roles)
-  const maxAge = deriveMaxAge(payload.expires_at)
+  const email = typeof claims.email === 'string' ? claims.email.trim() : ''
+  if (!email) {
+    return NextResponse.json(
+      { error: 'Access token is missing an email claim' },
+      { status: 401 }
+    )
+  }
+  let roles = normalizeRoles(claims.roles)
+  // Parity with the client-side session bootstrap (login/page.tsx): when the
+  // verified token carries is_admin but no materialized roles yet, treat it as
+  // the 'admin' role so the middleware allow-list behaves identically. This is
+  // still derived from a VERIFIED claim, not the request body.
+  if (!roles && claims.is_admin === true) {
+    roles = 'admin'
+  }
+  // Prefer the token's own exp; fall back to the (advisory) body expires_at.
+  const maxAge = deriveMaxAge(
+    typeof claims.exp === 'number' ? claims.exp : payload.expires_at
+  )
   const isProd = process.env.NODE_ENV === 'production'
 
   const cookieStore = await cookies()

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -34,6 +34,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "date-fns": "^4.1.0",
+    "jose": "^5.2.0",
     "lucide-react": "^0.303.0",
     "next": "16.2.6",
     "react": "18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      jose:
+        specifier: '>=4.15.9'
+        version: 5.10.0
       lucide-react:
         specifier: ^0.303.0
         version: 0.303.0(react@18.3.1)
@@ -959,10 +962,10 @@ importers:
     dependencies:
       '@sentry/nextjs':
         specifier: ^10.51.0
-        version: 10.51.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.105.4(esbuild@0.28.1))
+        version: 10.51.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.105.4(esbuild@0.28.1))
       next:
         specifier: '>=16.2.6'
-        version: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+        version: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.0.0
         version: 18.3.1
@@ -15334,7 +15337,7 @@ snapshots:
 
   '@sentry/core@10.51.0': {}
 
-  '@sentry/nextjs@10.51.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.105.4(esbuild@0.28.1))':
+  '@sentry/nextjs@10.51.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(webpack@5.105.4(esbuild@0.28.1))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
@@ -15347,7 +15350,7 @@ snapshots:
       '@sentry/react': 10.51.0(react@18.3.1)
       '@sentry/vercel-edge': 10.51.0
       '@sentry/webpack-plugin': 5.2.1(webpack@5.105.4(esbuild@0.28.1))
-      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1)
+      next: 16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rollup: 4.60.3
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -16692,14 +16695,6 @@ snapshots:
       '@vitest/utils': 3.2.6
       chai: 5.3.3
       tinyrainbow: 2.0.0
-
-  '@vitest/mocker@3.2.6(vite@8.0.16(@types/node@20.19.33)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 3.2.6
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.16(@types/node@20.19.33)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3)
 
   '@vitest/mocker@3.2.6(vite@8.0.16(@types/node@25.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3))':
     dependencies:
@@ -18314,7 +18309,7 @@ snapshots:
       '@typescript-eslint/parser': 8.56.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
@@ -18334,7 +18329,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@5.5.0)
@@ -18349,14 +18344,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.56.1(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -18371,7 +18366,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.1(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -21630,32 +21625,6 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.4(react@18.3.1))(react@18.3.1):
-    dependencies:
-      '@next/env': 16.2.6
-      '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.23
-      caniuse-lite: 1.0.30001791
-      postcss: 8.5.15
-      react: 18.3.1
-      react-dom: 19.2.4(react@18.3.1)
-      styled-jsx: 5.1.6(@babel/core@7.29.7)(react@18.3.1)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.6
-      '@next/swc-darwin-x64': 16.2.6
-      '@next/swc-linux-arm64-gnu': 16.2.6
-      '@next/swc-linux-arm64-musl': 16.2.6
-      '@next/swc-linux-x64-gnu': 16.2.6
-      '@next/swc-linux-x64-musl': 16.2.6
-      '@next/swc-win32-arm64-msvc': 16.2.6
-      '@next/swc-win32-x64-msvc': 16.2.6
-      '@opentelemetry/api': 1.9.1
-      '@playwright/test': 1.60.0
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
   node-addon-api@8.5.0: {}
 
   node-domexception@1.0.0: {}
@@ -22237,11 +22206,6 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
-
-  react-dom@19.2.4(react@18.3.1):
-    dependencies:
-      react: 18.3.1
-      scheduler: 0.27.0
 
   react-dom@19.2.4(react@19.2.4):
     dependencies:
@@ -24203,7 +24167,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.6
-      '@vitest/mocker': 3.2.6(vite@8.0.16(@types/node@20.19.33)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.6(vite@8.0.16(@types/node@25.3.0)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.6
       '@vitest/runner': 3.2.6
       '@vitest/snapshot': 3.2.6


### PR DESCRIPTION
## Security finding

The Janua admin console's edge middleware (`apps/admin/middleware.ts`) gates every protected route on three cookies — `janua_access_token`, `janua_admin_email`, `janua_admin_roles`. Those cookies were set **verbatim from the client-supplied POST body** in `app/api/auth/session/route.ts`, with no server-side verification.

**Impact:** anyone able to reach `POST /api/auth/session` could send
```json
{ "access_token": "anything", "email": "ops@madfam.io", "roles": ["superadmin"] }
```
and receive cookies that pass the middleware's domain+role allow-list — bypassing the edge gate without a valid session.

**Bound (why not critical):** actual data operations carry `janua_access_token` as a bearer to `auth.madfam.io`, which validates the JWT server-side, so a forged token can't read/write tenant data or vault secrets. This closes the **edge gate** (admin shell reachability) and removes the client-trusted email/roles that the middleware bases its decision on — the middleware's stated purpose is otherwise defeated.

## Fix

`POST /api/auth/session` now:
- verifies the access token's **RS256 signature + expiry** against Janua's JWKS (`jose` `createRemoteJWKSet` + `jwtVerify`, module-cached key set);
- derives `email` and `roles` from the **verified claims**, ignoring whatever the body asserts for them;
- is **fail-closed** — a forged / unsigned / expired token → `401`, no cookies set;
- mirrors the login page's `is_admin → 'admin'` roles fallback, but from the **verified** `is_admin` claim, so no legitimate operator is regressed.

Audience/issuer are intentionally **not** pinned — the console accepts tokens for its own per-client audience, and the upstream data plane independently enforces audience per call. Signature+expiry is the security-critical check a forged token cannot satisfy. `JANUA_JWKS_URL` overrides the default `${NEXT_PUBLIC_JANUA_API_URL}/.well-known/jwks.json`.

## Tests

`apps/admin/app/api/auth/session/route.test.ts` rewritten — **13/13 pass**, including:
- spoofed body email/roles are ignored (cookies reflect verified claims only);
- forged/expired token → 401, zero cookies;
- verified-but-no-email-claim → 401;
- `is_admin`-with-empty-roles → `admin`; `is_admin:false` → no invented role.

## ⚠️ Before merge — needs one live smoke-test

I could not exercise the real `auth.madfam.io` token against this route in the sandbox. Please confirm a real SSO login into the admin console still lands (the happy path: SDK obtains a genuine RS256 token → route verifies it → cookies set → middleware admits). The logic is unit-covered; this only checks the live JWKS URL/claim-shape assumptions (`email` top-level, `roles` array, `is_admin` bool — confirmed against `oauth_provider.py` token mint).

Part of the Janua uniformity remediation sweep.