### PR TITLE
feat(oauth): nauta-legal-drafts service client (Nauta→Karafiel legal edge)

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -683,6 +683,7 @@ def openid_configuration():
             # Service-to-service (client_credentials) scopes — see docs/service-tokens.md
             "cfdi:issue",
             "billing:events",
+            "legal:draft",
         ],
         "token_endpoint_auth_methods_supported": [
             "client_secret_basic",

--- a/apps/api/scripts/seed_service_clients.py
+++ b/apps/api/scripts/seed_service_clients.py
@@ -64,6 +64,20 @@ SERVICE_CLIENTS: list[dict[str, Any]] = [
         "is_confidential": True,
     },
     {
+        "name": "nauta-legal-drafts",
+        "description": (
+            "Nauta → Karafiel legal document generation service client "
+            "(nauta docs/LEGAL_OPS_INTEGRATION_PLAN_2026-08-12.md, step "
+            "D3.5). Creates and compiles service-agreement drafts and reads "
+            "generated-document metadata; nothing else."
+        ),
+        "audience": "karafiel-api",
+        "redirect_uris": [],
+        "allowed_scopes": ["legal:draft"],
+        "grant_types": ["client_credentials"],
+        "is_confidential": True,
+    },
+    {
         "name": "routecraft-billing-relay",
         "description": (
             "RouteCraft → Dhanam billing delegation service client "

--- a/apps/api/tests/unit/routers/test_service_token_clients.py
+++ b/apps/api/tests/unit/routers/test_service_token_clients.py
@@ -39,6 +39,8 @@ INTROSPECT_URL = "/api/v1/oauth/introspect"
 # Placeholder credentials for tests only — never real secrets.
 ZAVLO_CLIENT_ID = "jnc_test_zavlo_cfdi_emitter"
 ZAVLO_SECRET = "jns_test_zavlo_secret_placeholder"
+NAUTA_CLIENT_ID = "jnc_test_nauta_legal_drafts"
+NAUTA_SECRET = "jns_test_nauta_secret_placeholder"
 ROUTECRAFT_CLIENT_ID = "jnc_test_routecraft_billing_relay"
 ROUTECRAFT_SECRET = "jns_test_routecraft_secret_placeholder"
 INTERACTIVE_CLIENT_ID = "jnc_test_interactive_only"
@@ -126,6 +128,17 @@ async def service_token_client():
         session.add(
             _service_client(
                 created_by=admin_id,
+                name="nauta-legal-drafts",
+                client_id=NAUTA_CLIENT_ID,
+                secret=NAUTA_SECRET,
+                audience="karafiel-api",
+                allowed_scopes=["legal:draft"],
+                grant_types=["client_credentials"],
+            )
+        )
+        session.add(
+            _service_client(
+                created_by=admin_id,
                 name="routecraft-billing-relay",
                 client_id=ROUTECRAFT_CLIENT_ID,
                 secret=ROUTECRAFT_SECRET,
@@ -206,6 +219,38 @@ class TestServiceTokenIssuance:
         assert "service_account" in claims["roles"]
         assert claims["scope"] == "cfdi:issue"
         assert claims["aud"] == "karafiel-api"
+
+    async def test_nauta_legal_drafts_client_receives_scoped_service_token(
+        self, service_token_client
+    ):
+        # The Nauta -> Karafiel legal-drafts edge (nauta plan doc, step D3.5):
+        # audience karafiel-api, scope legal:draft, machine-identity sub.
+        response = await _request_token(
+            service_token_client,
+            client_id=NAUTA_CLIENT_ID,
+            client_secret=NAUTA_SECRET,
+            scope="legal:draft",
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["scope"] == "legal:draft"
+        claims = jwt_manager.verify_token(
+            body["access_token"], token_type="access", audience="karafiel-api"
+        )
+        assert claims is not None
+        assert claims["sub"] == f"service-account:{NAUTA_CLIENT_ID}"
+        assert claims["actor_type"] == "service_account"
+        assert claims["scope"] == "legal:draft"
+
+    def test_seed_list_pins_the_nauta_legal_drafts_contract(self):
+        from scripts.seed_service_clients import SERVICE_CLIENTS
+
+        entry = next(c for c in SERVICE_CLIENTS if c["name"] == "nauta-legal-drafts")
+        assert entry["audience"] == "karafiel-api"
+        assert entry["allowed_scopes"] == ["legal:draft"]
+        assert entry["grant_types"] == ["client_credentials"]
+        assert entry["is_confidential"] is True
+        assert entry["redirect_uris"] == []
 
     async def test_routecraft_client_defaults_to_full_allowlist(self, service_token_client):
         """Omitting scope grants the client's (single-scope) allowlist."""

--- a/docs/service-tokens.md
+++ b/docs/service-tokens.md
@@ -6,6 +6,7 @@ Cross-service identity for the RFC 0024 §P4 consolidations:
 |---|---|---|---|---|
 | Zavlo → Karafiel CFDI bridge (§P4.2) | `zavlo-cfdi-emitter` | `cfdi:issue` | `karafiel-api` | Karafiel API |
 | RouteCraft → Dhanam billing (§P4.3) | `routecraft-billing-relay` | `billing:events` | `dhanam-api` | Dhanam API |
+| Nauta → Karafiel legal drafts (D3.5) | `nauta-legal-drafts` | `legal:draft` | `karafiel-api` | Karafiel API |
 
 Both migration plans (`zavlo/docs/karafiel-cfdi-migration-plan.md`,
 `routecraft/docs/dhanam-payments-migration-plan.md`) are gated on this


### PR DESCRIPTION
Third `client_credentials` consolidation client per `docs/service-tokens.md`: audience `karafiel-api`, scope `legal:draft` only. Discovery `scopes_supported` updated; tests pin scoped issuance (machine-identity claims) + the seed-list contract. Consumer: nauta `engagement.provision` (D3.5). Karafiel-side enforcement lands separately (service-scope permission on the legal ViewSets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)