### PR TITLE
fix(ui): await afterSignIn so the session-cookie bridge wins the navigation race

### DIFF
--- a/packages/ui/src/components/auth/sign-in.test.tsx
+++ b/packages/ui/src/components/auth/sign-in.test.tsx
@@ -187,6 +187,55 @@ describe('SignIn', () => {
       expect(mockAfterSignIn).toHaveBeenCalledWith(mockUser)
     })
 
+    it('awaits an async afterSignIn before navigating (session-bridge contract)', async () => {
+      // Regression: the admin's afterSignIn mirrors SDK tokens into an HttpOnly
+      // session cookie via a server bridge. If SignIn does not await it, a
+      // consumer navigation races the un-awaited bridge and the edge middleware
+      // bounces the authenticated user back to /login. This pins that the async
+      // callback fully resolves BEFORE the redirect fires.
+      const user = userEvent.setup()
+      const events: string[] = []
+      let resolveBridge: () => void = () => {}
+      const bridge = new Promise<void>((r) => {
+        resolveBridge = r
+      })
+      const asyncAfterSignIn = vi.fn(async () => {
+        await bridge
+        events.push('bridge-done')
+      })
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ user: { id: '1', email: 'test@example.com' } }),
+      })
+
+      const hrefSpy = vi.fn()
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: {
+          ...window.location,
+          set href(v: string) {
+            events.push(`redirect:${v}`)
+            hrefSpy(v)
+          },
+        },
+      })
+
+      render(<SignIn afterSignIn={asyncAfterSignIn} redirectUrl="/dashboard" />)
+      await user.type(screen.getByRole('textbox', { name: /email/i }), 'test@example.com')
+      await user.type(screen.getByLabelText('Password'), 'password123')
+      await user.click(screen.getByRole('button', { name: /sign in/i }))
+
+      await waitFor(() => expect(asyncAfterSignIn).toHaveBeenCalled())
+      // The redirect must NOT have fired while the bridge is still pending.
+      expect(hrefSpy).not.toHaveBeenCalled()
+
+      resolveBridge()
+      await waitFor(() => expect(hrefSpy).toHaveBeenCalledWith('/dashboard'))
+      // Ordering proof: the bridge resolved before the redirect.
+      expect(events).toEqual(['bridge-done', 'redirect:/dashboard'])
+    })
+
     it('should include remember me in submission when checked', async () => {
       const user = userEvent.setup()
       global.fetch = vi.fn().mockResolvedValue({

--- a/packages/ui/src/components/auth/sign-in.tsx
+++ b/packages/ui/src/components/auth/sign-in.tsx
@@ -17,8 +17,10 @@ export interface SignInProps {
   redirectUrl?: string
   /** URL to sign-up page */
   signUpUrl?: string
-  /** Callback after successful sign-in */
-  afterSignIn?: (user: any) => void
+  /** Callback after successful sign-in. Awaited: return a Promise (e.g. an
+   *  HttpOnly session-cookie bridge) to guarantee it completes before any
+   *  post-sign-in navigation. */
+  afterSignIn?: (user: any) => void | Promise<void>
   /** Callback on error */
   onError?: (error: Error) => void
   /** Theme customization */
@@ -155,7 +157,15 @@ export function SignIn({
           return
         }
 
-        afterSignIn?.(response.user)
+        // AWAIT afterSignIn: consumers use it to mirror the SDK's freshly
+        // persisted tokens into an HttpOnly session cookie (the admin's
+        // /api/auth/session bridge). If we don't await, a consumer that
+        // navigates on return races the un-awaited bridge — the edge
+        // middleware then sees no cookie and bounces the (authenticated)
+        // user back to /login with tokens stranded in localStorage. Awaiting
+        // also lets a bridge failure surface through onError instead of
+        // becoming a silent unhandled rejection.
+        await afterSignIn?.(response.user)
 
         if (redirectUrl) {
           window.location.href = redirectUrl
@@ -186,7 +196,9 @@ export function SignIn({
         }
 
         const data = await response.json()
-        afterSignIn?.(data.user)
+        // Awaited for the same reason as the SDK branch above: a consumer's
+        // cookie-bridge must finish before any post-sign-in navigation.
+        await afterSignIn?.(data.user)
 
         if (redirectUrl) {
           window.location.href = redirectUrl


### PR DESCRIPTION
## The bug
Signing into **admin.janua.dev** with valid SSO credentials (admin@madfam.io) lands on `/login` instead of the dashboard, even though login succeeded.

## Root cause (verified live)
`SignIn` calls `afterSignIn?.(user)` **without awaiting**. The admin's `afterSignIn` is async — it mirrors the SDK's freshly-persisted localStorage tokens into an HttpOnly session cookie via the `/api/auth/session` bridge, then navigates. Un-awaited, the navigation races the bridge; the edge middleware sees no cookie and bounces the authenticated user back to `/login`, tokens stranded in localStorage.

Diagnosed in the browser: access token present in `localStorage`, `GET /auth/me` returns 200 + the real admin identity with a Bearer, but `document.cookie` empty. Replaying the bridge POST by hand returned `{ok:true}` and the dashboard rendered immediately.

## Fix
- `await afterSignIn?.(user)` in both the SDK and direct-`/auth/login` branches, so any consumer cookie-bridge completes before post-sign-in navigation.
- Bridge failures now surface through `onError` instead of becoming silent unhandled rejections.
- `afterSignIn` type widened to `(user) => void | Promise<void>`.
- Regression test asserts an async `afterSignIn` resolves **before** `redirectUrl` navigation (explicit ordering).

## Validation
UI test suite: **504 passed** (new regression test included). `sign-in.tsx` typechecks clean in isolation.

Sibling of #471 (provider-side event-name bounce, merged 08-01) — this is the component-side half of the same login-bounce family.

> Note (separate, pre-existing): `packages/ui/src/index.ts` re-exports `validatePasswordPolicy`/`PASSWORD_SPECIAL_CHARS` through the auth barrel, which doesn't export them (they live in `lib/password-policy`). Present on main before this PR; left out to keep this change surgical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)