### PR TITLE
test(ui): stop 20 loading-state tests racing a 100ms timer

### DIFF
--- a/packages/ui/src/components/auth/audit-log.test.tsx
+++ b/packages/ui/src/components/auth/audit-log.test.tsx
@@ -350,8 +350,9 @@ describe('AuditLog', () => {
 
     it('should show loading state during export', async () => {
       const user = userEvent.setup()
+      let resolveExport: () => void = () => {}
       mockOnExport.mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 100))
+        () => new Promise<void>((resolve) => { resolveExport = resolve })
       )
 
       render(<AuditLog events={mockEvents} showExport={true} onExport={mockOnExport} />)
@@ -359,7 +360,9 @@ describe('AuditLog', () => {
       const csvButton = screen.getByRole('button', { name: /export csv/i })
       await user.click(csvButton)
 
-      expect(screen.getAllByText(/exporting\.\.\./i)[0]).toBeInTheDocument()
+      expect((await screen.findAllByText(/exporting\.\.\./i))[0]).toBeInTheDocument()
+
+      resolveExport()
 
       await waitFor(() => {
         expect(screen.queryByText(/exporting\.\.\./i)).not.toBeInTheDocument()
@@ -431,8 +434,9 @@ describe('AuditLog', () => {
 
     it('should show loading state during load more', async () => {
       const user = userEvent.setup()
+      let resolveLoadMore: () => void = () => {}
       mockOnLoadMore.mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 100))
+        () => new Promise<void>((resolve) => { resolveLoadMore = resolve })
       )
 
       render(<AuditLog events={mockEvents} hasMore={true} onLoadMore={mockOnLoadMore} />)
@@ -440,7 +444,9 @@ describe('AuditLog', () => {
       const loadMoreButton = screen.getByRole('button', { name: /load more/i })
       await user.click(loadMoreButton)
 
-      expect(screen.getByText(/loading\.\.\./i)).toBeInTheDocument()
+      expect(await screen.findByText(/loading\.\.\./i)).toBeInTheDocument()
+
+      resolveLoadMore()
 
       await waitFor(() => {
         expect(screen.queryByText(/loading\.\.\./i)).not.toBeInTheDocument()

--- a/packages/ui/src/components/auth/backup-codes.test.tsx
+++ b/packages/ui/src/components/auth/backup-codes.test.tsx
@@ -407,8 +407,12 @@ describe('BackupCodes', () => {
     })
 
     it('should show loading state during regeneration', async () => {
+      // Deliberately stays pending: the assertion below is about the loading
+      // state existing, and a 100ms timer made that a race under load. Nothing
+      // here asserts the loading state clearing, so the promise never needs to
+      // settle.
       mockOnRegenerateCodes.mockImplementation(
-        () => new Promise((resolve) => setTimeout(() => resolve([]), 100))
+        () => new Promise(() => {})
       )
 
       render(

--- a/packages/ui/src/components/auth/device-management.test.tsx
+++ b/packages/ui/src/components/auth/device-management.test.tsx
@@ -278,8 +278,9 @@ describe('DeviceManagement', () => {
 
     it('should show loading state during trust', async () => {
       const user = userEvent.setup()
+      let resolveTrust: () => void = () => {}
       mockOnTrustDevice.mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 100))
+        () => new Promise<void>((resolve) => { resolveTrust = resolve })
       )
 
       render(
@@ -293,7 +294,9 @@ describe('DeviceManagement', () => {
       const trustButton = screen.getByRole('button', { name: /trust device/i })
       await user.click(trustButton)
 
-      expect(screen.getByText(/processing\.\.\./i)).toBeInTheDocument()
+      expect(await screen.findByText(/processing\.\.\./i)).toBeInTheDocument()
+
+      resolveTrust()
 
       await waitFor(() => {
         expect(screen.queryByText(/processing\.\.\./i)).not.toBeInTheDocument()
@@ -446,8 +449,9 @@ describe('DeviceManagement', () => {
     it('should show loading state during removal', async () => {
       const user = userEvent.setup()
       window.confirm = vi.fn(() => true)
+      let resolveRemove: () => void = () => {}
       mockOnRemoveDevice.mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 100))
+        () => new Promise<void>((resolve) => { resolveRemove = resolve })
       )
 
       render(
@@ -461,7 +465,9 @@ describe('DeviceManagement', () => {
       const removeButtons = screen.getAllByRole('button', { name: /^remove$/i })
       await user.click(removeButtons[0])
 
-      expect(screen.getByText(/removing\.\.\./i)).toBeInTheDocument()
+      expect(await screen.findByText(/removing\.\.\./i)).toBeInTheDocument()
+
+      resolveRemove()
 
       await waitFor(() => {
         expect(screen.queryByText(/removing\.\.\./i)).not.toBeInTheDocument()

--- a/packages/ui/src/components/auth/mfa-challenge.test.tsx
+++ b/packages/ui/src/components/auth/mfa-challenge.test.tsx
@@ -198,8 +198,9 @@ describe('MFAChallenge', () => {
 
     it('should show loading state during verification', async () => {
       const user = userEvent.setup()
+      let resolveVerify: () => void = () => {}
       mockOnVerify.mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 100))
+        () => new Promise<void>((resolve) => { resolveVerify = resolve })
       )
 
       render(<MFAChallenge onVerify={mockOnVerify} />)
@@ -212,11 +213,10 @@ describe('MFAChallenge', () => {
       await user.type(screen.getByLabelText('Digit 5'), '5')
       await user.type(screen.getByLabelText('Digit 6'), '6')
 
-      const verifyButton = screen.getByRole('button', { name: /verifying/i })
+      const verifyButton = await screen.findByRole('button', { name: /verifying/i })
+      expect(verifyButton).toBeDisabled()
 
-      await waitFor(() => {
-        expect(verifyButton).toBeDisabled()
-      })
+      resolveVerify()
     })
 
     it('should show success state after verification', async () => {
@@ -413,9 +413,8 @@ describe('MFAChallenge', () => {
   describe('Loading States', () => {
     it('should disable digit inputs during verification', async () => {
       const user = userEvent.setup()
-      mockOnVerify.mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 100))
-      )
+      // Stays pending -- the assertion is about the verifying state, not its end.
+      mockOnVerify.mockImplementation(() => new Promise(() => {}))
 
       render(<MFAChallenge onVerify={mockOnVerify} />)
 
@@ -434,9 +433,8 @@ describe('MFAChallenge', () => {
 
     it('should show loading spinner during verification', async () => {
       const user = userEvent.setup()
-      mockOnVerify.mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 100))
-      )
+      // Stays pending -- the assertion is about the verifying state, not its end.
+      mockOnVerify.mockImplementation(() => new Promise(() => {}))
 
       render(<MFAChallenge onVerify={mockOnVerify} />)
 

--- a/packages/ui/src/components/auth/password-reset.test.tsx
+++ b/packages/ui/src/components/auth/password-reset.test.tsx
@@ -70,8 +70,9 @@ describe('PasswordReset', () => {
 
     it('should show loading state during request', async () => {
       const user = userEvent.setup()
+      let resolveRequest: () => void = () => {}
       mockOnRequestReset.mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 100))
+        () => new Promise<void>((resolve) => { resolveRequest = resolve })
       )
 
       render(<PasswordReset onRequestReset={mockOnRequestReset} />)
@@ -82,7 +83,9 @@ describe('PasswordReset', () => {
       await user.type(emailInput, 'test@example.com')
       await user.click(submitButton)
 
-      expect(screen.getByText(/sending\.\.\./i)).toBeInTheDocument()
+      expect(await screen.findByText(/sending\.\.\./i)).toBeInTheDocument()
+
+      resolveRequest()
 
       await waitFor(() => {
         expect(screen.queryByText(/sending\.\.\./i)).not.toBeInTheDocument()
@@ -297,8 +300,9 @@ describe('PasswordReset', () => {
 
     it('should show loading state during reset', async () => {
       const user = userEvent.setup()
+      let resolveReset: () => void = () => {}
       mockOnResetPassword.mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 100))
+        () => new Promise<void>((resolve) => { resolveReset = resolve })
       )
 
       render(<PasswordReset step="reset" token="token" onResetPassword={mockOnResetPassword} />)
@@ -312,7 +316,9 @@ describe('PasswordReset', () => {
       const submitButton = screen.getByRole('button', { name: /reset password/i })
       await user.click(submitButton)
 
-      expect(screen.getByText(/resetting\.\.\./i)).toBeInTheDocument()
+      expect(await screen.findByText(/resetting\.\.\./i)).toBeInTheDocument()
+
+      resolveReset()
 
       await waitFor(() => {
         expect(screen.queryByText(/resetting\.\.\./i)).not.toBeInTheDocument()

--- a/packages/ui/src/components/auth/session-management.test.tsx
+++ b/packages/ui/src/components/auth/session-management.test.tsx
@@ -285,8 +285,9 @@ describe('SessionManagement', () => {
 
     it('should show loading state during revoke', async () => {
       const user = userEvent.setup()
+      let resolveRevoke: () => void = () => {}
       mockOnRevokeSession.mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 100))
+        () => new Promise<void>((resolve) => { resolveRevoke = resolve })
       )
 
       render(
@@ -300,7 +301,9 @@ describe('SessionManagement', () => {
       const revokeButtons = screen.getAllByRole('button', { name: 'Revoke' })
       await user.click(revokeButtons[0])
 
-      expect(screen.getByText(/revoking\.\.\./i)).toBeInTheDocument()
+      expect(await screen.findByText(/revoking\.\.\./i)).toBeInTheDocument()
+
+      resolveRevoke()
 
       await waitFor(() => {
         expect(screen.queryByText(/revoking\.\.\./i)).not.toBeInTheDocument()
@@ -332,9 +335,8 @@ describe('SessionManagement', () => {
 
     it('should disable button during revoke', async () => {
       const user = userEvent.setup()
-      mockOnRevokeSession.mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 100))
-      )
+      // Stays pending -- the assertion is about the revoking state, not its end.
+      mockOnRevokeSession.mockImplementation(() => new Promise(() => {}))
 
       render(
         <SessionManagement
@@ -347,7 +349,9 @@ describe('SessionManagement', () => {
       const revokeButtons = screen.getAllByRole('button', { name: 'Revoke' })
       await user.click(revokeButtons[0])
 
-      expect(revokeButtons[0]).toBeDisabled()
+      await waitFor(() => {
+        expect(revokeButtons[0]).toBeDisabled()
+      })
     })
   })
 
@@ -398,8 +402,9 @@ describe('SessionManagement', () => {
 
     it('should show loading state during revoke all', async () => {
       const user = userEvent.setup()
+      let resolveRevokeAll: () => void = () => {}
       mockOnRevokeAllOthers.mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 100))
+        () => new Promise<void>((resolve) => { resolveRevokeAll = resolve })
       )
 
       render(
@@ -413,7 +418,9 @@ describe('SessionManagement', () => {
       const revokeAllButton = screen.getByRole('button', { name: /revoke all other sessions/i })
       await user.click(revokeAllButton)
 
-      expect(screen.getByText(/revoking\.\.\./i)).toBeInTheDocument()
+      expect(await screen.findByText(/revoking\.\.\./i)).toBeInTheDocument()
+
+      resolveRevokeAll()
 
       await waitFor(() => {
         expect(screen.queryByText(/revoking\.\.\./i)).not.toBeInTheDocument()

--- a/packages/ui/src/components/auth/sign-in.test.tsx
+++ b/packages/ui/src/components/auth/sign-in.test.tsx
@@ -347,11 +347,12 @@ describe('SignIn', () => {
   describe('Loading State', () => {
     it('should show loading state during submission', async () => {
       const user = userEvent.setup()
+      // The test decides when the request completes. A 100ms timer here made the
+      // loading assertions a race: under load the timer fired before they ran,
+      // the button re-enabled, and the test failed while passing in isolation.
+      let resolveFetch: (response: unknown) => void = () => {}
       global.fetch = vi.fn().mockImplementation(
-        () =>
-          new Promise((resolve) =>
-            setTimeout(() => resolve({ ok: true, json: async () => ({ user: {} }) }), 100)
-          )
+        () => new Promise((resolve) => { resolveFetch = resolve })
       )
 
       render(<SignIn />)
@@ -365,8 +366,12 @@ describe('SignIn', () => {
       await user.click(submitButton)
 
       // Button should be disabled and show loading text
-      expect(submitButton).toBeDisabled()
+      await waitFor(() => {
+        expect(submitButton).toBeDisabled()
+      })
       expect(screen.getByRole('button', { name: /signing in/i })).toBeInTheDocument()
+
+      resolveFetch({ ok: true, json: async () => ({ user: {} }) })
 
       await waitFor(() => {
         expect(submitButton).not.toBeDisabled()
@@ -375,12 +380,8 @@ describe('SignIn', () => {
 
     it('should disable all inputs during loading', async () => {
       const user = userEvent.setup()
-      global.fetch = vi.fn().mockImplementation(
-        () =>
-          new Promise((resolve) =>
-            setTimeout(() => resolve({ ok: true, json: async () => ({ user: {} }) }), 100)
-          )
-      )
+      // Stays pending -- the assertion is about the in-flight state, not its end.
+      global.fetch = vi.fn().mockImplementation(() => new Promise(() => {}))
 
       render(<SignIn />)
 
@@ -392,7 +393,9 @@ describe('SignIn', () => {
       await user.type(passwordInput, 'password123')
       await user.click(submitButton)
 
-      expect(emailInput).toBeDisabled()
+      await waitFor(() => {
+        expect(emailInput).toBeDisabled()
+      })
       expect(passwordInput).toBeDisabled()
     })
   })

--- a/packages/ui/src/components/auth/sign-up.test.tsx
+++ b/packages/ui/src/components/auth/sign-up.test.tsx
@@ -406,11 +406,12 @@ describe('SignUp', () => {
   describe('Loading State', () => {
     it('should show loading state during submission', async () => {
       const user = userEvent.setup()
+      // The test decides when the request completes. A 100ms timer here made the
+      // loading assertions a race: under load the timer fired before they ran,
+      // the button re-enabled, and the test failed while passing in isolation.
+      let resolveFetch: (response: unknown) => void = () => {}
       global.fetch = vi.fn().mockImplementation(
-        () =>
-          new Promise((resolve) =>
-            setTimeout(() => resolve({ ok: true, json: async () => ({}) }), 100)
-          )
+        () => new Promise((resolve) => { resolveFetch = resolve })
       )
 
       render(<SignUp requireEmailVerification={false} />)
@@ -429,8 +430,12 @@ describe('SignUp', () => {
       await user.click(termsCheckbox)
       await user.click(submitButton)
 
-      expect(submitButton).toHaveTextContent(/creating account/i)
+      await waitFor(() => {
+        expect(submitButton).toHaveTextContent(/creating account/i)
+      })
       expect(submitButton).toBeDisabled()
+
+      resolveFetch({ ok: true, json: async () => ({}) })
 
       await waitFor(() => {
         expect(submitButton).not.toBeDisabled()
@@ -439,12 +444,8 @@ describe('SignUp', () => {
 
     it('should disable all inputs during loading', async () => {
       const user = userEvent.setup()
-      global.fetch = vi.fn().mockImplementation(
-        () =>
-          new Promise((resolve) =>
-            setTimeout(() => resolve({ ok: true, json: async () => ({}) }), 100)
-          )
-      )
+      // Stays pending -- the assertion is about the in-flight state, not its end.
+      global.fetch = vi.fn().mockImplementation(() => new Promise(() => {}))
 
       render(<SignUp requireEmailVerification={false} />)
 
@@ -462,7 +463,9 @@ describe('SignUp', () => {
       await user.click(termsCheckbox)
       await user.click(submitButton)
 
-      expect(firstNameInput).toBeDisabled()
+      await waitFor(() => {
+        expect(firstNameInput).toBeDisabled()
+      })
       expect(lastNameInput).toBeDisabled()
       expect(emailInput).toBeDisabled()
       expect(passwordInput).toBeDisabled()

--- a/packages/ui/src/components/auth/user-profile.test.tsx
+++ b/packages/ui/src/components/auth/user-profile.test.tsx
@@ -149,8 +149,13 @@ describe('UserProfile', () => {
 
     it('should show loading state during profile save', async () => {
       const user = userEvent.setup()
+      // The test holds the promise open rather than racing a 100ms timer -- see
+      // the note on 'should show loading state during account deletion' below.
+      // Here the disappearance of the loading state is also asserted, so the
+      // promise has to be resolvable rather than merely pending forever.
+      let resolveUpdate: () => void = () => {}
       mockOnUpdateProfile.mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 100))
+        () => new Promise<void>((resolve) => { resolveUpdate = resolve })
       )
 
       render(<UserProfile user={mockUser} onUpdateProfile={mockOnUpdateProfile} />)
@@ -158,8 +163,12 @@ describe('UserProfile', () => {
       const saveButton = screen.getByRole('button', { name: /save changes/i })
       await user.click(saveButton)
 
-      expect(saveButton).toHaveTextContent(/saving/i)
+      await waitFor(() => {
+        expect(saveButton).toHaveTextContent(/saving/i)
+      })
       expect(saveButton).toBeDisabled()
+
+      resolveUpdate()
 
       await waitFor(() => {
         expect(saveButton).not.toBeDisabled()
@@ -444,9 +453,8 @@ describe('UserProfile', () => {
   describe('Loading States', () => {
     it('should disable inputs during profile save', async () => {
       const user = userEvent.setup()
-      mockOnUpdateProfile.mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 100))
-      )
+      // Stays pending -- the assertion is about the saving state, not its end.
+      mockOnUpdateProfile.mockImplementation(() => new Promise(() => {}))
 
       render(<UserProfile user={mockUser} onUpdateProfile={mockOnUpdateProfile} />)
 
@@ -455,14 +463,15 @@ describe('UserProfile', () => {
 
       await user.click(saveButton)
 
-      expect(firstNameInput).toBeDisabled()
+      await waitFor(() => {
+        expect(firstNameInput).toBeDisabled()
+      })
     })
 
     it('should disable inputs during email update', async () => {
       const user = userEvent.setup()
-      mockOnUpdateEmail.mockImplementation(
-        () => new Promise((resolve) => setTimeout(resolve, 100))
-      )
+      // Stays pending -- the assertion is about the updating state, not its end.
+      mockOnUpdateEmail.mockImplementation(() => new Promise(() => {}))
 
       render(
         <UserProfile user={mockUser} onUpdateEmail={mockOnUpdateEmail} showSecurityTab={true} />
@@ -477,7 +486,9 @@ describe('UserProfile', () => {
       await user.type(emailInput, 'newemail@example.com')
       await user.click(updateButton)
 
-      expect(emailInput).toBeDisabled()
+      await waitFor(() => {
+        expect(emailInput).toBeDisabled()
+      })
     })
   })
 


### PR DESCRIPTION
## Why this exists

Found while clearing the open-PR backlog. It is currently the largest source of false reds in CI, and **no PR can reach genuinely-all-green while it stands** — it reddens PRs at random, unrelated to what they change.

Observed across four CI runs, **five distinct tests, none repeating**:

| PR | run | failed |
|---|---|---|
| #470 | attempt 1 | `SessionManagement > should show loading state during revoke all` |
| #470 | attempt 2 | `DeviceManagement > should show loading state during trust`<br>`UserProfile > should show loading state during profile save` |
| #480 | — | `DeviceManagement > Remove Device > should show loading state during removal` |
| #484 | — | `UserProfile > Profile Tab > should show loading state during profile save` |

A different random subset each time is the signature of a timing race, not a defect — and the reason reruns kept "fixing" it without fixing anything.

## The race

Every one of these tests gave itself a **100 ms wall-clock window** to observe a transient loading state, then asserted **synchronously**:

```js
mockOnTrustDevice.mockImplementation(
  () => new Promise((resolve) => setTimeout(resolve, 100))   // 100ms WALL CLOCK
)
…
await user.click(trustButton)                                 // consumes unknown time
expect(screen.getByText(/processing\.\.\./i)).toBeInTheDocument()   // SYNCHRONOUS
```

`await user.click(...)` flushes microtasks and can itself eat tens of milliseconds. On a fast machine the click returns inside the window and the text is still rendered. On a loaded runner it overruns, the `setTimeout` fires, React re-renders without the loading state, and the synchronous `getByText` finds nothing.

These tests only began executing two days ago (#482, "make the 50 dead frontend tests runnable and run them"), which is why this is surfacing now rather than being long-known.

## The fix

Give the test control of when the promise settles, instead of racing a timer.

Where the test **also asserts the loading state clearing**, it holds the resolver and calls it at the right moment:

```js
let resolveTrust: () => void = () => {}
mockOnTrustDevice.mockImplementation(
  () => new Promise<void>((resolve) => { resolveTrust = resolve })
)
…
await user.click(trustButton)
expect(await screen.findByText(/processing\.\.\./i)).toBeInTheDocument()
resolveTrust()
await waitFor(() => {
  expect(screen.queryByText(/processing\.\.\./i)).not.toBeInTheDocument()
})
```

Where the test **only asserts the pending state**, the promise simply never settles:

```js
mockOnUpdateProfile.mockImplementation(() => new Promise(() => {}))
```

That second form is not new here — it is the approach already used by `should show loading state during account deletion`, whose existing comment describes exactly this race:

> Deliberately never resolves. This previously used a 100ms timer, which made the assertions below a race: under full-suite parallel load the timer fired before they ran, isDeleting flipped back to false, and the test failed while passing in isolation.

This PR generalises that one-off fix to the rest of the family. Assertions on transient state move from `getBy*` to `findBy*`/`waitFor`.

**Nothing is skipped, deleted, or weakened.** Every assertion still runs and still checks the same behaviour — deterministically now. Test counts are unchanged.

## Scope

20 tests across 9 files:

```
audit-log.test.tsx            export, load more
backup-codes.test.tsx         regeneration
device-management.test.tsx    trust, removal
mfa-challenge.test.tsx        verification, disable digits, spinner
password-reset.test.tsx       request, reset
session-management.test.tsx   revoke, revoke all, disable button
sign-in.test.tsx              submission, disable inputs
sign-up.test.tsx              submission, disable inputs
user-profile.test.tsx         profile save, disable inputs, email update
```

Already written this way and **untouched**: `user-profile.test.tsx:413`, `phone-verification.test.tsx:92`, `phone-verification.test.tsx:267`, `mfa-setup.test.tsx:289`.

Deliberately **not** changed — asserted immediately after `render()` with no intervening `await`, so no window can elapse and there is no race: `backup-codes.test.tsx:69`, `mfa-setup.test.tsx:59`, `email-verification.test.tsx:123`. Also unchanged: `organization-switcher.test.tsx:462`, which waits for the *loaded* state, not the transient one.

## Verified

Under **saturated CPUs**, which is the condition that provokes it (one busy loop per core):

| | 10 runs |
|---|---|
| `main` @ d9f66608 | **9 pass, 1 FAIL** — `UserProfile > should disable inputs during profile save` |
| this branch | **10 pass, 0 FAIL** |

Repo gates on this branch:

| gate | result |
|---|---|
| `pnpm lint` | 0 errors, 545 warnings (identical to `main`) |
| `pnpm typecheck` | pass |
| `pnpm test:unit` | `packages/core` 36/36 · **`packages/ui` 504 passed / 20 skipped (524), 20 files / 1 skipped** · `apps/admin` 24/25 · `apps/dashboard` 17/29 · `apps/website` 13/16 |

`packages/ui` counts are unchanged from `main` — same coverage, made honest.

## Note on merging

GitHub Actions is in a major incident (qcvjkzcs7j74). Do not merge on `gh pr checks` alone — it omits queued runs and reports "0 pending" when GitHub has created no runs at all. Require at least one completed run per workflow on the exact head SHA:

```
gh api "repos/madfam-org/janua/actions/runs?head_sha=<SHA>"
```

Independently of that: a large share of reds in this repo right now are **self-hosted ARC runner deaths**, not test failures. Their signature is that no step is ever marked `failure` — the in-flight step and everything after it are recorded as *not run*, and the logs are `BlobNotFound` because the runner died before uploading. That is a different problem from this one and is not addressed here.
