### PR TITLE
fix(core): unref and clear MFAService's cleanup interval

### DIFF
--- a/packages/core/src/services/mfa-service.ts
+++ b/packages/core/src/services/mfa-service.ts
@@ -71,6 +71,8 @@ export class MFAService extends EventEmitter {
   private challenges: Map<string, MFAChallenge> = new Map();
   private verificationHistory: Map<string, Date[]> = new Map();
   private trustedDevices: Map<string, Set<string>> = new Map();
+  /** Handle for the expired-challenge sweep, so destroy() can clear it. */
+  private cleanupTimer?: ReturnType<typeof setInterval>;
   private smsProvider?: SMSProvider;
   private hardwareProvider?: HardwareTokenProvider;
 
@@ -857,9 +859,9 @@ export class MFAService extends EventEmitter {
    * Cleanup expired challenges
    */
   private startCleanupTimer(): void {
-    setInterval(() => {
+    this.cleanupTimer = setInterval(() => {
       const now = new Date();
-      
+
       for (const [id, challenge] of this.challenges) {
         if (challenge.expires_at < now) {
           challenge.status = 'expired';
@@ -867,6 +869,36 @@ export class MFAService extends EventEmitter {
         }
       }
     }, 60000); // Every minute
+
+    // LOAD-BEARING. A background sweep must not, on its own, keep the Node
+    // process alive. Before this, the interval handle was never stored and the
+    // class had no cleanup method, so every `new MFAService()` leaked an
+    // interval that nothing could ever clear.
+    //
+    // Consequence measured 2026-08-07: `jest --detectOpenHandles` in
+    // packages/core reported three open Timeout handles, all this line, one per
+    // construction in mfa-service.test.ts. In worker mode Jest force-kills the
+    // worker and prints "A worker process has failed to exit gracefully"; run
+    // in-band it simply HANGS — reproduced locally past 600s. That hang is what
+    // has been holding janua#497 (Node 22 alignment) open.
+    //
+    // unref() does not stop the sweep: in a running server the HTTP listener
+    // keeps the event loop alive, so it still fires every minute. It only stops
+    // the timer from being the *reason* the loop stays alive.
+    this.cleanupTimer.unref?.();
+  }
+
+  /**
+   * Stop the background cleanup sweep.
+   *
+   * Callers that create short-lived instances (tests, scripts, one-shot jobs)
+   * should call this. Long-lived server instances need not, but it is safe.
+   */
+  destroy(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = undefined;
+    }
   }
 
   /**


### PR DESCRIPTION
**This is the leak that has been holding #497 open.**

`startCleanupTimer()` created a bare `setInterval` in the constructor. The handle was never stored, and `MFAService` had **no cleanup method at all** — so every `new MFAService()` leaked an interval that nothing could ever clear.

## Diagnosed by reproduction, not inference

Run locally on **Node 22.19** — the version #497 moves CI to:

```
jest --detectOpenHandles (packages/core)
  → 3 open Timeout handles, all mfa-service.ts:860
    one per construction in mfa-service.test.ts (lines 29, 142, 168)
```

## Why it presented two different ways

This is what made it confusing for so long:

| mode | behaviour |
|---|---|
| **worker** | Jest force-kills the worker, prints *"A worker process has failed to exit gracefully"*. **Tests pass, exit 0** — easy to ignore for months. |
| **in-band** (what `--detectOpenHandles` forces) | nothing to force-kill, so it **HANGS**. Reproduced locally **past 600s**. |

That hang is exactly the CI symptom on #497: `Run frontend tests` sat `in_progress` for **73, 31 and 26 minutes** across three heads, against a ~7 minute healthy baseline. I had wrongly called that a dead runner and rebased twice before the third stall made the pattern undeniable.

## The fix

Stores the handle, `unref()`s it, and adds `destroy()`.

**`unref()` does not stop the sweep.** In a running server the HTTP listener keeps the event loop alive, so it still fires every minute. It only stops the timer being the *reason* the loop stays alive — which is what a background sweep should never be.

## Verified before and after, Node 22.19

| | before | after |
|---|---|---|
| `packages/core` in-band | **hung >600s** | **exit 0 in 1.9s, 0 handles** |
| `packages/core` worker | warning present | warning gone, exit 0 |
| full `pnpm test:unit` | blocked by the above | **exit 0** — 36 + 504 + 24 + 13 + 19 passing |

## Deliberately not chased

`apps/dashboard` still prints *"Jest did not exit one second after the test run has completed"*. It reports **zero open handles in-band and exits 0** — that is jsdom teardown exceeding Jest's one-second grace, not a leak. Noted rather than papered over with `--forceExit`, which would hide a real leak if one ever appeared there.

## Relationship to #497

Landing here rather than inside #497 so the alignment PR only has to rebase, and its diff stays purely the Node/types change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)