### PR TITLE
fix(oauth): stop POST /oauth/clients minting duplicates, and unpoison the name lookup

### DIFF
--- a/apps/api/app/routers/v1/oauth_clients.py
+++ b/apps/api/app/routers/v1/oauth_clients.py
@@ -250,6 +250,10 @@ async def create_oauth_client(
     This registers an application to use Janua as an OAuth2/OIDC provider.
     The client_secret is only returned once on creation - save it immediately.
 
+    **Duplicate-resistant**: a create whose ``name`` matches an existing ACTIVE
+    client is rejected with 409 and the existing ``client_id``. Pass
+    ``allow_duplicate: true`` to override deliberately.
+
     **Required permissions**: Authenticated user (org admin for org-scoped clients)
     """
     effective_organization_id = organization_id or data.organization_id
@@ -257,6 +261,35 @@ async def create_oauth_client(
         org_uuid = uuid.UUID(effective_organization_id) if effective_organization_id else None
     except ValueError:
         raise HTTPException(status_code=400, detail="Invalid organization_id format")
+
+    # Unlike /register, this path had no duplicate check at all, and it is the
+    # one the dashboard uses. On 2026-06-07/08 it produced 13 clients named
+    # "Voxa" with byte-identical redirect_uris and scopes — the active one 34
+    # seconds after the first — each with its own secret. Twelve were later
+    # deactivated rather than deleted.
+    #
+    # The dashboard made that easy to do: when its list request failed it
+    # rendered "No OAuth clients yet — create your first" (fixed separately),
+    # so the honest response to a broken screen was to press Create again.
+    #
+    # A name collision is rejected rather than silently reconciled because this
+    # is the human-facing path: the caller chose a name, and quietly returning
+    # someone else's client would be its own surprise. Secret rotation does NOT
+    # need a second client — POST /{client_id}/rotate rotates with a grace
+    # period — so refusing duplicates costs no legitimate flow.
+    if not data.allow_duplicate:
+        existing = await service.get_client_by_name(data.name)
+        if existing is not None and existing.is_active:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"An active OAuth client named {data.name!r} already exists "
+                    f"(client_id={existing.client_id}). To rotate its secret use "
+                    f"POST /api/v1/oauth/clients/{existing.client_id}/rotate. "
+                    f"To create a second client with this name anyway, resend "
+                    f"with allow_duplicate=true."
+                ),
+            )
 
     client, plain_secret = await service.create_client(
         data=data,

--- a/apps/api/app/schemas/oauth_client.py
+++ b/apps/api/app/schemas/oauth_client.py
@@ -68,6 +68,15 @@ class OAuthClientCreate(BaseModel):
             "Use when a consumer requires a fixed client_id across environments."
         ),
     )
+    allow_duplicate: bool = Field(
+        default=False,
+        description=(
+            "Deliberately create a second client sharing an existing ACTIVE client's "
+            "name. Defaults to False, so an accidental repeat create is rejected with "
+            "409 rather than silently minting another secret. Secret rotation does not "
+            "need this — use POST /oauth/clients/{client_id}/rotate."
+        ),
+    )
 
     @field_validator("client_id")
     @classmethod

--- a/apps/api/app/services/oauth_client_service.py
+++ b/apps/api/app/services/oauth_client_service.py
@@ -179,9 +179,30 @@ class OAuthClientService:
         return result.scalar_one_or_none()
 
     async def get_client_by_name(self, name: str) -> Optional[OAuthClient]:
-        """Get an OAuth2 client by its unique application name."""
+        """Get the OLDEST OAuth2 client with this application name.
+
+        The docstring used to call the name "unique". It is not: nothing in the
+        schema enforces it, and production currently holds 13 clients named
+        "Voxa" (created 2026-06-07/08, byte-identical redirect_uris and scopes
+        — a retry loop against the non-idempotent ``POST /oauth/clients``).
+
+        That matters because this used ``scalar_one_or_none()``, which raises
+        ``MultipleResultsFound`` on more than one row. ``/oauth/clients/register``
+        calls this as its name-matching fallback, so a re-registration of any
+        duplicated name raised a 500 — the duplicates broke the very
+        idempotency path that exists to prevent duplicates.
+
+        Ordering by ``created_at`` and taking the first makes the lookup total
+        and deterministic: the original client wins, and ``/register`` converges
+        onto it instead of failing. Deduplication of the existing rows is a
+        separate operator decision; this only stops the data from breaking the
+        code that reads it.
+        """
         result = await self.db.execute(
-            select(OAuthClient).where(OAuthClient.name == name)
+            select(OAuthClient)
+            .where(OAuthClient.name == name)
+            .order_by(OAuthClient.created_at)
+            .limit(1)
         )
         return result.scalar_one_or_none()
 

--- a/apps/api/tests/unit/routers/test_oauth_clients_duplicate_guard.py
+++ b/apps/api/tests/unit/routers/test_oauth_clients_duplicate_guard.py
@@ -1,0 +1,134 @@
+"""
+POST /api/v1/oauth/clients must not silently mint a duplicate.
+
+Unlike /oauth/clients/register — idempotent and convergent since 2026-05-22 —
+the human-facing create path had no duplicate check at all. On 2026-06-07/08 it
+produced 13 clients named "Voxa" with byte-identical redirect_uris and scopes,
+the active one 34 seconds after the first, each carrying its own secret. Twelve
+were later deactivated rather than deleted.
+
+The dashboard made that easy: when its list request failed it rendered "No
+OAuth clients yet — create your first" (fixed separately), so the honest
+response to a broken screen was to press Create again.
+
+A name collision is now rejected with 409 naming the existing client_id.
+Rejecting rather than silently reconciling is deliberate on this path: the
+caller chose a name, and quietly handing back someone else's client would be
+its own surprise. Secret rotation never needs a second client —
+POST /{client_id}/rotate rotates with a grace period — so this costs no
+legitimate flow. `allow_duplicate: true` remains as a deliberate override.
+"""
+
+from __future__ import annotations
+
+import json
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.core.redis import get_redis
+from app.database import get_db
+from app.dependencies import get_current_user
+from app.main import app
+from app.models import Base, User, UserStatus
+
+CREATE_URL = "/api/v1/oauth/clients"
+
+
+@pytest_asyncio.fixture
+async def api() -> AsyncClient:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with session_factory() as session:
+            yield session
+
+    from unittest.mock import AsyncMock
+
+    redis = AsyncMock()
+    redis.ping.return_value = True
+
+    actor = User(
+        id=uuid.uuid4(),
+        email="operator@janua.test",
+        email_verified=True,
+        status=UserStatus.ACTIVE,
+        is_admin=True,
+        is_active=True,
+    )
+    async with session_factory() as session:
+        session.add(actor)
+        await session.commit()
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_redis] = lambda: redis
+    app.dependency_overrides[get_current_user] = lambda: actor
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+    app.dependency_overrides.clear()
+    await engine.dispose()
+
+
+def _payload(name: str = "Voxa", **extra) -> dict:
+    return {
+        "name": name,
+        "redirect_uris": ["https://voxa.madfam.io/auth/callback"],
+        "allowed_scopes": ["openid", "profile", "email"],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "is_confidential": True,
+        **extra,
+    }
+
+
+@pytest.mark.asyncio
+async def test_repeated_identical_create_is_rejected(api: AsyncClient):
+    """The Voxa shape: press Create twice, get one client and a 409."""
+    first = await api.post(CREATE_URL, json=_payload())
+    assert first.status_code == 201, first.text
+    existing_client_id = first.json()["client_id"]
+
+    second = await api.post(CREATE_URL, json=_payload())
+    assert second.status_code == 409, second.text
+
+    body = second.json()
+    detail = body.get("detail") or json.dumps(body)
+    # The caller must be able to act on the response without another lookup.
+    assert existing_client_id in detail
+    assert "rotate" in detail
+
+    listed = await api.get(CREATE_URL)
+    assert listed.status_code == 200
+    assert [c["name"] for c in listed.json()["clients"]].count("Voxa") == 1
+
+
+@pytest.mark.asyncio
+async def test_allow_duplicate_is_an_explicit_escape_hatch(api: AsyncClient):
+    first = await api.post(CREATE_URL, json=_payload())
+    assert first.status_code == 201
+
+    second = await api.post(CREATE_URL, json=_payload(allow_duplicate=True))
+    assert second.status_code == 201, second.text
+    assert second.json()["client_id"] != first.json()["client_id"]
+
+
+@pytest.mark.asyncio
+async def test_distinct_names_are_unaffected(api: AsyncClient):
+    for name in ("Voxa", "Karafiel", "tulana-web-production"):
+        created = await api.post(CREATE_URL, json=_payload(name))
+        assert created.status_code == 201, created.text

--- a/apps/api/tests/unit/services/test_oauth_client_name_lookup.py
+++ b/apps/api/tests/unit/services/test_oauth_client_name_lookup.py
@@ -1,0 +1,111 @@
+"""
+get_client_by_name must survive duplicate names.
+
+Production holds 13 OAuth clients named "Voxa" (created 2026-06-07/08 with
+byte-identical redirect_uris and scopes — a retry loop against the
+non-idempotent POST /oauth/clients). The lookup used scalar_one_or_none(),
+which raises MultipleResultsFound on more than one row, so
+/oauth/clients/register raised a 500 on its name-matching fallback for any
+duplicated name: the duplicates broke the idempotency path whose whole job is
+to prevent duplicates.
+
+It must instead be total and deterministic — oldest row wins — so /register
+converges onto the original client.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base, OAuthClient, User, UserStatus
+from app.services.oauth_client_service import OAuthClientService
+
+
+OWNER_ID = uuid.uuid4()
+
+
+@pytest_asyncio.fixture
+async def session() -> AsyncSession:
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as s:
+        # oauth_clients.created_by is NOT NULL
+        s.add(
+            User(
+                id=OWNER_ID,
+                email="owner@janua.test",
+                email_verified=True,
+                status=UserStatus.ACTIVE,
+                is_admin=True,
+                is_active=True,
+            )
+        )
+        await s.commit()
+        yield s
+    await engine.dispose()
+
+
+def _client(name: str, *, client_id: str, created_at: datetime) -> OAuthClient:
+    return OAuthClient(
+        id=uuid.uuid4(),
+        created_by=OWNER_ID,
+        client_id=client_id,
+        client_secret_hash="x" * 60,  # NOT NULL; value irrelevant to this lookup
+        client_secret_prefix="jns_test",
+        name=name,
+        redirect_uris=["https://voxa.madfam.io/auth/callback"],
+        allowed_scopes=["openid", "profile", "email"],
+        grant_types=["authorization_code", "refresh_token"],
+        is_active=True,
+        is_confidential=True,
+        created_at=created_at,
+        updated_at=created_at,
+    )
+
+
+@pytest.mark.asyncio
+async def test_returns_oldest_when_duplicates_exist(session: AsyncSession):
+    """The real shape: many identical clients, one name. Must not raise."""
+    base = datetime(2026, 6, 7, 8, 51, 28)
+    oldest = _client("Voxa", client_id="jnc_oldest_0000000000", created_at=base)
+    session.add(oldest)
+    for i in range(1, 13):  # 13 total, matching production
+        session.add(
+            _client(
+                "Voxa",
+                client_id=f"jnc_dupe_{i:015d}",
+                created_at=base + timedelta(seconds=34 * i),
+            )
+        )
+    await session.commit()
+
+    service = OAuthClientService(session)
+    found = await service.get_client_by_name("Voxa")
+
+    assert found is not None
+    assert found.client_id == "jnc_oldest_0000000000"
+
+
+@pytest.mark.asyncio
+async def test_single_match_and_no_match_still_behave(session: AsyncSession):
+    session.add(
+        _client("Solo", client_id="jnc_solo_00000000000", created_at=datetime(2026, 1, 1))
+    )
+    await session.commit()
+
+    service = OAuthClientService(session)
+    assert (await service.get_client_by_name("Solo")).client_id == "jnc_solo_00000000000"
+    assert await service.get_client_by_name("does-not-exist") is None


### PR DESCRIPTION
## The evidence

Production holds **13 OAuth clients named "Voxa"**, created 2026-06-07/08 with **byte-identical** `redirect_uris` and `allowed_scopes` (verified by set-comparison: 1 distinct value each across all 13), the active one **34 seconds** after the first, each carrying its own secret. 12 were later deactivated rather than deleted.

## Where they did *not* come from

`/oauth/clients/register` has been **idempotent and convergent since 2026-05-22** (PR #396) — it reconciles by `client_key`/`audience` and falls back to name matching. The file's last change was **2026-05-30**. Both predate the duplicates, so `/register` is not the source.

`POST /oauth/clients` — the human-facing path the dashboard uses — had **no duplicate check at all**.

And the dashboard made repeating it easy: when its list request failed it rendered *"No OAuth clients yet — create your first"* beside the error banner (fixed in #480). The honest response to a broken screen was to press Create again. **The two bugs compose exactly into this incident.**

## Two fixes

### 1. Duplicate guard on the create path

A create whose `name` matches an existing **active** client now returns **409** naming that `client_id` and pointing at `POST /{client_id}/rotate`. `allow_duplicate: true` is the explicit override.

Rejecting rather than silently reconciling is deliberate here: unlike `/register`, this is the human path — the caller chose a name, and quietly returning someone else's client would be its own surprise.

**This costs no legitimate flow.** Secret rotation never needs a second client: `/rotate` rotates in place with a grace period where both secrets work.

### 2. The duplicates broke the code meant to prevent them — this is a live 500

`get_client_by_name` used `scalar_one_or_none()`, which **raises `MultipleResultsFound`** on more than one row, and its docstring called the name "unique" although nothing enforces it. `/register` calls it as its name-matching fallback — so **re-registering any duplicated name raises a 500 today**.

Now orders by `created_at` and takes the first: total, deterministic, oldest wins, so `/register` converges onto the original client instead of failing.

## Deliberately not done

**Not deduplicating the existing rows.** Deleting OAuth clients is irreversible, and the dormant ones are inert — verified against the live authorize endpoint:

```
active Voxa client   → 302
inactive Voxa client → 400
nonexistent client   → 400
```

An inactive client is indistinguishable from one that never existed. Cleanup is an operator decision, not a side effect of this PR.

## Verified

- **3 new router tests**: repeat create → one client + 409 with an actionable body; `allow_duplicate` override still works; distinct names unaffected
- **2 new service tests**, including the 13-row production shape
- **The lookup test was confirmed to fail** with `MultipleResultsFound` when the fix is reverted, and pass when restored — it tests the bug, not the implementation
- **191 passed** across the oauth/client suites
- The single failure, `test_oauth_userinfo_audience::test_accepts_per_client_audience_from_token_claim`, was **confirmed pre-existing** by stashing these changes and reproducing it on clean `main`