### PR TITLE
fix(db): budget the DB pools — one process could claim 150 of the cluster's 100 slots

### DIFF
--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -65,8 +65,18 @@ class Settings(BaseSettings):
         default="postgresql://postgres:postgres@localhost:5432/janua",
         description="PostgreSQL connection URL",
     )
-    DATABASE_POOL_SIZE: int = Field(default=20)
-    DATABASE_MAX_OVERFLOW: int = Field(default=10)
+    # Connection budget vs the SHARED postgres.data.svc: max_connections=100
+    # for the ENTIRE cluster (3 reserved for superuser), ~90 in use at steady
+    # state, and 3,057 "remaining connection slots are reserved" FATALs logged
+    # in the 48h before the 2026-07-22 exhaustion incident. Budget for
+    # janua-api: 2 replicas x (pool 5 + overflow 5) = 20 absolute max against
+    # a measured steady state of ~5-7 total. Janua is the SSO backbone for
+    # every platform — it must never be the tenant that exhausts the shared
+    # database, because auth outages cascade to all of them. Raise per-env via
+    # these env vars, not by editing code. (Same budgeting pattern as
+    # fortuna/infra/k8s/production/api-deployment.yaml.)
+    DATABASE_POOL_SIZE: int = Field(default=5)
+    DATABASE_MAX_OVERFLOW: int = Field(default=5)
     DATABASE_POOL_TIMEOUT: int = Field(default=30)
     AUTO_MIGRATE: bool = Field(default=False)
 

--- a/apps/api/app/database.py
+++ b/apps/api/app/database.py
@@ -63,15 +63,22 @@ if hasattr(settings, "DATABASE_URL") and settings.DATABASE_URL:
     # Create sync engine for migrations and some operations. Explicitly small:
     # without pool_size, SQLAlchemy's QueuePool default (5+10) adds 15 more
     # legal claims per process on top of the async pool's budget, for an
-    # engine that idles at 0-1 connections.
-    sync_engine = create_engine(
-        database_url,
-        echo=settings.DEBUG if hasattr(settings, "DEBUG") else False,
-        pool_pre_ping=True,
-        pool_size=2,
-        max_overflow=3,
-        pool_timeout=settings.DATABASE_POOL_TIMEOUT,
-    )
+    # engine that idles at 0-1 connections. Pool args are QueuePool-only, so
+    # they get the same sqlite guard as the async engine above — SQLite tests
+    # run on StaticPool, which rejects them at import time.
+    sync_engine_kwargs = {
+        "echo": settings.DEBUG if hasattr(settings, "DEBUG") else False,
+        "pool_pre_ping": True,
+    }
+    if "sqlite" not in database_url:
+        sync_engine_kwargs.update(
+            {
+                "pool_size": 2,
+                "max_overflow": 3,
+                "pool_timeout": settings.DATABASE_POOL_TIMEOUT,
+            }
+        )
+    sync_engine = create_engine(database_url, **sync_engine_kwargs)
 else:
     # Require explicit DATABASE_URL configuration
     DATABASE_URL = os.getenv("DATABASE_URL")

--- a/apps/api/app/database.py
+++ b/apps/api/app/database.py
@@ -28,12 +28,18 @@ if hasattr(settings, "DATABASE_URL") and settings.DATABASE_URL:
 
     # Add pooling parameters only for non-SQLite databases
     if "sqlite" not in async_database_url:
+        # Pool caps come from settings (env-overridable), never hardcoded here.
+        # The previous values — pool_size=50, max_overflow=100, "increased to
+        # handle concurrent requests" — let ONE process claim 150 connections
+        # on a shared server with max_connections=100. They also silently
+        # ignored the DATABASE_POOL_SIZE field that config.py already carried.
+        # Budget rationale lives on the fields in config.py.
         engine_kwargs.update(
             {
-                "pool_size": 50,  # Increased from 5 to handle concurrent requests
-                "max_overflow": 100,  # Increased from 10 for burst capacity
+                "pool_size": settings.DATABASE_POOL_SIZE,
+                "max_overflow": settings.DATABASE_MAX_OVERFLOW,
                 "pool_recycle": 3600,  # Recycle connections after 1 hour
-                "pool_timeout": 30,  # Wait up to 30 seconds for a connection
+                "pool_timeout": settings.DATABASE_POOL_TIMEOUT,
             }
         )
         # Disable SSL for asyncpg if connecting to PostgreSQL without SSL
@@ -54,11 +60,17 @@ if hasattr(settings, "DATABASE_URL") and settings.DATABASE_URL:
 
     engine = create_async_engine(async_database_url, **engine_kwargs)
 
-    # Create sync engine for migrations and some operations
+    # Create sync engine for migrations and some operations. Explicitly small:
+    # without pool_size, SQLAlchemy's QueuePool default (5+10) adds 15 more
+    # legal claims per process on top of the async pool's budget, for an
+    # engine that idles at 0-1 connections.
     sync_engine = create_engine(
         database_url,
         echo=settings.DEBUG if hasattr(settings, "DEBUG") else False,
         pool_pre_ping=True,
+        pool_size=2,
+        max_overflow=3,
+        pool_timeout=settings.DATABASE_POOL_TIMEOUT,
     )
 else:
     # Require explicit DATABASE_URL configuration
@@ -73,14 +85,21 @@ else:
     # Convert to async URL
     async_database_url = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://")
 
+    # Same budget as the settings-driven branch above (rationale in
+    # config.py). This branch has no `settings`, so read the same env vars
+    # directly — the two paths must never disagree on the cap.
+    _pool_size = int(os.getenv("DATABASE_POOL_SIZE", "5"))
+    _max_overflow = int(os.getenv("DATABASE_MAX_OVERFLOW", "5"))
+    _pool_timeout = int(os.getenv("DATABASE_POOL_TIMEOUT", "30"))
+
     engine = create_async_engine(
         async_database_url,
         echo=True,
         pool_pre_ping=True,
-        pool_size=50,  # Handle concurrent requests
-        max_overflow=100,  # Burst capacity
+        pool_size=_pool_size,
+        max_overflow=_max_overflow,
         pool_recycle=3600,  # Recycle connections after 1 hour
-        pool_timeout=30,  # Wait up to 30 seconds for a connection
+        pool_timeout=_pool_timeout,
         connect_args={"ssl": False},  # Disable SSL for asyncpg
     )
 
@@ -88,10 +107,10 @@ else:
         DATABASE_URL,
         echo=True,
         pool_pre_ping=True,
-        pool_size=50,
-        max_overflow=100,
+        pool_size=2,
+        max_overflow=3,
         pool_recycle=3600,
-        pool_timeout=30,
+        pool_timeout=_pool_timeout,
     )
 
 # Create session factories


### PR DESCRIPTION
## The hazard

`database.py` hardcoded `pool_size=50, max_overflow=100` — while silently ignoring the `DATABASE_POOL_SIZE` field `config.py` already carried. Janua also runs **two** live engine modules (`app/database.py` + `app/core/database_manager.py`, both imported by routers), so one janua-api process could legally claim **~195 connections**; two replicas, ~390.

The shared `postgres.data.svc` has `max_connections=100` for the **entire MADFAM cluster** and runs ~90 in steady state. It logged **3,057** "remaining connection slots are reserved" FATALs in the 48h before the 2026-07-22 exhaustion incident. Janua's actual steady state is 5–7 connections — the 50/100 bought no real headroom, only the ability to take every platform's auth down in a burst.

## The change

- `config.py`: defaults → `pool 5 + overflow 5`, budget rationale on the fields, env-overridable per environment. `database_manager.py` already reads these fields, so both engine paths now draw the same budget.
- `database.py`: main branch uses settings; the no-settings fallback branch reads the same env vars — the paths can no longer disagree. Sync engine pinned to 2+3 (it idles at 0–1; the implicit QueuePool default added 15 more claims).

**Budget: 2 replicas × (5+5 async, 5+5 manager, 2+3 sync) = 50 absolute max, ~10 steady.** Same pattern fortuna adopted after the incident (`fortuna/infra/k8s/production/api-deployment.yaml`).

Part of the 2026-08-05 saturation audit (ledger in internal-devops runbook, same date). Sibling caps: ceq, bloom-scroll, enclii. Follow-up worth its own PR: consolidate the two async engine modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)