### PR TITLE
fix(entitlement): accept hyphenated product slugs in plan ids (pravara-mes, nuit-one)

### DIFF
--- a/apps/api/app/routers/v1/webhooks_dhanam.py
+++ b/apps/api/app/routers/v1/webhooks_dhanam.py
@@ -33,9 +33,13 @@ from app.services.entitlements_service import (
 logger = structlog.get_logger()
 router = APIRouter(prefix="/webhooks/dhanam", tags=["webhooks"])
 
-# Open product validation: any lowercase alphanumeric name is a valid product.
-# No hardcoded product list — new ecosystem services are accepted automatically.
-PRODUCT_PATTERN = re.compile(r"^[a-z][a-z0-9]*$")
+# Open product validation: lowercase alphanumeric names, with interior hyphens
+# allowed because catalog product slugs carry them (`nuit-one`, `pravara-mes` —
+# see dhanam catalog.yaml). No hardcoded product list — new ecosystem services
+# are accepted automatically. Before hyphens were accepted, a paid
+# `pravara-mes_*` / `nuit-one_*` plan fell through to ("dhanam", None), which
+# not only granted nothing but REMOVED the buyer's existing dhanam tier.
+PRODUCT_PATTERN = re.compile(r"^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$")
 VALID_TIERS = {"essentials", "pro", "madfam"}
 
 # Legacy plan names -> (product, tier) for backwards compatibility
@@ -64,6 +68,7 @@ def parse_product_plan(plan_id: str) -> tuple[str, str | None]:
     Examples:
         "tezca_pro" -> ("tezca", "pro")
         "enclii_essentials" -> ("enclii", "essentials")
+        "pravara-mes_starter" -> ("pravara-mes", "starter")  # hyphenated product
         "pro" -> ("dhanam", "pro")
         "sovereign" -> ("enclii", "pro")  # legacy
         "free" -> ("dhanam", None)  # cancel tier

--- a/apps/api/tests/unit/routers/test_webhooks_dhanam.py
+++ b/apps/api/tests/unit/routers/test_webhooks_dhanam.py
@@ -33,6 +33,14 @@ class TestParseProductPlan:
             ("karafiel_essentials", ("karafiel", "essentials")),
             ("forgesight_madfam", ("forgesight", "madfam")),
             ("newservice_pro", ("newservice", "pro")),
+            # Hyphenated catalog slugs — before the hyphen fix these fell
+            # through to ("dhanam", None), which cancelled the buyer's dhanam
+            # tier instead of granting the purchased product.
+            ("pravara-mes_starter", ("pravara-mes", "starter")),
+            ("pravara-mes_growth", ("pravara-mes", "growth")),
+            ("pravara-mes_enterprise", ("pravara-mes", "enterprise")),
+            ("nuit-one_artist_pro", ("nuit-one", "artist_pro")),
+            ("nuit-one_label", ("nuit-one", "label")),
         ],
     )
     def test_product_prefixed_plans(self, plan_id: str, expected: tuple):
@@ -74,6 +82,7 @@ class TestParseProductPlan:
             ("dhanam_free", "dhanam"),
             ("karafiel_free", "karafiel"),
             ("newservice_community", "newservice"),
+            ("pravara-mes_free", "pravara-mes"),
         ],
     )
     def test_cancel_tier_product_prefixed(self, plan_id: str, expected_product: str):
@@ -105,6 +114,8 @@ class TestParseProductPlan:
             ("enclii_essentials_annual", ("enclii", "essentials")),
             ("pro_yearly", ("dhanam", "pro")),
             ("sovereign_monthly", ("enclii", "pro")),
+            ("nuit-one_artist_pro_monthly", ("nuit-one", "artist_pro")),
+            ("pravara-mes_starter_yearly", ("pravara-mes", "starter")),
         ],
     )
     def test_billing_suffix_stripped(self, plan_id: str, expected: tuple):
@@ -132,6 +143,11 @@ class TestParseProductPlan:
     def test_numeric_prefix_rejected(self):
         """Product names starting with digits are rejected."""
         assert parse_product_plan("123_pro") == ("dhanam", None)
+
+    @pytest.mark.parametrize("plan_id", ["-nuit_pro", "nuit-_pro", "nuit--one_pro"])
+    def test_malformed_hyphen_slugs_rejected(self, plan_id: str):
+        """Leading/trailing/doubled hyphens are not valid product slugs."""
+        assert parse_product_plan(plan_id) == ("dhanam", None)
 
     def test_unknown_tier_for_any_product(self):
         """Any product with unknown tier returns (product, tier) as-is."""


### PR DESCRIPTION
## ⚠️ HOLD — merge after [M8] (money-path freeze)

Janua is in the pre-first-charge freeze window; this rolls the entitlement workload and nothing about the [M7] Essentials charge touches it. Found by the 2026-08-01 SKU functional audit; staged now so the fix is review-ready the moment the freeze lifts.

## The defect

`PRODUCT_PATTERN = ^[a-z][a-z0-9]*$` rejects interior hyphens, and the catalog carries two hyphenated product slugs: **`pravara-mes`** (3 priced SKUs, MX$4,999–49,999) and **`nuit-one`** (2 priced SKUs). Their plan ids fell through `parse_product_plan()` to `("dhanam", None)`, and the webhook's `None`-tier path **pops the product key** — so a paid `pravara-mes_starter`:

1. granted **no** pravara-mes entitlement, and
2. **removed the buyer's existing dhanam tier** (misattributed cancel).

karafiel's CFDI map and dhanam's checkout DTO both already accept these slugs — janua was the only hop that couldn't.

## The fix

`^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$` — interior hyphens only; leading/trailing/doubled hyphens stay rejected (pinned by new negative tests).

## Validation

- New parametrized cases: all five real catalog ids, hyphen + billing-suffix stripping (`nuit-one_artist_pro_monthly`), hyphenated cancel tier (`pravara-mes_free` → `("pravara-mes", None)`), malformed-slug rejections.
- **Battery against the live dhanam catalog: all 49 priced plan ids parse to their exact `(product, tier)`** (0 mis-parses), plus 16 behavior cases covering legacy plans, cancel tiers, case-insensitivity, and empty/unrecognized inputs — run against the verbatim extracted function text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)