### PR TITLE
fix(python-sdk): make the package importable and stop CI hiding it

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -115,7 +115,16 @@ jobs:
       - name: Run tests
         run: |
           cd packages/python-sdk
-          pytest tests/ -v || true
+          pytest tests/ -v
+
+      # Catches the class of breakage this job missed for months: the package
+      # importing only because pytest ran from the source tree. Import from a
+      # directory that contains no `janua/`, so the installed distribution is
+      # the only thing that can satisfy it.
+      - name: Verify installed package imports
+        run: |
+          cd "$RUNNER_TEMP"
+          python -c "import janua; print('janua', janua.__version__, 'imported from', janua.__file__)"
 
       - name: Verify dist/
         run: |

--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -118,13 +118,31 @@ jobs:
           pytest tests/ -v
 
       # Catches the class of breakage this job missed for months: the package
-      # importing only because pytest ran from the source tree. Import from a
-      # directory that contains no `janua/`, so the installed distribution is
-      # the only thing that can satisfy it.
-      - name: Verify installed package imports
+      # appearing importable only because of the source tree.
+      #
+      # This deliberately does NOT reuse the `pip install -e .[dev]` env above.
+      # An editable install resolves `janua` back to the checkout, so
+      # `janua.__file__` points at the source tree no matter how broken the
+      # packaging or the declared dependencies are. Only a non-editable install
+      # of the built wheel, in a venv that has nothing else in it, exercises
+      # what a real consumer gets — that is how the missing pydantic[email]
+      # extra was found, having been invisible from the source tree.
+      - name: Verify built wheel imports as a consumer would
         run: |
-          cd "$RUNNER_TEMP"
-          python -c "import janua; print('janua', janua.__version__, 'imported from', janua.__file__)"
+          set -euo pipefail
+          python -m venv "$RUNNER_TEMP/consumer-venv"
+          "$RUNNER_TEMP/consumer-venv/bin/pip" install --quiet --upgrade pip
+          "$RUNNER_TEMP/consumer-venv/bin/pip" install --quiet packages/python-sdk/dist/*.whl
+          cd "$RUNNER_TEMP"   # contains no janua/, so the install is the only source
+          "$RUNNER_TEMP/consumer-venv/bin/python" -c "
+          import janua, pathlib
+          print('janua', janua.__version__, 'from', janua.__file__)
+          assert 'site-packages' in janua.__file__, 'resolved outside site-packages: ' + janua.__file__
+          from janua.types import JanuaConfig, ListResponse, MFAMethod, Organization
+          ListResponse[Organization](items=[], total=0, limit=10, offset=0)
+          janua.JanuaClient(api_key='sk_test_ci')
+          print('consumer import OK')
+          "
 
       - name: Verify dist/
         run: |

--- a/packages/python-sdk/janua/types.py
+++ b/packages/python-sdk/janua/types.py
@@ -7,7 +7,7 @@ the SDK, implemented using Pydantic for validation and serialization.
 
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Generic, List, Optional, TypeVar
 from uuid import UUID
 
 from pydantic import BaseModel, EmailStr, Field, HttpUrl, ConfigDict
@@ -119,6 +119,11 @@ class User(BaseResponse):
     mfa_enabled: bool = False
     passkeys_enabled: bool = False
     oauth_accounts: List["OAuthAccount"] = Field(default_factory=list)
+    # Flat list of linked provider names, as returned by the API alongside the
+    # richer oauth_accounts (see the `oauth_providers: List[str]` field on the
+    # server's user response in apps/api/app/routers/v1/admin.py, and the
+    # matching field in packages/typescript-sdk/src/admin.ts).
+    oauth_providers: List[str] = Field(default_factory=list)
 
 
 class UserUpdateRequest(BaseModel):
@@ -217,19 +222,27 @@ class MagicLinkRequest(BaseModel):
 # ====================
 
 class Session(BaseResponse):
-    """Session model."""
+    """Session model.
+
+    `token`, `updated_at` and `last_activity_at` are optional: the server's
+    SessionResponse (apps/api/app/routers/v1/sessions.py) has no `token` and no
+    `updated_at` at all — a session's tokens are carried in the sibling `tokens`
+    object of the sign-in response, not inside `session` — and the sign-in
+    payload omits `last_activity_at`. Requiring them made every real response
+    fail validation.
+    """
     id: UUID
     user_id: UUID
-    token: str
+    token: Optional[str] = None
     status: SessionStatus = SessionStatus.ACTIVE
     ip_address: Optional[str] = None
     user_agent: Optional[str] = None
     device_info: Optional[Dict[str, Any]] = None
     location: Optional[Dict[str, Any]] = None
     created_at: datetime
-    updated_at: datetime
+    updated_at: Optional[datetime] = None
     expires_at: datetime
-    last_activity_at: datetime
+    last_activity_at: Optional[datetime] = None
 
 
 class SessionListResponse(PaginatedResponse):
@@ -547,6 +560,211 @@ class OAuthCallbackRequest(BaseModel):
     code: str
     state: Optional[str] = None
     code_verifier: Optional[str] = None
+
+
+# ====================
+# Client Configuration
+# ====================
+
+class JanuaConfig(BaseModel):
+    """Resolved client configuration.
+
+    Built once by :class:`janua.client.JanuaClient` and handed to every service
+    client. Mutable: ``JanuaClient.set_api_key`` / ``set_environment`` /
+    ``enable_debug`` / ``disable_debug`` assign to it after construction.
+    """
+    api_key: str = Field(..., description="API key used to authenticate requests")
+    base_url: str = Field(..., description="Base URL of the Janua API")
+    timeout: float = Field(30.0, description="Per-request timeout in seconds")
+    max_retries: int = Field(3, description="Maximum retry attempts per request")
+    environment: str = Field("production", description="Deployment environment")
+    debug: bool = Field(False, description="Emit verbose client-side diagnostics")
+
+
+# ====================
+# Generic List Response
+# ====================
+
+T = TypeVar("T")
+
+
+class ListResponse(BaseResponse, Generic[T]):
+    """Offset-paginated collection returned by the list endpoints.
+
+    Distinct from :class:`PaginatedResponse`, which is page-based and carries no
+    ``items``. The service clients construct this by subscripting at runtime,
+    e.g. ``ListResponse[Organization](items=..., total=..., limit=..., offset=...)``.
+    """
+    items: List[T] = Field(default_factory=list, description="Items in this page")
+    total: int = Field(..., description="Total number of items across all pages")
+    limit: int = Field(..., description="Maximum items requested")
+    offset: int = Field(..., description="Offset of the first item")
+
+
+# ====================
+# Additional User Models
+# ====================
+
+class UserRole(str, Enum):
+    """Platform-level user role.
+
+    Distinct from :class:`OrganizationRole`, which scopes a user within a single
+    organization. Serialized via ``.value`` into both query params and request
+    bodies.
+    """
+    USER = "user"
+    ADMIN = "admin"
+    SUPER_ADMIN = "super_admin"
+
+
+class UserProfile(BaseResponse):
+    """Extended profile fields for a user."""
+    bio: Optional[str] = None
+    location: Optional[str] = None
+    website: Optional[str] = None
+    company: Optional[str] = None
+    job_title: Optional[str] = None
+
+
+class UserPreferences(BaseResponse):
+    """Per-user display and notification preferences."""
+    language: Optional[str] = None
+    timezone: Optional[str] = None
+    date_format: Optional[str] = None
+    time_format: Optional[str] = Field(None, description="12h or 24h")
+    email_notifications: Optional[bool] = None
+    sms_notifications: Optional[bool] = None
+    push_notifications: Optional[bool] = None
+
+
+# ====================
+# Additional Auth Models
+# ====================
+
+class EmailVerificationRequest(BaseModel):
+    """Request a verification email be (re)sent to an address."""
+    email: EmailStr
+
+
+# `AuthClient.request_password_reset` sends only an address, matching
+# ForgotPasswordRequest. Note this is NOT ResetPasswordRequest, whose required
+# token/new_password would reject an email-only payload.
+PasswordResetRequest = ForgotPasswordRequest
+
+
+# ====================
+# Additional Organization Models
+# ====================
+
+class OrganizationSettings(BaseResponse):
+    """Organization-wide policy settings."""
+    require_mfa: Optional[bool] = None
+    allowed_email_domains: Optional[List[str]] = None
+    session_duration: Optional[int] = Field(None, description="Session lifetime in seconds")
+    password_policy: Optional[Dict[str, Any]] = None
+
+
+OrganizationInvite = OrganizationInvitation
+
+
+# ====================
+# Additional MFA Models
+# ====================
+
+class MFAMethod(str, Enum):
+    """A second-factor method.
+
+    Constructed from raw server strings in ``MFAClient.list_methods`` and
+    serialized via ``.value`` when sent, so it must remain a ``str`` enum.
+    """
+    TOTP = "totp"
+    SMS = "sms"
+    BACKUP_CODES = "backup_codes"
+
+
+class MFAChallenge(BaseResponse):
+    """A pending second-factor challenge awaiting verification."""
+    id: str = Field(..., description="Challenge id, passed back to verify_challenge")
+    method: Optional[MFAMethod] = None
+    user_id: Optional[UUID] = None
+    expires_at: Optional[datetime] = None
+
+
+class TOTPSetup(BaseResponse):
+    """Enrollment material for a TOTP authenticator."""
+    secret: Optional[str] = Field(None, description="Shared secret in base32")
+    qr_code_url: Optional[str] = Field(None, description="Provisioning URI, renderable as a QR code")
+    backup_codes: Optional[List[str]] = None
+
+
+class SMSSetup(BaseResponse):
+    """Enrollment state for SMS-delivered codes."""
+    phone_number: Optional[str] = None
+    verified: bool = Field(False, description="Whether the number has been confirmed")
+
+
+class BackupCodes(BaseResponse):
+    """A set of single-use account recovery codes."""
+    codes: List[str] = Field(default_factory=list, description="The codes themselves")
+    remaining: Optional[int] = Field(None, description="Unused codes left")
+
+
+MFASettings = MFAStatusResponse
+
+
+# ====================
+# Additional Passkey Models
+# ====================
+
+Passkey = PasskeyResponse
+
+
+class PasskeyChallenge(BaseResponse):
+    """A WebAuthn challenge.
+
+    Serves both ceremonies — registration (creation options) and authentication
+    (request options) — so the raw option payload is kept permissive.
+    """
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True, extra="allow")
+
+    id: str = Field(..., description="Challenge id, passed back to the complete_* call")
+    challenge: Optional[str] = None
+    options: Optional[Dict[str, Any]] = Field(None, description="Raw WebAuthn options")
+
+
+class PasskeyCredential(BaseResponse):
+    """A WebAuthn credential as returned by the authenticator."""
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True, extra="allow")
+
+    id: Optional[str] = None
+    raw_id: Optional[str] = None
+    type: Optional[str] = None
+    response: Optional[Dict[str, Any]] = None
+
+
+# ====================
+# Additional Session Models
+# ====================
+
+class SessionDevice(BaseResponse):
+    """The device a session is bound to."""
+    name: Optional[str] = None
+    trusted: Optional[bool] = None
+    device_type: Optional[str] = None
+    os: Optional[str] = None
+    browser: Optional[str] = None
+    last_seen_at: Optional[datetime] = None
+
+
+class SessionActivity(BaseResponse):
+    """A single audit entry recorded against a session."""
+    id: Optional[UUID] = None
+    session_id: Optional[UUID] = None
+    action: Optional[str] = None
+    ip_address: Optional[str] = None
+    user_agent: Optional[str] = None
+    location: Optional[str] = None
+    created_at: Optional[datetime] = None
 
 
 # Update forward references

--- a/packages/python-sdk/janua/users.py
+++ b/packages/python-sdk/janua/users.py
@@ -10,6 +10,10 @@ from .types import (
     UserRole,
     ListResponse,
     JanuaConfig,
+    # `get_sessions` annotates List[Session] in its signature, which is
+    # evaluated at class-definition time. Session was only imported inside the
+    # function body, so the annotation raised NameError on import.
+    Session,
 )
 
 

--- a/packages/python-sdk/janua/utils.py
+++ b/packages/python-sdk/janua/utils.py
@@ -11,7 +11,7 @@ import hmac
 import json
 import time
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 from urllib.parse import urlencode, urlparse, urlunparse, parse_qs, ParseResult
 
 import jwt
@@ -548,7 +548,10 @@ def validate_password_strength(
     require_lowercase: bool = True,
     require_numbers: bool = True,
     require_special: bool = False,
-) -> tuple[bool, list[str]]:
+    # typing.Tuple/List rather than the PEP 585 builtins: this project declares
+    # requires-python = ">=3.8" and tests on 3.8, where `tuple[...]` at
+    # module-import time raises "TypeError: 'type' object is not subscriptable".
+) -> Tuple[bool, List[str]]:
     """
     Validate password strength.
 

--- a/packages/python-sdk/janua/utils.py
+++ b/packages/python-sdk/janua/utils.py
@@ -101,6 +101,11 @@ def parse_jwt_without_verification(token: str) -> Dict[str, Any]:
         raise InvalidTokenError(f"Invalid token format: {str(e)}")
 
 
+#: Public name for :func:`parse_jwt_without_verification`, re-exported from the
+#: package root.
+decode_jwt_claims = parse_jwt_without_verification
+
+
 def is_token_expired(token: str, leeway: int = 0) -> bool:
     """
     Check if a JWT token is expired.
@@ -222,6 +227,24 @@ def decode_base64url(data: str) -> bytes:
         data += "=" * padding
     
     return base64.urlsafe_b64decode(data)
+
+
+def generate_code_verifier(length: int = 32) -> str:
+    """
+    Generate a PKCE code verifier.
+
+    The counterpart to :func:`generate_code_challenge`. RFC 7636 requires the
+    verifier to be 43-128 unreserved characters; the default length of 32 random
+    bytes yields 43 characters.
+
+    Args:
+        length: Number of random bytes to draw
+
+    Returns:
+        Code verifier for PKCE flow
+    """
+    import secrets
+    return secrets.token_urlsafe(length)
 
 
 def generate_code_challenge(code_verifier: str) -> str:
@@ -356,8 +379,40 @@ def format_iso_datetime(dt: datetime) -> str:
     # Ensure timezone aware
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
-    
+
     return dt.isoformat()
+
+
+def build_query_params(params: Dict[str, Any]) -> Dict[str, str]:
+    """
+    Normalize a dict of loosely-typed values into query-string parameters.
+
+    Drops ``None`` entries, lowercases booleans, joins sequences with commas and
+    ISO-formats datetimes. Restored from the pre-rebrand implementation, which
+    was dropped during the plinto -> janua utils rewrite while its callers in
+    :mod:`janua.admin` were left in place.
+
+    Args:
+        params: Raw parameter mapping
+
+    Returns:
+        Mapping of parameter name to string value, omitting None
+    """
+    query_params: Dict[str, str] = {}
+
+    for key, value in params.items():
+        if value is None:
+            continue
+        elif isinstance(value, bool):
+            query_params[key] = str(value).lower()
+        elif isinstance(value, (list, tuple)):
+            query_params[key] = ','.join(str(v) for v in value)
+        elif isinstance(value, datetime):
+            query_params[key] = format_iso_datetime(value)
+        else:
+            query_params[key] = str(value)
+
+    return query_params
 
 
 def get_expires_at(expires_in: int) -> datetime:

--- a/packages/python-sdk/pyproject.toml
+++ b/packages/python-sdk/pyproject.toml
@@ -49,7 +49,11 @@ keywords = [
 ]
 dependencies = [
     "httpx>=0.25.0",
-    "pydantic>=2.0.0",
+    # The [email] extra is required, not optional: janua.types uses
+    # pydantic.EmailStr in 10 places, and pydantic defers the email-validator
+    # import to class-construction time. Without it, `import janua` dies with
+    # "email-validator is not installed" on a clean install.
+    "pydantic[email]>=2.0.0",
     "pyjwt>=2.8.0",
     "cryptography>=41.0.0",
 ]

--- a/packages/python-sdk/requirements.txt
+++ b/packages/python-sdk/requirements.txt
@@ -1,6 +1,7 @@
 # Core dependencies
 httpx>=0.25.0
-pydantic>=2.0.0
+# [email] extra is required: janua.types uses pydantic.EmailStr.
+pydantic[email]>=2.0.0
 PyJWT>=2.8.0
 
 # Optional dependencies for specific features


### PR DESCRIPTION
`import janua` fails on `main`, and has **never** worked. CI missed it because the test step was `pytest tests/ -v || true` — the job was green by construction.

```
$ python -c "import janua"
ImportError: cannot import name 'PasswordResetRequest' from 'janua.types'
```

## Root cause

53 names imported across 11 modules were never defined. They arrived with `da222f3a` ("enhance Python SDK with MFA, passkeys, and session management") and `386430ee` ("achieve 100% API parity"), which added the calling modules without the types they referenced.

`git log -S "class JanuaConfig"` over `packages/python-sdk` returns nothing: `JanuaConfig` is used in 8 modules and re-exported from `__init__`, and has never existed. Even at the "100% API parity" commit, `types.py` had 53 classes and zero `JanuaConfig`.

| From | Missing |
|---|---|
| `.types` | `JanuaConfig`, `ListResponse`, `UserRole`, `UserProfile`, `UserPreferences`, `PasswordResetRequest`, `EmailVerificationRequest`, `OrganizationInvite`, `OrganizationSettings`, `MFASettings`, `MFAMethod`, `MFAChallenge`, `TOTPSetup`, `SMSSetup`, `BackupCodes`, `Passkey`, `PasskeyChallenge`, `PasskeyCredential`, `SessionDevice`, `SessionActivity` |
| `.utils` | `build_query_params`, `decode_jwt_claims`, `generate_code_verifier` |

Each is defined from its actual call sites, not guessed:

- **Five are aliases** where the existing field set already matches usage — `Passkey`→`PasskeyResponse`, `MFASettings`→`MFAStatusResponse`, `OrganizationInvite`→`OrganizationInvitation`, `PasswordResetRequest`→`ForgotPasswordRequest`, `decode_jwt_claims`→`parse_jwt_without_verification`.
- **`ListResponse` is deliberately not an alias** of `PaginatedResponse`. It is offset-based with an `items` list and is subscripted at runtime in 10 places (`ListResponse[Organization](items=…, total=…, limit=…, offset=…)`); `PaginatedResponse` is page-based with neither `items` nor `offset`. Aliasing would break all 10 sites.
- **`build_query_params` is restored verbatim** from `00e11728`, where the plinto→janua utils rewrite dropped it while leaving its callers in `janua/admin.py`.
- `JanuaConfig` is mutable — `JanuaClient.set_api_key` / `set_environment` / `enable_debug` assign to it after construction.

## Three further defects, each independently fatal

All were masked by the `|| true`.

1. **`janua/users.py` raised `NameError` at import.** It annotates `-> List[Session]` but imported `Session` only inside the function body; there is no `from __future__ import annotations`, so the signature is evaluated at `def` time.

2. **`Session` required fields the server does not send.** It required `token`, `updated_at` and `last_activity_at`. The server's `SessionResponse` (`apps/api/app/routers/v1/sessions.py:24`) has **no `token`** and **no `updated_at`** — tokens are carried in the sibling `tokens` object of the sign-in response, not inside `session`. Every real response failed validation. Now optional.

3. **`pip install janua` produced an unimportable package.** `pyproject.toml` declared `pydantic>=2.0.0`, but `janua.types` uses `pydantic.EmailStr` in 10 places, which needs the `email-validator` extra:
   ```
   ImportError: email-validator is not installed, run `pip install 'pydantic[email]'`
   ```
   Now `pydantic[email]>=2.0.0`. **This one is invisible from the source tree** — importing there succeeds whenever the ambient environment happens to have `email-validator`, which is exactly why the clean-venv check below matters.

Also added `User.oauth_providers`, a real API field (see the user response in `apps/api/app/routers/v1/admin.py:83` and the matching field in `packages/typescript-sdk/src/admin.ts`) that the SDK did not model.

## CI

- Removed the `|| true` from the pytest step.
- Added a step that imports the **installed** distribution from `$RUNNER_TEMP` — a directory with no `janua/` in it — so this class of breakage cannot pass by importing from the source tree again.

## Verification

```
$ pytest tests/ -q
...................................                    [100%]
35 passed
```
(before: collection impossible — the package could not be imported)

Consumer-grade proof, run from a directory containing no `janua/`:

```
$ python -m build
Successfully built janua-0.1.0b1.tar.gz and janua-0.1.0b1-py3-none-any.whl

$ python3 -m venv cleanvenv
$ ./cleanvenv/bin/pip install dist/janua-0.1.0b1-py3-none-any.whl
$ cd /tmp/scratch && ls -d janua        # -> no such directory
$ ./cleanvenv/bin/python -c "import janua; ..."
IMPORT OK
  version: 1.0.0
  file   : .../cleanvenv/lib/python3.11/site-packages/janua/__init__.py
  exports: 59
  client : JanuaClient | env = production | debug = False
  generic: ListResponse[Organization] -> total 0
  enum   : MFAMethod.TOTP
```

`email-validator==2.3.0` now appears in the venv's `pip list`, pulled in by the corrected extra.

## Reported, not fixed — needs a decision

- **`packages/python-sdk/src/janua/` is a stale duplicate.** 1,700 lines vs 6,452 in the packaged `janua/`, last touched 4 days earlier, self-consistent but a much smaller API surface. Nothing installs or imports it (`packages.find` uses `include = ["janua*"]` from the repo root, and the built wheel's only top-level entry is `janua`). It is dead code and should probably be deleted, but that is a call for whoever owns the SDK.
- **Version mismatch:** `janua.__version__` is `1.0.0` while `pyproject.toml` says `0.1.0b1`. Unclear which is authoritative.
- **`janua/admin.py` is dead and non-functional.** Every method is `async` and `await`s the synchronous `HTTPClient`, and passes `json_data=` where `post`/`patch` accept `json=`. It is not imported by `__init__.py` or `client.py`. Defining `build_query_params` makes it importable, not working.
- **`examples.py`** targets a different, fully-async surface (`AsyncJanuaClient`, `client.auth.forgot_password`) that does not exist, and imports names `__init__.py` does not re-export. It fails regardless of this PR.
- `README.md:369` documents `endpoint.signing_secret`; the model field is `secret`.