### PR TITLE
chore(ui,react-sdk): declare React 19 support in the peer range

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -228,29 +228,38 @@ jobs:
       # retries once first, since the underlying fault is a transient response
       # the registry sometimes returns.
       - name: Run pnpm audit
+        # `shell:` is spelled out because the GitHub default is `bash -e`, and -e
+        # kills this script at the first capture — the failure it exists to
+        # classify. The first version of this step lost to exactly that: it died
+        # on line 4 and emitted none of its own diagnostics, so it looked
+        # identical to the bug it was fixing.
+        shell: bash --noprofile --norc {0}
         run: |
           set -uo pipefail
-          run_audit() { pnpm audit --audit-level=critical 2>&1; }
 
-          out="$(run_audit)"; code=$?
-          if [ "$code" -ne 0 ] && printf '%s' "$out" | grep -q 'is not valid JSON'; then
+          # Output goes to a FILE, not a variable. pnpm's crash output contains a
+          # NUL byte; `$(...)` drops it with a "ignored null byte in input"
+          # warning and can mangle what is left, so the crash signature must be
+          # matched on bytes as written.
+          run_audit() { pnpm audit --audit-level=critical >audit.log 2>&1; }
+          crashed() { grep -qa 'is not valid JSON' audit.log; }
+
+          run_audit; code=$?
+          if [ "$code" -ne 0 ] && crashed; then
             echo "::notice::pnpm audit crashed parsing the registry response; retrying once."
             sleep 10
-            out="$(run_audit)"; code=$?
+            run_audit; code=$?
           fi
 
-          printf '%s\n' "$out"
+          cat audit.log
 
           if [ "$code" -eq 0 ]; then
             echo "Audit ran and found no advisories at or above 'critical'."
             exit 0
           fi
 
-          if printf '%s' "$out" | grep -q 'is not valid JSON'; then
-            echo "::error title=Audit did not run::pnpm audit CRASHED and reported nothing. \
-          This is NOT a vulnerability finding -- do not go looking for one. The tool failed \
-          to parse the registry response (pnpm 10.25). Re-run the job; if it persists, audit \
-          with an independent scanner before assuming the tree is clean."
+          if crashed; then
+            echo "::error title=Audit did not run::pnpm audit CRASHED and reported nothing. This is NOT a vulnerability finding -- do not go looking for one. The tool failed to parse the registry response (pnpm 10.25). Re-run the job; if it persists, audit with an independent scanner before assuming the tree is clean."
             exit 1
           fi
 

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -213,8 +213,49 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # `pnpm audit` alone conflates two outcomes that need different responses:
+      # "a CRITICAL advisory exists" and "the audit could not run". Both exit
+      # non-zero, so the job reported a critical vulnerability while producing NO
+      # output at all -- pnpm 10.25 crashes parsing the registry's audit response
+      # ("Unexpected token ... is not valid JSON"), and the crash reads exactly
+      # like a finding. Verified 2026-07-26: `trivy fs --severity CRITICAL` on
+      # this tree reports 0, while this step failed on three consecutive runs and
+      # emitted nothing after ##[endgroup]. Someone would have gone looking for a
+      # vulnerability that does not exist.
+      #
+      # This keeps the gate FAILING in both cases -- a security check that cannot
+      # run must never read as green -- but makes the two distinguishable, and
+      # retries once first, since the underlying fault is a transient response
+      # the registry sometimes returns.
       - name: Run pnpm audit
-        run: pnpm audit --audit-level=critical
+        run: |
+          set -uo pipefail
+          run_audit() { pnpm audit --audit-level=critical 2>&1; }
+
+          out="$(run_audit)"; code=$?
+          if [ "$code" -ne 0 ] && printf '%s' "$out" | grep -q 'is not valid JSON'; then
+            echo "::notice::pnpm audit crashed parsing the registry response; retrying once."
+            sleep 10
+            out="$(run_audit)"; code=$?
+          fi
+
+          printf '%s\n' "$out"
+
+          if [ "$code" -eq 0 ]; then
+            echo "Audit ran and found no advisories at or above 'critical'."
+            exit 0
+          fi
+
+          if printf '%s' "$out" | grep -q 'is not valid JSON'; then
+            echo "::error title=Audit did not run::pnpm audit CRASHED and reported nothing. \
+          This is NOT a vulnerability finding -- do not go looking for one. The tool failed \
+          to parse the registry response (pnpm 10.25). Re-run the job; if it persists, audit \
+          with an independent scanner before assuming the tree is clean."
+            exit 1
+          fi
+
+          echo "::error title=Critical advisory::pnpm audit reported an advisory at 'critical'. See the output above."
+          exit 1
 
   security-scanning:
     name: Security Scanning

--- a/packages/react-sdk/package.json
+++ b/packages/react-sdk/package.json
@@ -32,8 +32,8 @@
     "@janua/ui": "workspace:^"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -58,8 +58,8 @@
     "zustand": "^5.0.12"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@asamuzakjp/css-color": "^4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1069,10 +1069,10 @@ importers:
         specifier: workspace:^
         version: link:../ui
       react:
-        specifier: ^18.0.0
+        specifier: ^18.0.0 || ^19.0.0
         version: 18.3.1
       react-dom:
-        specifier: ^18.0.0
+        specifier: ^18.0.0 || ^19.0.0
         version: 18.3.1(react@18.3.1)
     devDependencies:
       '@testing-library/dom':
@@ -1221,10 +1221,10 @@ importers:
         specifier: ^0.4.4
         version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
-        specifier: ^18.0.0
+        specifier: ^18.0.0 || ^19.0.0
         version: 18.3.1
       react-dom:
-        specifier: ^18.0.0
+        specifier: ^18.0.0 || ^19.0.0
         version: 18.3.1(react@18.3.1)
       tailwind-merge:
         specifier: ^3.5.0


### PR DESCRIPTION
## Why this matters outside janua

`@janua/ui` and `@janua/react-sdk` declare `peerDependencies: react ^18.0.0`. **Tezca's web app is on `react@19.2.3`**, so its `package-lock.json` can only be produced with `--legacy-peer-deps` / `--force`. That kind of lockfile carries entries with no `resolved` and no `integrity` — tezca has **13** of them under `apps/web/node_modules` — and npm's audit service rejects such a tree outright:

```
npm error audit endpoint returned an error
{ statusCode: 400, message: 'Invalid package tree, run npm install to
  rebuild your package-lock.json' }
```

**So tezca's `npm audit --production --audit-level=high` CI step has not been scanning anything.** It has been erroring, and it surfaces as a red CI job that looks like a flaky registry call.

Reproduced locally against tezca `main` on 2026-07-26 — a clean `npm install --package-lock-only` there fails with:

```
While resolving: web@0.1.0
Found: react@19.2.3
Could not resolve dependency: peer react@"^18.0.0" from @janua/ui@0.1.4
```

A stale peer range in a published package isn't a cosmetic inaccuracy. It propagates into consumers' lockfiles and **silently disables their dependency scanning**.

## Verified, not assumed

A peer range is a compatibility claim to every consumer, so this was measured:

- Installed `react@19.2.4` + `@types/react@19` into `packages/ui`, ran `tsc --noEmit` across all **124 source files / ~31k LOC**, then downgraded to `react@18.3.1` in the same tree and re-ran.

| | errors |
|---|---|
| React 19 | 688 |
| React 18 | 690 |
| **React-19-only (set difference)** | **0** |

- **Zero** type errors exist under 19 that don't also exist under 18. The shared 688 are artifacts of a partial workspace install (missing `@storybook/react` types, unresolved `@/test` alias, jest-dom matchers) — identical on both sides, which is exactly why this is run as a **differential** rather than a pass/fail.
- React 19 actually **fixes two** pre-existing errors: the `children` prop typing on `ThemeProviderProps` in `theme-toggle.tsx` and `janua-theme-provider.tsx`.
- Separately grepped for every API React 19 removed — `defaultProps` on function components, `propTypes`, `ReactDOM.render`, `findDOMNode`, string refs. **None present.**

## Limit of this evidence

This verifies **type** compatibility. It is **not** a runtime test against React 19, and the vitest suite was not run under 19 — the partial install lacks the jest-dom setup, so it would fail identically on both versions and prove nothing. If a consumer hits a runtime issue, this range is the thing to revisit.

`@janua/nextjs` already declares `react >=17.0.0`, so a permissive range is already the precedent; these two were the outliers.

## Operator note

**Publishing is a separate step.** Consumers keep seeing `^18.0.0` until new versions of both packages are published to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)