### PR TITLE
fix(ui): avoid string spread in password policy — unbreaks the dashboard image

### DIFF
--- a/packages/ui/src/lib/password-policy.ts
+++ b/packages/ui/src/lib/password-policy.ts
@@ -32,7 +32,13 @@ export function validatePasswordPolicy(password: string): PasswordPolicyResult {
   if (!/\d/.test(password)) {
     failures.push('At least one number')
   }
-  if (![...password].some((c) => PASSWORD_SPECIAL_CHARS.includes(c))) {
+  // Array.from, not [...password]: spreading a string requires
+  // --downlevelIteration under the consuming apps' TS target, and this module
+  // is compiled by each app (dashboard/admin/website), not prebuilt. The
+  // spread form type-checked only while the module was unreachable from the
+  // package entrypoint — it broke the dashboard build the moment the export
+  // was wired up correctly.
+  if (!Array.from(password).some((c) => PASSWORD_SPECIAL_CHARS.includes(c))) {
     failures.push(`At least one special character (${PASSWORD_SPECIAL_CHARS})`)
   }
 


### PR DESCRIPTION
Follow-up to #477. That PR fixed the barrel export and the frontend build went green in PR CI — but the **Docker** build for the dashboard then failed on a *second*, independent defect in the same module:

```
packages/ui/src/lib/password-policy.ts:35:12
Type error: Type 'string' can only be iterated through when using the
'--downlevelIteration' flag or with a '--target' of 'es2015'
```

## Why it appeared only now

`[...password]` type-checked for as long as **nothing could import the module**. Wiring the export up correctly made it reachable from the package entrypoint, so each consuming app compiles it — and the dashboard's TS target rejects string spread.

Same root pathology as the barrel bug: *an unreachable module is an unverified module.* Fixing #477 didn't cause this; it revealed it.

## The fix

`Array.from(password)` — target-agnostic, semantically identical.

Fixing the source rather than loosening the dashboard's `tsconfig`: `@janua/ui` ships TypeScript that every app compiles, so it must hold to the **strictest** consumer target, not the loosest. Relaxing tsconfig would move the constraint to the wrong side of the boundary and let the next such defect through.

## Swept for recurrence

Checked every spread in `packages/ui/src`: all others are over arrays (confirmed `digits` is `string[]`, not a string). This was the only string-spread site.

## Note on why PR CI didn't catch it

`Frontend Tests & Build` passed on #477 while the Docker build failed — the two use different compilation paths (the image runs `next build` per app with the app's own tsconfig and a full type-check pass). Worth aligning later so image-only failures stop reaching main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)