### PR TITLE
ci(dependabot): hold @types/node major bumps to the Node runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,18 @@ updates:
     labels:
       - "dependencies"
       - "automated"
+    ignore:
+      # `@types/node` must track the Node MAJOR we actually run, not the newest
+      # version published. Dependabot cannot know that, so its "latest" is wrong
+      # here by construction: on 2026-08-07 `main` ran Node 20 in all 8 workflows
+      # while carrying @types/node ^25.3.0 — five majors of drift, with the types
+      # describing APIs that do not exist where the code executes. #433 then
+      # proposed 26.1.2, which would have widened it further, and was closed.
+      # #493 is the correct shape: move the runtime AND the types together.
+      # Minor/patch updates still flow; only the major is held so the pairing
+      # stays a deliberate decision instead of a weekly re-triage.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   # Docker base images
   - package-ecosystem: "docker"


### PR DESCRIPTION
Follow-up to closing #433, so the same wrong answer stops being re-proposed every week.

## The problem

`@types/node` is not an ordinary dependency — it must track the Node **major you actually run**, not the newest version published. Dependabot has no way to know your runtime, so its "latest" is wrong here by construction.

Measured on `main` today:

| | |
|---|---|
| Workflows running Node 20 | **8 of 8** (`NODE_VERSION: '20'`) |
| `@types/node` in package.json | **^25.3.0** |
| Drift | **five majors** — types describing APIs that do not exist at runtime |

**#433** then proposed `26.1.2`, which would have widened that further. Closed for that reason.

**#493** has the correct shape: it moves the runtime **and** the types together — Node 22 with `@types/node ^22.20.1`.

## The change

One `ignore` rule on the npm root entry, holding only `version-update:semver-major` for `@types/node`. Minor and patch updates still flow normally.

The point is not to freeze the dependency — it is to make pairing the types to the runtime a **deliberate decision** rather than a weekly re-triage that keeps landing on the wrong answer.

## Verified

`dependabot.yml` parses; the npm root entry carries exactly one ignore rule; all 3 update entries intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)