### PR TITLE
feat(db): pgbouncer-ready runtime — statement cache off in both engines, migrations stay direct

### DIFF
--- a/apps/api/alembic/env.py
+++ b/apps/api/alembic/env.py
@@ -29,7 +29,10 @@ config = context.config
 
 # Override sqlalchemy.url with our DATABASE_URL
 # Convert to async driver for async migrations
-database_url = settings.DATABASE_URL
+# Migrations keep a DIRECT postgres connection when the runtime routes
+# through pgbouncer (transaction pooling breaks DDL session semantics).
+# DIRECT_DATABASE_URL is optional; unset => DATABASE_URL (unchanged).
+database_url = getattr(settings, "DIRECT_DATABASE_URL", None) or settings.DATABASE_URL
 if database_url.startswith("postgresql://"):
     database_url = database_url.replace("postgresql://", "postgresql+asyncpg://")
 config.set_main_option("sqlalchemy.url", database_url)

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -75,6 +75,9 @@ class Settings(BaseSettings):
     # database, because auth outages cascade to all of them. Raise per-env via
     # these env vars, not by editing code. (Same budgeting pattern as
     # fortuna/infra/k8s/production/api-deployment.yaml.)
+    # Optional: set when runtime DATABASE_URL routes through pgbouncer so
+    # alembic (manual in-pod runs; AUTO_MIGRATE) keeps a direct connection.
+    DIRECT_DATABASE_URL: Optional[str] = Field(default=None)
     DATABASE_POOL_SIZE: int = Field(default=5)
     DATABASE_MAX_OVERFLOW: int = Field(default=5)
     DATABASE_POOL_TIMEOUT: int = Field(default=30)

--- a/apps/api/app/core/database_manager.py
+++ b/apps/api/app/core/database_manager.py
@@ -73,7 +73,10 @@ class DatabaseManager:
                 # Disable SSL for asyncpg connections when DATABASE_SSL_MODE is 'disable'
                 ssl_mode = getattr(settings, "DATABASE_SSL_MODE", "disable")
                 if ssl_mode == "disable" and "asyncpg" in database_url:
-                    engine_kwargs["connect_args"] = {"ssl": False}
+                    # statement_cache_size=0 for pgbouncer transaction pooling
+                    # (same rationale as app/database.py — the two engine
+                    # paths must not diverge on pooler compatibility).
+                    engine_kwargs["connect_args"] = {"ssl": False, "statement_cache_size": 0}
 
                 # Production-specific optimizations
                 if settings.ENVIRONMENT == "production":

--- a/apps/api/app/database.py
+++ b/apps/api/app/database.py
@@ -44,7 +44,12 @@ if hasattr(settings, "DATABASE_URL") and settings.DATABASE_URL:
         )
         # Disable SSL for asyncpg if connecting to PostgreSQL without SSL
         if "asyncpg" in async_database_url:
-            engine_kwargs["connect_args"] = {"ssl": False}
+            # statement_cache_size=0: pgbouncer (transaction pooling)
+            # compatibility — unnamed prepared statements are per-transaction
+            # and pool-safe; named-cache entries break when consecutive
+            # transactions land on different server connections. One extra
+            # round-trip when connecting direct.
+            engine_kwargs["connect_args"] = {"ssl": False, "statement_cache_size": 0}
     else:
         # Use NullPool for SQLite to avoid connection sharing issues
         engine_kwargs["poolclass"] = NullPool
@@ -107,7 +112,7 @@ else:
         max_overflow=_max_overflow,
         pool_recycle=3600,  # Recycle connections after 1 hour
         pool_timeout=_pool_timeout,
-        connect_args={"ssl": False},  # Disable SSL for asyncpg
+        connect_args={"ssl": False, "statement_cache_size": 0},  # asyncpg: no SSL; unnamed statements for pgbouncer
     )
 
     sync_engine = create_engine(

--- a/k8s/base/deployments/janua-api.yaml
+++ b/k8s/base/deployments/janua-api.yaml
@@ -63,6 +63,16 @@ spec:
                 secretKeyRef:
                   name: janua-secrets
                   key: database-url
+            # Direct 5432 URL for alembic when DATABASE_URL routes through
+            # pgbouncer (adoption ruling, move 3). optional: true — absent
+            # until the flip writes the key, and the app treats unset as
+            # "use DATABASE_URL".
+            - name: DIRECT_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: janua-secrets
+                  key: direct-database-url
+                  optional: true
             - name: REDIS_URL
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Move 3 of the pgbouncer adoption ruling (internal-devops runbook 2026-08-05, RULING section) — the SSO backbone, in its low-traffic window. Siblings: bloom-scroll#114, ceq#71.

- `statement_cache_size: 0` merged into the asyncpg `connect_args` of **both** engine paths (`app/database.py` + `core/database_manager.py`) — they must not diverge on pooler compatibility.
- alembic prefers optional `DIRECT_DATABASE_URL` — prod migrations are manual in-pod runs (`AUTO_MIGRATE` unset), and this keeps future ones on direct 5432 automatically.
- Unset ⇒ unchanged; deploys safely before the flip.

Already done for this move: janua-api egress to pgbouncer:6432 (was default-denied — `ConnectionRefusedError` measured from a janua pod; fixed in enclii's policy pack), pooler auth proven end-to-end from a janua pod (`JANUA PGBOUNCER AUTH OK`). After merge: publish → **manual promote dispatch** (scheduled promotes are validation-only — tonight's discovery) → flip → `client_addr` verification + Hosted Auth Synthetics as the SSO proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)