### PR TITLE
fix(dashboard): one session-cookie constant — ends the post-login redirect loop

### DIFF
--- a/apps/dashboard/app/login/page.tsx
+++ b/apps/dashboard/app/login/page.tsx
@@ -1,5 +1,14 @@
 'use client'
 
+import {
+  ACCESS_TOKEN_KEY,
+  REFRESH_TOKEN_KEY,
+  TOKEN_EXPIRES_AT_KEY,
+  USER_KEY,
+  setAuthCookie,
+  clearAuthCookie,
+} from '@/lib/auth-storage'
+
 import { Suspense, useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@janua/ui'
@@ -8,13 +17,6 @@ import { Shield, Loader2, AlertCircle } from 'lucide-react'
 import { januaClient } from '@/lib/janua-client'
 
 // Storage keys - must match auth.tsx
-const STORAGE_KEYS = {
-  ACCESS_TOKEN: 'janua_access_token',
-  REFRESH_TOKEN: 'janua_refresh_token',
-  TOKEN_EXPIRES_AT: 'janua_token_expires_at',
-  USER: 'janua_user',
-  COOKIE: 'janua_access_token',
-} as const
 
 /**
  * Clears all authentication state - called on login page load
@@ -23,13 +25,12 @@ const STORAGE_KEYS = {
 function clearAuthStateOnLoad(reason: string | null): void {
   if (!reason) return
 
-  localStorage.removeItem(STORAGE_KEYS.ACCESS_TOKEN)
-  localStorage.removeItem(STORAGE_KEYS.REFRESH_TOKEN)
-  localStorage.removeItem(STORAGE_KEYS.TOKEN_EXPIRES_AT)
-  localStorage.removeItem(STORAGE_KEYS.USER)
+  localStorage.removeItem(ACCESS_TOKEN_KEY)
+  localStorage.removeItem(REFRESH_TOKEN_KEY)
+  localStorage.removeItem(TOKEN_EXPIRES_AT_KEY)
+  localStorage.removeItem(USER_KEY)
 
-  document.cookie = `${STORAGE_KEYS.COOKIE}=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT`
-  document.cookie = `${STORAGE_KEYS.COOKIE}=; path=/; domain=.janua.dev; expires=Thu, 01 Jan 1970 00:00:01 GMT`
+  clearAuthCookie()
 }
 
 function isSafeRedirectPath(path: string): boolean {
@@ -61,13 +62,12 @@ function LoginForm() {
 
   const handleAfterSignIn = (user: any) => {
     // Sync cookie for middleware compatibility
-    const token = localStorage.getItem(STORAGE_KEYS.ACCESS_TOKEN)
+    const token = localStorage.getItem(ACCESS_TOKEN_KEY)
     if (token) {
-      const cookieDomain = window.location.hostname.includes('janua.dev') ? '; domain=.janua.dev' : ''
-      document.cookie = `${STORAGE_KEYS.COOKIE}=${token}; path=/${cookieDomain}; secure; samesite=lax`
+      setAuthCookie(token)
     }
     if (user) {
-      localStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(user))
+      localStorage.setItem(USER_KEY, JSON.stringify(user))
     }
     router.push(redirectTo)
   }

--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -16,6 +16,7 @@ import {
   Settings
 } from 'lucide-react'
 import { DashboardStats } from '@/components/dashboard/stats'
+import { getAuthToken, clearAuthCookie, USER_KEY } from '@/lib/auth-storage'
 import { RecentActivity } from '@/components/dashboard/recent-activity'
 import { UsersDataTable } from '@/components/users/users-data-table'
 import { SessionList } from '@/components/sessions/session-list'
@@ -74,13 +75,13 @@ function DashboardContent() {
     // Check authentication and load user data
     const initializeDashboard = async () => {
       try {
-        const token = getCookie('janua_token')
+        const token = getAuthToken()
         if (!token) {
           window.location.href = '/login'
           return
         }
 
-        const storedUser = localStorage.getItem('janua_user')
+        const storedUser = localStorage.getItem(USER_KEY)
         if (storedUser) {
           setUser(JSON.parse(storedUser))
         }
@@ -97,23 +98,11 @@ function DashboardContent() {
 
   const handleLogout = () => {
     // Clear authentication (both local and cross-domain for SSO cleanup)
-    document.cookie = 'janua_token=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT'
-    document.cookie = 'janua_token=; path=/; domain=.janua.dev; expires=Thu, 01 Jan 1970 00:00:01 GMT'
-    localStorage.removeItem('janua_user')
+    clearAuthCookie()
+    localStorage.removeItem(USER_KEY)
     window.location.href = '/login'
   }
 
-  // Helper function to get cookie value
-  const getCookie = (name: string): string | null => {
-    if (typeof document === 'undefined') return null
-
-    const value = `; ${document.cookie}`
-    const parts = value.split(`; ${name}=`)
-    if (parts.length === 2) {
-      return parts.pop()?.split(';').shift() || null
-    }
-    return null
-  }
 
   if (isLoading) {
     return (

--- a/apps/dashboard/components/layout/dashboard-layout.tsx
+++ b/apps/dashboard/components/layout/dashboard-layout.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { Sidebar } from './sidebar'
+import { getAuthToken, clearAuthCookie, USER_KEY } from '@/lib/auth-storage'
 
 interface DashboardLayoutProps {
   children: React.ReactNode
@@ -16,13 +17,13 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
   useEffect(() => {
     const initializeAuth = async () => {
       try {
-        const token = getCookie('janua_token')
+        const token = getAuthToken()
         if (!token) {
           router.push('/login')
           return
         }
 
-        const storedUser = localStorage.getItem('janua_user')
+        const storedUser = localStorage.getItem(USER_KEY)
         if (storedUser) {
           setUser(JSON.parse(storedUser))
         }
@@ -37,20 +38,10 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
     initializeAuth()
   }, [router])
 
-  const getCookie = (name: string): string | null => {
-    if (typeof document === 'undefined') return null
-    const value = `; ${document.cookie}`
-    const parts = value.split(`; ${name}=`)
-    if (parts.length === 2) {
-      return parts.pop()?.split(';').shift() || null
-    }
-    return null
-  }
 
   const handleLogout = () => {
-    document.cookie = 'janua_token=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT'
-    document.cookie = 'janua_token=; path=/; domain=.janua.dev; expires=Thu, 01 Jan 1970 00:00:01 GMT'
-    localStorage.removeItem('janua_user')
+    clearAuthCookie()
+    localStorage.removeItem(USER_KEY)
     router.push('/login')
   }
 

--- a/apps/dashboard/lib/auth-keys.ts
+++ b/apps/dashboard/lib/auth-keys.ts
@@ -1,0 +1,37 @@
+/**
+ * Auth storage key names — the single source of truth, shared by the edge
+ * middleware and the browser code.
+ *
+ * Deliberately DOM-free and dependency-free so `middleware.ts` (edge runtime)
+ * can import it. Browser-only helpers live in `./auth-storage`, which imports
+ * from here.
+ *
+ * WHY THIS EXISTS: these strings were hand-written at five call sites and
+ * drifted. The login page wrote `janua_access_token` (matching middleware),
+ * while the post-login page and layout read `janua_token`. Middleware admitted
+ * the user; the page found no cookie and redirected to /login; middleware
+ * bounced them back — an infinite loop that looked like a frozen loading
+ * screen after a SUCCESSFUL login, with nothing logged on either side.
+ *
+ * Because middleware.ts and the pages now import the SAME constant, that
+ * divergence is a compile error rather than a silent redirect loop. Keep it
+ * that way: import these names, never re-type them.
+ */
+
+/** Session cookie the middleware gates every request on. */
+export const AUTH_COOKIE = 'janua_access_token'
+
+/** localStorage key holding the SDK's access token. */
+export const ACCESS_TOKEN_KEY = 'janua_access_token'
+
+/** localStorage key holding the refresh token. */
+export const REFRESH_TOKEN_KEY = 'janua_refresh_token'
+
+/** localStorage key holding the access-token expiry timestamp. */
+export const TOKEN_EXPIRES_AT_KEY = 'janua_token_expires_at'
+
+/** localStorage key holding the serialized user object. */
+export const USER_KEY = 'janua_user'
+
+/** Cookie domain suffix so the session is shared across *.janua.dev hosts. */
+export const COOKIE_DOMAIN_SUFFIX = 'janua.dev'

--- a/apps/dashboard/lib/auth-storage.ts
+++ b/apps/dashboard/lib/auth-storage.ts
@@ -1,0 +1,75 @@
+/**
+ * Canonical auth storage keys for the dashboard.
+ *
+ * WHY THIS FILE EXISTS: these names were previously hand-written at five call
+ * sites, and they drifted. The login page wrote the session cookie as
+ * `janua_access_token` (matching middleware.ts, which gates every route), while
+ * app/page.tsx and components/layout/dashboard-layout.tsx read `janua_token`
+ * and the logout handlers cleared `janua_token`.
+ *
+ * The result was an infinite redirect loop that presented as a frozen loading
+ * screen after a SUCCESSFUL login: middleware saw a valid `janua_access_token`
+ * and admitted the user to `/`; the page looked for `janua_token`, found
+ * nothing, and sent them to `/login`; middleware saw the valid cookie again and
+ * bounced them back to `/`. Neither side believed it had failed, so nothing was
+ * logged and no error surfaced. Logout was broken by the same typo — it cleared
+ * a cookie that did not exist, leaving the real session intact.
+ *
+ * Import these constants. Do not re-type the strings.
+ */
+
+import {
+  AUTH_COOKIE,
+  COOKIE_DOMAIN_SUFFIX,
+} from './auth-keys'
+
+// Re-exported so callers have one import site for keys AND helpers.
+export {
+  AUTH_COOKIE,
+  ACCESS_TOKEN_KEY,
+  REFRESH_TOKEN_KEY,
+  TOKEN_EXPIRES_AT_KEY,
+  USER_KEY,
+} from './auth-keys'
+
+/** Read a cookie value by name; returns null on the server or when absent. */
+export function getCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null
+  const value = `; ${document.cookie}`
+  const parts = value.split(`; ${name}=`)
+  if (parts.length === 2) {
+    return parts.pop()?.split(';').shift() || null
+  }
+  return null
+}
+
+/** The session token as middleware sees it. */
+export function getAuthToken(): string | null {
+  return getCookie(AUTH_COOKIE)
+}
+
+/**
+ * Persist the session cookie. Scoped to .janua.dev in production so the
+ * dashboard, admin and website share one session; host-only elsewhere
+ * (localhost, preview hosts) where a domain attribute would be rejected.
+ */
+export function setAuthCookie(token: string): void {
+  if (typeof document === 'undefined') return
+  const domain = window.location.hostname.includes(COOKIE_DOMAIN_SUFFIX)
+    ? `; domain=.${COOKIE_DOMAIN_SUFFIX}`
+    : ''
+  document.cookie = `${AUTH_COOKIE}=${token}; path=/${domain}; secure; samesite=lax`
+}
+
+/**
+ * Clear the session everywhere it could live. Both the host-only and
+ * domain-scoped forms are expired, because a cookie set with a domain
+ * attribute is NOT removed by expiring the host-only one — that asymmetry is
+ * how a "logged out" user stayed logged in.
+ */
+export function clearAuthCookie(): void {
+  if (typeof document === 'undefined') return
+  const expired = 'expires=Thu, 01 Jan 1970 00:00:01 GMT'
+  document.cookie = `${AUTH_COOKIE}=; path=/; ${expired}`
+  document.cookie = `${AUTH_COOKIE}=; path=/; domain=.${COOKIE_DOMAIN_SUFFIX}; ${expired}`
+}

--- a/apps/dashboard/middleware.ts
+++ b/apps/dashboard/middleware.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server'
+import { AUTH_COOKIE } from '@/lib/auth-keys'
 import type { NextRequest } from 'next/server'
 
 /**
@@ -45,7 +46,7 @@ export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
 
   // Get token from cookie
-  const token = request.cookies.get('janua_access_token')?.value
+  const token = request.cookies.get(AUTH_COOKIE)?.value
   const hasValidToken = isValidTokenStructure(token)
 
   // If user is authenticated and trying to access login page, redirect to home
@@ -63,7 +64,7 @@ export function middleware(request: NextRequest) {
   if (!hasValidToken) {
     // Clear the invalid cookie
     const response = NextResponse.redirect(new URL('/login', request.url))
-    response.cookies.set('janua_access_token', '', {
+    response.cookies.set(AUTH_COOKIE, '', {
       path: '/',
       expires: new Date(0),
     })


### PR DESCRIPTION
## The bug

Signing in to app.janua.dev with correct credentials leaves you on a **frozen loading screen forever**. The login itself succeeds — the freeze is an infinite redirect loop caused by two names for one cookie:

| Component | Cookie name |
|---|---|
| Login page **writes** | `janua_access_token` ✅ |
| Middleware **reads** | `janua_access_token` ✅ |
| `app/page.tsx` **reads** | `janua_token` ❌ |
| `dashboard-layout.tsx` **reads** | `janua_token` ❌ |
| Both logout handlers **clear** | `janua_token` ❌ |

The loop: sign in → cookie set → middleware admits you to `/` → the page looks for `janua_token`, finds nothing, fires `window.location.href = '/login'` → middleware sees a valid cookie and bounces you back to `/` → forever. **Neither side believes it failed**, so nothing is logged and no error surfaces.

Logout was broken by the same typo: it cleared a cookie that doesn't exist, leaving the real session intact.

## The fix

Not "correct three strings" — that leaves the next drift undetected. The names now live in one **DOM-free module** (`lib/auth-keys.ts`) imported by **both the edge middleware and the browser code**, so divergence is a *compile error* rather than a silent redirect loop.

`lib/auth-storage.ts` adds the browser helpers (`getAuthToken` / `setAuthCookie` / `clearAuthCookie`) so no call site hand-writes a cookie string. `clearAuthCookie` expires **both** the host-only and `.janua.dev`-scoped forms — expiring only the host-only one is exactly why "logged out" users stayed logged in.

## Verification, and its limits

Verified mechanically: every consumer imports the shared keys and **zero hardcoded session-cookie names remain**. That check is what caught a **second middleware site** my first pass missed — the invalid-token clear path at line 67. All six changed files parse clean.

**Not** verified by a local build: `pnpm install --frozen-lockfile` fails on pre-existing lockfile drift (9 svelte-SDK deps missing from the lockfile) and the private registry needs `NPM_MADFAM_TOKEN`. The Docker build on merge is the real proof.

## Why a test wasn't the answer here

I wrote one, then deleted it — because **CI would never have run it**. `pnpm test:unit` → `test:packages` → `cd packages/core && npm test`. The dashboard ships `app/page.test.tsx` and `lib/utils.test.ts` that **nothing executes**; `pnpm lint` and `pnpm typecheck` are also packages/core-only. The single thing exercising this app in CI is the Docker `next build`.

That gap is why a defect this simple reached production and survived. Making the invariant **structural** puts it where the one job that does run will catch it. Wiring the dashboard's orphaned tests into CI is worth a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)