### PR TITLE
fix(auth): truth wave — honest errors, real password policy, working recovery pipeline

### DIFF
--- a/apps/api/alembic/versions/009_add_legacy_webhook_events.py
+++ b/apps/api/alembic/versions/009_add_legacy_webhook_events.py
@@ -1,0 +1,39 @@
+"""Add legacy_webhook_events table.
+
+The LegacyWebhookEvent model (app/models/__init__.py) shipped without any
+migration, so environments that only ran migrations never had the table.
+In prod (alembic at 002) every fully-valid signup 503'd: the user row
+committed, then the event-log INSERT poisoned the session and the next
+commit blew up with UndefinedTableError (2026-08-02 incident; hand-DDL
+hotfix applied the same day). IF NOT EXISTS keeps this idempotent against
+environments that received that hotfix or ran metadata.create_all.
+
+Revision ID: 009_add_legacy_webhook_events
+Revises: 008_connected_accounts
+"""
+
+from alembic import op
+
+revision = "009_add_legacy_webhook_events"
+down_revision = "008_connected_accounts"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS legacy_webhook_events (
+            id uuid PRIMARY KEY,
+            type varchar(255) NOT NULL,
+            data jsonb DEFAULT '{}'::jsonb,
+            user_id uuid REFERENCES users(id),
+            organization_id uuid REFERENCES organizations(id),
+            created_at timestamp
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS legacy_webhook_events")

--- a/apps/api/app/auth/router.py
+++ b/apps/api/app/auth/router.py
@@ -470,7 +470,12 @@ async def forgot_password(request: ForgotPasswordRequest, redis=Depends(get_redi
             status_code=status.HTTP_429_TOO_MANY_REQUESTS, detail="Too many password reset requests"
         )
 
-    # Send password reset email (regardless of user existence for security)
+    # KNOWN-BROKEN LEGACY (documented 2026-08-02, auth truth wave): this call
+    # has ALWAYS raised TypeError — `to_email`/`reset_url` were never valid
+    # kwargs on any signature — so the except below fires every time and no
+    # email is sent; the hardcoded temp-reset-token could never validate
+    # anyway. The canonical flow is /api/v1/auth/password/forgot. Left
+    # behavior-identical pending removal of this router.
     email_service = get_email_service(redis)
     try:
         reset_url = f"{settings.BASE_URL}/auth/reset-password?token=temp-reset-token"

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -36,6 +36,11 @@ class Settings(BaseSettings):
         default="development", pattern="^(development|staging|production|test)$"
     )
     BASE_URL: str = Field(default="https://janua.dev")
+    # Comma-separated allowlist of product reset pages that may receive a
+    # password-reset token via ForgotPasswordRequest.redirect_base, e.g.
+    # "https://app.dhan.am/reset-password". Values not on this list are
+    # ignored and the email falls back to FRONTEND_URL's reset page.
+    PASSWORD_RESET_REDIRECT_ORIGINS: str = Field(default="")
     API_BASE_URL: str = Field(
         default="https://api.janua.dev",
         description="Base URL for the API (used for SSO callbacks, OIDC discovery, etc.)",

--- a/apps/api/app/routers/v1/auth.py
+++ b/apps/api/app/routers/v1/auth.py
@@ -21,12 +21,13 @@ import structlog
 from app.config import settings
 from app.core.redis import ResilientRedisClient, get_redis
 from app.core.url_security import validate_redirect_url
-from app.database import get_db
+from app.database import AsyncSessionLocal, get_db
 from app.dependencies import get_current_user
 from app.services.account_lockout_service import AccountLockoutService
 from app.services.auth_service import AuthService
 from app.services.audit_logger import AuditEventType, AuditLogger
 from app.services.email import EmailService
+from app.services.email_service import send_password_reset_email_task
 from app.services.webhooks import WebhookEventType, trigger_user_webhook
 
 from ...models import ActivityLog, EmailVerification, MagicLink, PasswordReset, User, UserStatus
@@ -81,6 +82,12 @@ class RefreshTokenRequest(BaseModel):
 
 class ForgotPasswordRequest(BaseModel):
     email: EmailStr
+    # Optional product-surface page that will consume the token, e.g.
+    # "https://app.dhan.am/reset-password". Only honored when its value is in
+    # settings.PASSWORD_RESET_REDIRECT_ORIGINS — otherwise the default
+    # FRONTEND_URL page is used. Lets each product's reset email land on that
+    # product's own UI instead of Janua's.
+    redirect_base: Optional[str] = None
 
 
 class ResetPasswordRequest(BaseModel):
@@ -239,21 +246,29 @@ async def sign_up(
     await log_activity(db, str(user.id), "signup", {"method": "email"}, request)
     await log_audit_event(db, str(user.id), "signup", {"method": "email"}, request)
 
-    # Dispatch user.created webhook for CRM integration
+    # Dispatch user.created webhook for CRM integration.
+    # ISOLATED session, deliberately: the webhook path inserts an event-log
+    # row, and a failure there (prod 2026-08-02: legacy_webhook_events table
+    # missing) used to poison THIS request's session — the except below
+    # swallowed the first error, but the doomed pending INSERT detonated at
+    # the next db.commit(), turning every valid signup into a 503. With a
+    # dedicated session, webhook logging cannot touch the signup transaction.
     try:
-        await trigger_user_webhook(
-            db,
-            WebhookEventType.USER_CREATED,
-            {
-                "id": str(user.id),
-                "email": user.email,
-                "first_name": user.first_name,
-                "last_name": user.last_name,
-                "username": user.username,
-                "created_at": user.created_at.isoformat() if user.created_at else None,
-            },
-            user_id=str(user.id),
-        )
+        async with AsyncSessionLocal() as webhook_db:
+            await trigger_user_webhook(
+                webhook_db,
+                WebhookEventType.USER_CREATED,
+                {
+                    "id": str(user.id),
+                    "email": user.email,
+                    "first_name": user.first_name,
+                    "last_name": user.last_name,
+                    "username": user.username,
+                    "created_at": user.created_at.isoformat() if user.created_at else None,
+                },
+                user_id=str(user.id),
+            )
+            await webhook_db.commit()
     except Exception:
         pass  # Webhook failure must not block signup
 
@@ -1231,8 +1246,28 @@ async def forgot_password(
         db.add(reset)
         await db.commit()
 
-        # Send email in background
-        background_tasks.add_task(EmailService.send_password_reset_email, user.email, reset_token)
+        # Only a pre-registered product page may receive the token.
+        redirect_base = None
+        if forgot_data.redirect_base:
+            allowed = {
+                origin.strip()
+                for origin in (settings.PASSWORD_RESET_REDIRECT_ORIGINS or "").split(",")
+                if origin.strip()
+            }
+            if forgot_data.redirect_base in allowed:
+                redirect_base = forgot_data.redirect_base
+
+        # Send email in background via the REAL mailer, with THE token that
+        # /password/reset validates. The previous dispatch pointed at a
+        # placebo EmailService (app.services.email logs and returns True —
+        # nothing was ever sent) and even misnamed its method
+        # (send_password_reset_email vs the placebo's send_password_reset),
+        # while the SMTP-capable service generated a DIFFERENT token for the
+        # URL than the one stored in password_resets. Recovery could never
+        # complete by construction.
+        background_tasks.add_task(
+            send_password_reset_email_task, user.email, reset_token, redirect_base
+        )
 
     return {"message": "If the email exists, a password reset link has been sent"}
 

--- a/apps/api/app/services/email_service.py
+++ b/apps/api/app/services/email_service.py
@@ -136,13 +136,22 @@ class EmailService:
             logger.error("Token verification failed", error_type=type(e).__name__)
             raise Exception("Invalid or expired verification token")
 
-    async def send_password_reset_email(self, email: str, user_name: str = None) -> str:
-        """Send password reset email and return reset token"""
+    async def send_password_reset_email(
+        self,
+        email: str,
+        reset_token: str,
+        user_name: str = None,
+        redirect_base: str = None,
+    ) -> str:
+        """Send password reset email for an already-issued token.
 
-        # Generate reset token
-        reset_token = self._generate_verification_token()
+        The token MUST be the caller's (stored in password_resets — the only
+        store /password/reset validates against). This method previously
+        generated its own token here, so the emailed link could never match
+        the stored one.
+        """
 
-        # Store token in Redis with 1-hour expiry (audit 2026-04-23 M2: JSON).
+        # Mirror to Redis for observability (audit 2026-04-23 M2: JSON).
         if self.redis_client:
             token_key = f"password_reset:{reset_token}"
             token_data = {
@@ -154,8 +163,15 @@ class EmailService:
                 token_key, 60 * 60, json.dumps(token_data)
             )  # 1 hour
 
-        # Generate reset URL
-        reset_url = f"{settings.BASE_URL}/auth/reset-password?token={reset_token}"
+        # Generate reset URL. redirect_base is a caller-validated product page
+        # (see PASSWORD_RESET_REDIRECT_ORIGINS); the default is Janua's own
+        # frontend — NOT BASE_URL, which points at the API host in prod and
+        # serves no pages.
+        if redirect_base:
+            reset_url = f"{redirect_base}?token={reset_token}"
+        else:
+            frontend = settings.FRONTEND_URL or settings.BASE_URL
+            reset_url = f"{frontend}/auth/reset-password?token={reset_token}"
 
         # Prepare email content
         template_data = {
@@ -298,3 +314,27 @@ class EmailService:
 def get_email_service(redis_client: Optional[redis.Redis] = None) -> EmailService:
     """Get email service instance"""
     return EmailService(redis_client)
+
+
+async def send_password_reset_email_task(
+    email: str, reset_token: str, redirect_base: Optional[str] = None
+) -> None:
+    """Background-task entrypoint for the forgot-password flow.
+
+    Instantiates the real mailer per-call (BackgroundTasks gives no DI) and
+    never raises — a mail failure must not surface into the request path.
+    Without SMTP_HOST configured, _send_email already degrades to a logged
+    no-op; the warning below makes that state visible instead of silent.
+    """
+    try:
+        service = EmailService()
+        sent = await service.send_password_reset_email(
+            email, reset_token, redirect_base=redirect_base
+        )
+        if not sent:
+            logger.warning(
+                "Password reset email NOT sent (mailer unconfigured or send failed) — "
+                "the user will never receive the link"
+            )
+    except Exception:
+        logger.exception("Password reset email task failed")

--- a/apps/api/tests/quarantine/services/test_email_service_comprehensive.py
+++ b/apps/api/tests/quarantine/services/test_email_service_comprehensive.py
@@ -310,12 +310,11 @@ class TestPasswordReset:
             mock_render.return_value = "Rendered content"
 
             token = await service.send_password_reset_email(
-                email="test@example.com", user_name="John Doe"
+                email="test@example.com", reset_token="caller-token-abc", user_name="John Doe"
             )
 
-            # Verify token was generated
-            assert isinstance(token, str)
-            assert len(token) == 64
+            # The service must email the caller's stored token, never mint one
+            assert token == "caller-token-abc"
 
             # Verify Redis storage with 1-hour expiry
             mock_redis.setex.assert_called_once()
@@ -617,10 +616,10 @@ class TestEmailWorkflows:
 
             # Send password reset email
             token = await service.send_password_reset_email(
-                email="test@example.com", user_name="John Doe"
+                email="test@example.com", reset_token="caller-token-abc", user_name="John Doe"
             )
 
-            assert isinstance(token, str)
+            assert token == "caller-token-abc"
             mock_redis.setex.assert_called_once()
 
             # Verify Redis storage with correct expiry

--- a/apps/api/tests/quarantine/services/test_email_service_comprehensive.py
+++ b/apps/api/tests/quarantine/services/test_email_service_comprehensive.py
@@ -340,10 +340,12 @@ class TestPasswordReset:
             mock_send.return_value = True
             mock_render.return_value = "Rendered content"
 
-            token = await service.send_password_reset_email("test@example.com")
+            # Token is now issued by the caller (stored in password_resets) —
+            # the service must email THAT token, never mint its own.
+            token = await service.send_password_reset_email("test@example.com", "caller-token-123")
 
-            # Should use email prefix as user name
-            assert isinstance(token, str)
+            # Should return the caller's token unchanged
+            assert token == "caller-token-123"
             mock_render.assert_called()
             render_call_args = mock_render.call_args[0][1]  # template_data
             assert render_call_args["user_name"] == "test"  # email prefix
@@ -360,7 +362,7 @@ class TestPasswordReset:
             mock_render.return_value = "Rendered content"
 
             with pytest.raises(Exception, match="Failed to send password reset email"):
-                await service.send_password_reset_email("test@example.com")
+                await service.send_password_reset_email("test@example.com", "caller-token-123")
 
 
 class TestWelcomeEmail:

--- a/apps/api/tests/unit/services/test_email_service.py
+++ b/apps/api/tests/unit/services/test_email_service.py
@@ -367,25 +367,29 @@ class TestSendPasswordResetEmail:
         return EmailService(redis_client=mock_redis)
 
     async def test_send_reset_returns_token(self, service):
-        """Test password reset email returns token."""
+        """The service emails and returns the CALLER's stored token — it must
+        never mint its own (the emailed link has to match password_resets)."""
         with patch.object(service, "_send_email", return_value=True):
             with patch.object(service, "_render_template", return_value="content"):
                 token = await service.send_password_reset_email(
                     email="test@example.com",
+                    reset_token="caller-token-abc",
                     user_name="Test User",
                 )
 
-        assert isinstance(token, str)
-        assert len(token) == 64
+        assert token == "caller-token-abc"
 
     async def test_send_reset_stores_token_in_redis(self, service, mock_redis):
-        """Test password reset stores token with 1-hour expiry."""
+        """Test password reset mirrors the caller's token with 1-hour expiry."""
         with patch.object(service, "_send_email", return_value=True):
             with patch.object(service, "_render_template", return_value="content"):
-                await service.send_password_reset_email(email="test@example.com")
+                await service.send_password_reset_email(
+                    email="test@example.com", reset_token="caller-token-abc"
+                )
 
         mock_redis.setex.assert_called_once()
         call_args = mock_redis.setex.call_args
+        assert call_args[0][0] == "password_reset:caller-token-abc"
         assert call_args[0][1] == 60 * 60  # 1 hour
 
     async def test_send_reset_raises_on_failure(self, service):
@@ -393,7 +397,9 @@ class TestSendPasswordResetEmail:
         with patch.object(service, "_send_email", return_value=False):
             with patch.object(service, "_render_template", return_value="content"):
                 with pytest.raises(Exception) as exc_info:
-                    await service.send_password_reset_email(email="test@example.com")
+                    await service.send_password_reset_email(
+                        email="test@example.com", reset_token="caller-token-abc"
+                    )
 
         assert "Failed to send password reset email" in str(exc_info.value)
 
@@ -528,6 +534,10 @@ class TestEmailTemplateData:
         with patch.object(service, "_send_email", return_value=True):
             with patch.object(service, "_render_template") as mock_render:
                 mock_render.return_value = "content"
-                await service.send_password_reset_email(email="test@example.com")
+                await service.send_password_reset_email(
+                    email="test@example.com", reset_token="caller-token-abc"
+                )
 
         assert mock_render.called
+        template_data = mock_render.call_args[0][1]
+        assert "caller-token-abc" in template_data["reset_url"]

--- a/packages/react-sdk/src/components/SignIn.tsx
+++ b/packages/react-sdk/src/components/SignIn.tsx
@@ -11,6 +11,12 @@ export interface SignInProps {
   className?: string
   /** Redirect URL after successful sign-in */
   redirectTo?: string
+  /**
+   * @deprecated Use `redirectTo`. Accepted as an alias because consumers
+   * behind `next/dynamic` lose prop typing — a silently-dropped redirect
+   * stranded users on the login page after a successful sign-in.
+   */
+  redirectUrl?: string
   /** Enable passkey sign-in */
   enablePasskeys?: boolean
   /** URL to sign-up page */
@@ -43,6 +49,7 @@ export function SignIn({
   onError,
   className,
   redirectTo,
+  redirectUrl: redirectUrlAlias,
   enablePasskeys = true,
   signUpUrl,
   socialProviders,
@@ -57,7 +64,7 @@ export function SignIn({
     <UISignIn
       januaClient={client}
       className={className}
-      redirectUrl={redirectTo}
+      redirectUrl={redirectTo ?? redirectUrlAlias}
       afterSignIn={onSuccess ? () => onSuccess() : undefined}
       onError={onError}
       enablePasskey={enablePasskeys}

--- a/packages/react-sdk/src/components/SignUp.tsx
+++ b/packages/react-sdk/src/components/SignUp.tsx
@@ -11,6 +11,12 @@ export interface SignUpProps {
   className?: string
   /** Redirect URL after successful sign-up */
   redirectTo?: string
+  /**
+   * @deprecated Use `redirectTo`. Accepted as an alias because consumers
+   * behind `next/dynamic` lose prop typing — a silently-dropped redirect
+   * stranded users on the register page after a successful sign-up.
+   */
+  redirectUrl?: string
   /** Require organization name during sign-up */
   requireOrganization?: boolean
   /** Require email verification after sign-up */
@@ -41,6 +47,7 @@ export function SignUp({
   onError,
   className,
   redirectTo,
+  redirectUrl: redirectUrlAlias,
   requireEmailVerification = false,
   signInUrl,
   socialProviders,
@@ -53,7 +60,7 @@ export function SignUp({
     <UISignUp
       januaClient={client}
       className={className}
-      redirectUrl={redirectTo}
+      redirectUrl={redirectTo ?? redirectUrlAlias}
       afterSignUp={onSuccess ? () => onSuccess() : undefined}
       onError={onError}
       requireEmailVerification={requireEmailVerification}

--- a/packages/ui/src/components/auth/sign-up.test.tsx
+++ b/packages/ui/src/components/auth/sign-up.test.tsx
@@ -198,10 +198,13 @@ describe('SignUp', () => {
       await user.click(termsCheckbox)
       await user.click(submitButton)
 
-      // API returns weak password error
+      // Blocked client-side by the exact server policy (12+ chars, upper,
+      // lower, digit, special) with the unmet rules listed — no round-trip.
       await waitFor(() => {
-        expect(screen.getByText(/password too weak/i)).toBeInTheDocument()
+        expect(screen.getByText(/does not meet the requirements/i)).toBeInTheDocument()
+        expect(screen.getByText(/at least 12 characters/i)).toBeInTheDocument()
       })
+      expect(global.fetch).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/ui/src/components/auth/sign-up.tsx
+++ b/packages/ui/src/components/auth/sign-up.tsx
@@ -9,6 +9,7 @@ import { AuthCard, type AuthCardLayout } from './auth-card'
 import { SocialButton, type SocialProvider } from './social-buttons'
 import { AuthDivider } from './divider'
 import { PasswordInput, calculatePasswordStrength } from './password-input'
+import { validatePasswordPolicy } from '../../lib/password-policy'
 
 export interface SignUpProps {
   /** Optional custom class name */
@@ -97,8 +98,15 @@ export function SignUp({
       return
     }
 
-    if (passwordStrength < 50) {
-      setError(formatErrorMessage(AUTH_ERRORS.WEAK_PASSWORD, true))
+    // Gate on the server's EXACT policy, not the heuristic meter — the meter
+    // accepted passwords the server rejects (e.g. 8 chars scoring 50+), and
+    // the user only learned after a 400 round-trip.
+    const policy = validatePasswordPolicy(password)
+    if (!policy.ok) {
+      setError(
+        'Password does not meet the requirements:\n' +
+          policy.failures.map((f) => `• ${f}`).join('\n')
+      )
       return
     }
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -65,6 +65,8 @@ export {
   AuthDivider,
   PasswordInput,
   calculatePasswordStrength,
+  validatePasswordPolicy,
+  PASSWORD_SPECIAL_CHARS,
   // SSO & Passkey Components
   JanuaSSOLoginButton,
   SSOEmailDetector,

--- a/packages/ui/src/lib/error-messages.ts
+++ b/packages/ui/src/lib/error-messages.ts
@@ -244,9 +244,20 @@ export const AUTH_ERRORS = {
  * Parse API error response and return actionable error
  */
 export function parseApiError(error: any, context?: ErrorContext): ActionableError {
-  // Extract error information
-  const status = context?.status || error?.response?.status || error?.status
-  const message = context?.message || error?.message || error?.response?.data?.message
+  // Extract error information. JanuaError (typescript-sdk) carries the HTTP
+  // status as `statusCode`, not `status` — missing it here made EVERY SDK
+  // error (400 password policy, 503 server bug, …) fall through to
+  // NETWORK_ERROR and display as "Unable to connect to the authentication
+  // server", swallowing the server's actionable detail. FastAPI puts the
+  // human-readable reason in `detail`.
+  const status =
+    context?.status || error?.response?.status || error?.status || error?.statusCode
+  const message =
+    context?.message ||
+    error?.response?.data?.detail ||
+    error?.response?.data?.message ||
+    error?.detail ||
+    error?.message
 
   // Map HTTP status codes to error types
   if (status === 401) {
@@ -290,6 +301,17 @@ export function parseApiError(error: any, context?: ErrorContext): ActionableErr
     if (message?.toLowerCase().includes('code')) {
       return AUTH_ERRORS.INVALID_MFA_CODE
     }
+    // Validation errors that match no known pattern: show the server's own
+    // words. "Password must be at least 12 characters long" is actionable;
+    // a generic (or worse, network) message is not.
+    if (message) {
+      return {
+        title: 'Please check your details',
+        message,
+        actions: ['Fix the issue above and try again'],
+        technical: error?.message,
+      }
+    }
   }
 
   if (status === 429) {
@@ -308,10 +330,15 @@ export function parseApiError(error: any, context?: ErrorContext): ActionableErr
     return AUTH_ERRORS.SERVER_ERROR
   }
 
-  // Network errors
-  if (error?.message?.toLowerCase().includes('network') ||
+  // Network errors — ONLY when there is genuinely no HTTP response. A bare
+  // `!status` here previously converted every unrecognized error into
+  // "Unable to connect", which is a lie whenever the server DID answer.
+  if (
+    !status &&
+    (error?.message?.toLowerCase().includes('network') ||
       error?.message?.toLowerCase().includes('fetch') ||
-      !status) {
+      error instanceof TypeError)
+  ) {
     return AUTH_ERRORS.NETWORK_ERROR
   }
 

--- a/packages/ui/src/lib/password-policy.ts
+++ b/packages/ui/src/lib/password-policy.ts
@@ -1,0 +1,40 @@
+/**
+ * Client-side mirror of the server's password policy
+ * (apps/api/app/services/auth_service.py::validate_password_strength).
+ *
+ * The sign-up form previously gated on a heuristic strength score (>= 50),
+ * which accepts passwords the server then rejects with a 400 — the user was
+ * told (at best) something vague after a round-trip. Validating the exact
+ * policy client-side gives the precise unmet rule before submission; the
+ * server remains the authority.
+ */
+
+export const PASSWORD_SPECIAL_CHARS = '!@#$%^&*()_+-=[]{}|;:,.<>?'
+
+export interface PasswordPolicyResult {
+  ok: boolean
+  /** Human-readable unmet requirements, in server-check order. */
+  failures: string[]
+}
+
+export function validatePasswordPolicy(password: string): PasswordPolicyResult {
+  const failures: string[] = []
+
+  if (password.length < 12) {
+    failures.push('At least 12 characters')
+  }
+  if (!/[A-Z]/.test(password)) {
+    failures.push('At least one uppercase letter')
+  }
+  if (!/[a-z]/.test(password)) {
+    failures.push('At least one lowercase letter')
+  }
+  if (!/\d/.test(password)) {
+    failures.push('At least one number')
+  }
+  if (![...password].some((c) => PASSWORD_SPECIAL_CHARS.includes(c))) {
+    failures.push(`At least one special character (${PASSWORD_SPECIAL_CHARS})`)
+  }
+
+  return { ok: failures.length === 0, failures }
+}


### PR DESCRIPTION
## Operator directive
Make janua-powered auth (registration, password recovery, …) **functional, truthful, complete** — validation and error handling included. Full audit run 2026-08-02; every claim below was live-verified against prod or reproduced locally.

## What was broken (all confirmed)
1. **Every SDK error displayed as a connection error.** `parseApiError` reads `.status`, but `JanuaError` carries `.statusCode` and FastAPI puts the reason in `.detail` — so 400 password-policy rejections AND the prod 503 all rendered as *“Unable to connect to the authentication server”* (operator hit this live on app.dhan.am/register).
2. **Client meter ≠ server policy.** The sign-up gate accepted strength ≥50; the server demands 12+ chars with upper/lower/digit/special → users got a post-round-trip 400 (then mislabeled per #1).
3. **Password recovery has NEVER worked, by construction, three ways:**
   - The endpoint dispatched to a **placebo** `EmailService` (`app/services/email.py` — logs and returns True, sends nothing), via a **misnamed method** (`send_password_reset_email` vs the placebo's `send_password_reset`).
   - The real SMTP mailer (`email_service.py`) **generated its own token** for the URL — never the one stored in `password_resets`, the only store `/password/reset` validates.
   - URLs were built on `BASE_URL` = **auth.madfam.io in prod = the API host, no pages** → guaranteed 404.
4. **Signup 503 root cause (2026-08-02 incident):** the `user.created` webhook event-log INSERT (into `legacy_webhook_events`, a model with **no migration** — prod DB at alembic 002) poisoned the request session; the swallowed exception detonated at the next commit. Every fully-valid signup 503'd *after creating the user row*.
5. **redirectTo/redirectUrl trap:** 0.1.3 consumers (dhanam) pass `redirectUrl`; this repo's renamed `redirectTo` would silently drop their redirect on upgrade (next/dynamic erases prop typing).

## Fixes
- `parseApiError`: statusCode+detail aware; unmatched 400/422 shows the **server's own words**; NETWORK_ERROR only with genuinely no response.
- `lib/password-policy.ts`: exact server policy mirrored client-side; sign-up lists unmet rules pre-submit (no round-trip). Exported.
- react-sdk SignIn/SignUp: `redirectUrl` accepted as deprecated alias of `redirectTo`.
- forgot-password → **real mailer**, with **the stored token**, defaulting to `FRONTEND_URL`'s reset page, honoring allowlisted per-product `redirect_base` (new `PASSWORD_RESET_REDIRECT_ORIGINS` setting) so e.g. dhanam users land on app.dhan.am/reset-password.
- Signup webhook → **isolated session** (cannot poison the signup transaction).
- alembic **009**: `legacy_webhook_events` (IF NOT EXISTS — idempotent vs the prod hand-DDL hotfix).

## Verification
ui: 503 tests passed (updated 1 test asserting the old heuristic gate). react-sdk build+DTS green. Python compiles. Live-verified prod facts recorded in the incident narrative.

## What this does NOT do (deploy-gated, needs operator)
- **No janua prod deploy happens on merge** (no deploy workflow) — API fixes are inert until the next deliberate deploy.
- **Email still cannot SEND until `SMTP_*` env is provisioned** in the janua deployment (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `FROM_EMAIL`, `FROM_NAME`); without it the task now logs a LOUD warning instead of silently pretending.
- At deploy: set `FRONTEND_URL=https://app.janua.dev` (prod currently points it at the API host) and `PASSWORD_RESET_REDIRECT_ORIGINS=https://app.dhan.am/reset-password`; run `alembic upgrade` (or verify the 009 table via the hotfix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)