### PR TITLE
seed: add fortuna-web public OIDC client (audience=fortuna)

### DIFF
--- a/apps/api/scripts/seed_oidc_clients.py
+++ b/apps/api/scripts/seed_oidc_clients.py
@@ -138,6 +138,19 @@ OIDC_CLIENTS: list[dict[str, Any]] = [
         ],
     },
     {
+        "client_id": "fortuna-web",
+        "name": "fortuna-web",
+        "description": "Fortuna opportunity-intelligence web app — Sign in with Janua (OIDC/PKCE)",
+        # Must match the audience fortuna-api enforces on the Janua JWT, so the
+        # OIDC-minted access token carries aud=fortuna (session-API tokens carry
+        # the global janua.dev audience and are rejected by fortuna-api).
+        "audience": "fortuna",
+        "redirect_uris": [
+            "https://fortuna.tube/auth/callback",
+            "http://localhost:3000/auth/callback",
+        ],
+    },
+    {
         "client_id": "dashboard",
         "name": "dashboard",
         "description": "Janua user dashboard — Sign in with Janua (OIDC/PKCE)",


### PR DESCRIPTION
## What

Adds the **`fortuna-web`** public (PKCE) OIDC client to `seed_oidc_clients.py` so the fortuna web app can use "Sign in with Janua" (OIDC/PKCE):

```python
{
  "client_id": "fortuna-web",
  "audience": "fortuna",
  "redirect_uris": ["https://fortuna.tube/auth/callback", "http://localhost:3000/auth/callback"],
}
```

## Why the audience matters

`fortuna-api` enforces `aud=fortuna` on the Janua JWT (`services/api/app/core/auth.py` `_try_decode`, `config.py` `janua_audience` default `"fortuna"`, `.enclii.yml` `JANUA_AUDIENCE: fortuna`). The web app today obtains **session-API** tokens carrying `aud=janua.dev`, which the API rejects. A public OIDC client with `audience: "fortuna"` makes the OIDC-minted access token carry `aud=fortuna` (via `client_audience` in `oauth_provider.py`), so the already-OIDC-ready backend accepts it.

`tezca-web` already existed with `audience: "tezca-api"` (no change needed there).

## Operator step

This script is operator-driven and side-effectful (writes the OAuth client registry). Run it against prod — it's a gate in the operator console (`janua.oidc-clients-fortuna-tezca-eido`). `client_id` values are public identifiers; safe to commit.

Paired with the fortuna and tezca web OIDC rewires.