### PR TITLE
fix(config): nauta hosts in CORS_ORIGINS — magic-link redirect allowlist

### DIFF
--- a/k8s/base/deployments/janua-api.yaml
+++ b/k8s/base/deployments/janua-api.yaml
@@ -192,7 +192,7 @@ spec:
             # CORS - All allowed frontend origins
             - name: CORS_ORIGINS
               # Non-core app origins auto-derived from OAuth client redirect_uris via DynamicCORSMiddleware
-              value: "https://admin.janua.dev,https://app.janua.dev,https://api.enclii.dev,https://app.enclii.dev,https://admin.enclii.dev,https://auth.madfam.io,https://tezca.mx,https://admin.tezca.mx,https://www.tezca.mx,https://madfam.io,https://www.madfam.io,https://dhanam.madfam.io,https://forgesight.madfam.io,https://forgesight.quest,https://www.forgesight.quest,https://app.forgesight.quest,https://admin.forgesight.quest,https://pravara.madfam.io,https://dhan.am,https://app.dhan.am,https://rondel.io,https://fortuna.tube,https://selva.town,https://ceq.lol,https://crm.madfam.io,https://staging-crm.madfam.io"
+              value: "https://admin.janua.dev,https://app.janua.dev,https://api.enclii.dev,https://app.enclii.dev,https://admin.enclii.dev,https://auth.madfam.io,https://tezca.mx,https://admin.tezca.mx,https://www.tezca.mx,https://madfam.io,https://www.madfam.io,https://dhanam.madfam.io,https://forgesight.madfam.io,https://forgesight.quest,https://www.forgesight.quest,https://app.forgesight.quest,https://admin.forgesight.quest,https://pravara.madfam.io,https://dhan.am,https://app.dhan.am,https://rondel.io,https://fortuna.tube,https://selva.town,https://ceq.lol,https://crm.madfam.io,https://staging-crm.madfam.io,https://nauta.madfam.io,https://cto.madfam.io,https://crea.madfam.io"
             # Cookie domain for cross-subdomain SSO (*.madfam.io for auth.madfam.io)
             - name: COOKIE_DOMAIN
               value: ".madfam.io"


### PR DESCRIPTION
Pre-flight audit of the CTM activation path found the N14-killer: `crea.madfam.io` absent from `CORS_ORIGINS` ⇒ absent from `get_allowed_redirect_hosts()` ⇒ magic-link `redirectUrl` blocked (apex ≠ subdomains; the client-derived path is #517-broken). Adds crea/nauta/cto.madfam.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)