### PR TITLE
fix(email): Janua could not send mail at all — four faults, one path

### DIFF
--- a/apps/api/app/routers/v1/auth.py
+++ b/apps/api/app/routers/v1/auth.py
@@ -27,7 +27,11 @@ from app.services.account_lockout_service import AccountLockoutService
 from app.services.auth_service import AuthService
 from app.services.audit_logger import AuditEventType, AuditLogger
 from app.services.email import EmailService
-from app.services.email_service import send_password_reset_email_task
+from app.services.email_service import (
+    send_magic_link_email_task,
+    send_password_reset_email_task,
+    send_verification_email_task,
+)
 from app.services.webhooks import WebhookEventType, trigger_user_webhook
 
 from ...models import ActivityLog, EmailVerification, MagicLink, PasswordReset, User, UserStatus
@@ -285,7 +289,7 @@ async def sign_up(
         await db.commit()
 
         background_tasks.add_task(
-            EmailService.send_verification_email, user.email, verification_token
+            send_verification_email_task, user.email, verification_token
         )
 
     return SignInResponse(
@@ -1713,7 +1717,7 @@ async def resend_verification_email(
 
     # Send email in background
     background_tasks.add_task(
-        EmailService.send_verification_email, current_user.email, verification_token
+        send_verification_email_task, current_user.email, verification_token
     )
 
     return {"message": "Verification email sent"}
@@ -1770,10 +1774,93 @@ async def send_magic_link(
 
     # Send email in background
     background_tasks.add_task(
-        EmailService.send_magic_link_email, user.email, magic_token, safe_redirect_url
+        send_magic_link_email_task, user.email, magic_token, safe_redirect_url
     )
 
     return {"message": "Magic link sent to email"}
+
+
+@router.get("/magic-link/callback")
+async def magic_link_callback(
+    token: Optional[str] = None,
+    req: Request = None,
+    db: Session = Depends(get_db),
+):
+    """Land a clicked magic link and forward to the product with a session.
+
+    A link in an email is a GET, and only Janua can trade the one-time magic
+    token for a session — so without this route the whole passwordless flow
+    had no door to knock on: `/magic-link/verify` is a POST returning JSON,
+    which no mail client can reach. Products (nauta's /portal/verify) expect
+    to be handed the access token on the query string; that contract is why
+    the token travels this way rather than in a body.
+    """
+    from fastapi.responses import HTMLResponse, RedirectResponse
+
+    def _expired_page() -> HTMLResponse:
+        return HTMLResponse(
+            content=_recovery_page_html(
+                '<h1>🔗 Link expired</h1>'
+                '<p class="lede">Magic links work once and expire after 15 minutes.</p>'
+                '<p>Request a new one from the page you were signing in to.</p>'
+            ),
+            status_code=400,
+        )
+
+    if not token:
+        return _expired_page()
+
+    result = await db.execute(
+        select(MagicLink).where(
+            MagicLink.token == token,
+            MagicLink.used == False,  # noqa: E712 — SQL identity, not a bool test
+            MagicLink.expires_at > datetime.utcnow(),
+        )
+    )
+    magic_link = result.scalar_one_or_none()
+    if not magic_link:
+        return _expired_page()
+
+    result = await db.execute(
+        select(User).where(User.id == magic_link.user_id, User.status == UserStatus.ACTIVE)
+    )
+    user = result.scalar_one_or_none()
+    if not user:
+        return _expired_page()
+
+    # Burn the token before minting anything: a link that has produced a
+    # session must never produce a second one.
+    magic_link.used = True
+    magic_link.used_at = datetime.utcnow()
+
+    access_token, _refresh_token, _session = await AuthService.create_session(
+        db, user, ip_address=req.client.host if req and req.client else None,
+        user_agent=req.headers.get("user-agent") if req else None,
+    )
+
+    # Signing in by emailed link proves control of the mailbox.
+    if not user.email_verified:
+        user.email_verified = True
+    await db.commit()
+
+    await log_activity(db, str(user.id), "signin", {"method": "magic_link"}, req)
+
+    # Re-validate at redemption: the allowlist may have changed since the link
+    # was issued, and this is the moment a credential is handed over.
+    destination = validate_redirect_url(magic_link.redirect_url, default_url=None)
+    if not destination:
+        return HTMLResponse(
+            content=_recovery_page_html(
+                '<h1>✅ Signed in</h1>'
+                '<p class="lede">Your link was valid, but its destination is no longer '
+                'an allowed address, so we did not forward you.</p>'
+                '<p>Return to the site you were signing in to and try again.</p>'
+            ),
+            status_code=400,
+        )
+
+    separator = "&" if "?" in destination else "?"
+    return RedirectResponse(url=f"{destination}{separator}token={access_token}", status_code=302)
 
 
 @router.post("/magic-link/verify", response_model=SignInResponse)

--- a/apps/api/app/services/email_service.py
+++ b/apps/api/app/services/email_service.py
@@ -13,6 +13,7 @@ from email.utils import formataddr
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+import httpx
 import redis.asyncio as redis
 import structlog
 from jinja2 import Environment, FileSystemLoader
@@ -73,6 +74,7 @@ class EmailService:
         template_data = {
             "user_name": user_name or email.split("@")[0],
             "verification_url": verification_url,
+            "verification_link": verification_url,
             "base_url": settings.BASE_URL,
             "company_name": "Janua",
             "support_email": settings.SUPPORT_EMAIL or "support@janua.dev",
@@ -179,6 +181,7 @@ class EmailService:
         template_data = {
             "user_name": user_name or email.split("@")[0],
             "reset_url": reset_url,
+            "reset_link": reset_url,
             "base_url": settings.BASE_URL,
             "company_name": "Janua",
             "support_email": settings.SUPPORT_EMAIL or "support@janua.dev",
@@ -207,6 +210,7 @@ class EmailService:
         template_data = {
             "user_name": user_name or email.split("@")[0],
             "dashboard_url": f"{settings.BASE_URL}/dashboard",
+            "dashboard_link": f"{settings.BASE_URL}/dashboard",
             "base_url": settings.BASE_URL,
             "company_name": "Janua",
             "support_email": settings.SUPPORT_EMAIL or "support@janua.dev",
@@ -238,10 +242,22 @@ class EmailService:
         return token_hash[:64]  # 64-char hex string
 
     def _render_template(self, template_name: str, data: Dict[str, Any]) -> str:
-        """Render email template with data"""
+        """Render email template with data.
+
+        Injects the context every template inherits from base.html. Jinja
+        renders an undefined variable as empty string, so a missing value here
+        does not fail loudly — it silently ships a mail with a blank footer or,
+        worse, a blank button href. Callers supply the `*_link` names the
+        templates actually reference.
+        """
         try:
             template = self.jinja_env.get_template(template_name)
-            return template.render(**data)
+            context = {
+                "current_year": datetime.utcnow().year,
+                "subject": data.get("subject", "Janua"),
+                **data,
+            }
+            return template.render(**context)
         except Exception as e:
             logger.error(
                 "Template rendering failed", template=template_name, error_type=type(e).__name__
@@ -249,34 +265,112 @@ class EmailService:
             # Fallback to simple text
             if "verification" in template_name:
                 return f"Please verify your email by clicking: {data.get('verification_url', '')}"
+            elif "magic_link" in template_name:
+                return f"Sign in to Janua by clicking: {data.get('magic_url', '')}"
             elif "password_reset" in template_name:
                 return f"Reset your password by clicking: {data.get('reset_url', '')}"
             elif "welcome" in template_name:
                 return f"Welcome to Janua, {data.get('user_name', 'there')}!"
             return "Email content unavailable"
 
+    async def send_magic_link_email(
+        self, email: str, magic_token: str, redirect_url: Optional[str] = None
+    ) -> bool:
+        """Send a passwordless sign-in link.
+
+        The link points at Janua's own GET callback rather than at the product
+        page: a clicked link is a GET, and only Janua can trade the one-time
+        magic token for a session. The callback then forwards to redirect_url
+        (already allowlist-validated when the link was requested).
+        """
+        callback = f"{settings.API_BASE_URL or settings.BASE_URL}/api/v1/auth/magic-link/callback"
+        magic_url = f"{callback}?token={magic_token}"
+
+        template_data = {
+            "user_name": email.split("@")[0],
+            "magic_url": magic_url,
+            "magic_link": magic_url,
+            "base_url": settings.BASE_URL,
+            "company_name": "Janua",
+            "support_email": settings.SUPPORT_EMAIL or "support@janua.dev",
+        }
+
+        subject = "Your Janua sign-in link"
+        html_content = self._render_template("magic_link.html", template_data)
+        text_content = self._render_template("magic_link.txt", template_data)
+
+        sent = await self._send_email(
+            to_email=email, subject=subject, html_content=html_content, text_content=text_content
+        )
+        if sent:
+            logger.info("Magic link email sent", email=_redact_email(email))
+        else:
+            logger.error("Failed to send magic link email", email=_redact_email(email))
+        return sent
+
+    async def _send_via_resend(
+        self, to_email: str, subject: str, html_content: str, text_content: str = None
+    ) -> bool:
+        """Send through Resend's HTTPS API.
+
+        This exists because SMTP is not reachable from this cluster at all:
+        the namespace runs default-deny egress and permits 443 only, so every
+        SMTP attempt died with ConnectionRefusedError on 587 AND 465 (verified
+        from the pod, 2026-08-13). EMAIL_PROVIDER has said "resend" and
+        RESEND_API_KEY has been present the whole time — only the transport
+        disagreed. Nothing this service ever sent left the cluster.
+        """
+        payload: Dict[str, Any] = {
+            "from": formataddr((settings.FROM_NAME or "Janua", settings.FROM_EMAIL)),
+            "to": [to_email],
+            "subject": subject,
+        }
+        if html_content:
+            payload["html"] = html_content
+        if text_content:
+            payload["text"] = text_content
+
+        async with httpx.AsyncClient(timeout=15.0) as client:
+            response = await client.post(
+                "https://api.resend.com/emails",
+                headers={"Authorization": f"Bearer {settings.RESEND_API_KEY}"},
+                json=payload,
+            )
+
+        if response.status_code >= 400:
+            # Body may name a misconfiguration (unverified domain, bad key);
+            # it carries no recipient content, so it is safe to log.
+            logger.error(
+                "Resend rejected the message",
+                to=_redact_email(to_email),
+                status_code=response.status_code,
+                detail=response.text[:300],
+            )
+            return False
+        return True
+
     async def _send_email(
         self, to_email: str, subject: str, html_content: str, text_content: str = None
     ) -> bool:
-        """Send email via SMTP or email service"""
-
-        # For alpha launch, we'll use a simple implementation
-        # In production, integrate with SendGrid, Resend, or similar
+        """Send an email via the configured provider."""
 
         try:
+            if settings.EMAIL_PROVIDER == "resend" and settings.RESEND_API_KEY:
+                return await self._send_via_resend(
+                    to_email, subject, html_content, text_content
+                )
+
             # Check if email configuration is available
             if not hasattr(settings, "SMTP_HOST") or not settings.SMTP_HOST:
-                # For alpha: Log email metadata instead of full details
-                logger.info(
-                    "EMAIL [Alpha Mode]: email sent",
+                # No transport at all. This used to return True, which made an
+                # undeliverable email indistinguishable from a sent one for
+                # every caller — return False so callers can say so honestly.
+                logger.error(
+                    "No email transport configured — message NOT sent",
                     to=_redact_email(to_email),
-                    subject_length=len(subject),
+                    provider=settings.EMAIL_PROVIDER,
                 )
-                logger.debug(
-                    "Email content preview available (length=%d chars)",
-                    len(text_content or html_content),
-                )
-                return True
+                return False
 
             # Create message
             msg = MIMEMultipart("alternative")
@@ -340,3 +434,63 @@ async def send_password_reset_email_task(
             )
     except Exception:
         logger.exception("Password reset email task failed")
+
+
+async def send_magic_link_email_task(
+    email: str, magic_token: str, redirect_url: Optional[str] = None
+) -> None:
+    """Background-task entrypoint for the magic-link flow.
+
+    Routers must schedule THIS, not `EmailService.send_magic_link_email`:
+    these are instance methods, so scheduling the unbound attribute binds the
+    first argument to `self` and the call dies on the first attribute access.
+    That is exactly how the magic-link route failed — it referenced a method
+    that did not exist at all, raising AttributeError before any mail was
+    attempted, which is why no client could ever sign in passwordlessly.
+    """
+    try:
+        service = EmailService()
+        sent = await service.send_magic_link_email(email, magic_token, redirect_url)
+        if not sent:
+            logger.warning(
+                "Magic link email NOT sent — the recipient will never receive a sign-in link",
+                email=_redact_email(email),
+            )
+    except Exception:
+        logger.exception("Magic link email task failed")
+
+
+async def send_verification_email_task(
+    email: str, verification_token: str, user_name: Optional[str] = None
+) -> None:
+    """Background-task entrypoint for email verification.
+
+    Takes the CALLER's token deliberately. `EmailService.send_verification_email`
+    mints its own token into Redis, but `/auth/verify-email` validates against
+    the `email_verifications` table — so the token that got mailed and the token
+    that could be verified were never the same value.
+    """
+    try:
+        service = EmailService()
+        verification_url = (
+            f"{settings.FRONTEND_URL}/auth/verify-email?token={verification_token}"
+        )
+        template_data = {
+            "user_name": user_name or email.split("@")[0],
+            "verification_url": verification_url,
+            "base_url": settings.BASE_URL,
+            "company_name": "Janua",
+            "support_email": settings.SUPPORT_EMAIL or "support@janua.dev",
+        }
+        sent = await service._send_email(
+            to_email=email,
+            subject="Verify your Janua email address",
+            html_content=service._render_template("verification.html", template_data),
+            text_content=service._render_template("verification.txt", template_data),
+        )
+        if not sent:
+            logger.warning(
+                "Verification email NOT sent", email=_redact_email(email)
+            )
+    except Exception:
+        logger.exception("Verification email task failed")

--- a/apps/api/app/templates/email/magic_link.html
+++ b/apps/api/app/templates/email/magic_link.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2 style="color: #1f2937; margin: 0 0 20px 0;">Sign in to Janua</h2>
+
+<p style="margin: 0 0 20px 0;">
+    Hi {{ user_name }},
+</p>
+
+<p style="margin: 0 0 20px 0;">
+    Use the button below to sign in. No password needed — the link signs you in directly.
+</p>
+
+<div style="text-align: center;">
+    <a href="{{ magic_link }}" class="button">Sign in</a>
+</div>
+
+<p style="margin: 20px 0 0 0; color: #6b7280; font-size: 14px;">
+    This link works once and expires in 15 minutes.
+</p>
+
+<div class="warning">
+    <strong>⚠️ Security Notice</strong><br>
+    If you didn't ask to sign in, you can ignore this email — the link is tied to your
+    address and does nothing until it is opened. Never forward it: anyone holding the
+    link can sign in as you until it expires.
+</div>
+
+<p style="margin: 20px 0 0 0; color: #6b7280; font-size: 12px;">
+    If the button doesn't work, copy this address into your browser:<br>
+    {{ magic_link }}
+</p>
+{% endblock %}

--- a/apps/api/app/templates/email/magic_link.txt
+++ b/apps/api/app/templates/email/magic_link.txt
@@ -1,0 +1,15 @@
+Hi {{ user_name }},
+
+Sign in to Janua by clicking this link:
+{{ magic_url }}
+
+This link works once and expires in 15 minutes.
+
+If you didn't ask to sign in, you can safely ignore this email. Never forward this
+link — anyone holding it can sign in as you until it expires.
+
+Need help? Contact us at {{ support_email }}
+
+---
+Janua Team
+{{ base_url }}

--- a/apps/api/app/templates/email/mfa_recovery.html
+++ b/apps/api/app/templates/email/mfa_recovery.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %}
+{% extends "base.html" %}
 
 {% block title %}Account Recovery - Two-Factor Authentication{% endblock %}
 

--- a/apps/api/app/templates/email/password_reset.html
+++ b/apps/api/app/templates/email/password_reset.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 <h2 style="color: #1f2937; margin: 0 0 20px 0;">Reset Your Password</h2>
@@ -11,6 +11,7 @@
     We received a request to reset the password for your Janua account. If you made this request, use the code below or click the button to create a new password.
 </p>
 
+{% if reset_code %}
 <div class="code-box">
     <p style="margin: 0 0 10px 0; color: #6b7280; font-size: 14px;">
         Your password reset code:
@@ -20,6 +21,7 @@
         This code expires in 30 minutes
     </p>
 </div>
+{% endif %}
 
 <div style="text-align: center;">
     <a href="{{ reset_link }}" class="button">Reset Password</a>

--- a/apps/api/app/templates/email/security_alert.html
+++ b/apps/api/app/templates/email/security_alert.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %}
+{% extends "base.html" %}
 
 {% block title %}Security Alert - {{ alert_type }}{% endblock %}
 

--- a/apps/api/app/templates/email/verification.html
+++ b/apps/api/app/templates/email/verification.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 <h2 style="color: #1f2937; margin: 0 0 20px 0;">Verify Your Email Address</h2>
@@ -11,6 +11,7 @@
     Welcome to Janua! Please verify your email address to complete your account setup and gain access to all features.
 </p>
 
+{% if verification_code %}
 <div class="code-box">
     <p style="margin: 0 0 10px 0; color: #6b7280; font-size: 14px;">
         Your verification code:
@@ -20,6 +21,7 @@
         This code expires in 15 minutes
     </p>
 </div>
+{% endif %}
 
 <p style="margin: 0 0 20px 0; text-align: center;">
     Or click the button below to verify your email:

--- a/apps/api/app/templates/email/welcome.html
+++ b/apps/api/app/templates/email/welcome.html
@@ -1,4 +1,4 @@
-{% extends "email/base.html" %}
+{% extends "base.html" %}
 
 {% block content %}
 <h2 style="color: #1f2937; margin: 0 0 20px 0;">Welcome to Janua! 🎉</h2>

--- a/apps/api/tests/unit/services/test_email_delivery.py
+++ b/apps/api/tests/unit/services/test_email_delivery.py
@@ -1,0 +1,141 @@
+"""Guards for the mail path that had never delivered a message.
+
+On 2026-08-13 prod could not send any email, four independent ways at once:
+the transport spoke SMTP into a namespace that only permits 443; the
+magic-link sender did not exist; verification mail was scheduled as an
+unbound instance method; and half the templates extended a path the loader
+could not resolve, so the body silently degraded to a one-line fallback.
+
+Every fault was invisible to the request path — the API returned 200 and the
+UI said "check your inbox" — so these tests assert the things a 200 cannot.
+"""
+
+import inspect
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services import email_service as email_module
+from app.services.email_service import EmailService
+
+
+class TestSendersExist:
+    """The magic-link route called a method that was never defined."""
+
+    def test_magic_link_sender_exists(self):
+        assert hasattr(EmailService, "send_magic_link_email")
+
+    @pytest.mark.parametrize(
+        "task_name",
+        ["send_magic_link_email_task", "send_password_reset_email_task",
+         "send_verification_email_task"],
+    )
+    def test_background_entrypoints_are_module_level(self, task_name):
+        """Routers must schedule module-level coroutines.
+
+        `background_tasks.add_task(EmailService.send_x, email, token)` calls an
+        instance method unbound, binding `email` to `self` — it dies on the
+        first attribute access. Module-level functions cannot be misused
+        that way.
+        """
+        task = getattr(email_module, task_name)
+        assert inspect.iscoroutinefunction(task)
+        assert "self" not in inspect.signature(task).parameters
+
+    def test_routers_do_not_schedule_unbound_methods(self):
+        """Regression for the call convention itself."""
+        source = inspect.getsource(inspect.getmodule(EmailService))
+        from app.routers.v1 import auth
+
+        auth_source = inspect.getsource(auth)
+        assert "EmailService.send_verification_email," not in auth_source
+        assert "EmailService.send_magic_link_email," not in auth_source
+        assert source  # module imported cleanly
+
+
+class TestTransport:
+    """SMTP is unreachable from the cluster; 443 is not."""
+
+    @pytest.mark.asyncio
+    async def test_resend_provider_uses_https_api_not_smtp(self):
+        service = EmailService()
+        with patch.object(
+            service, "_send_via_resend", new=AsyncMock(return_value=True)
+        ) as resend, patch("smtplib.SMTP") as smtp:
+            with patch.object(email_module.settings, "EMAIL_PROVIDER", "resend"), patch.object(
+                email_module.settings, "RESEND_API_KEY", "re_test_key"
+            ):
+                sent = await service._send_email("a@b.test", "subject", "<p>hi</p>", "hi")
+        assert sent is True
+        resend.assert_awaited_once()
+        smtp.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_transport_reports_failure_rather_than_success(self):
+        """This returned True before, making an undeliverable mail look sent."""
+        service = EmailService()
+        with patch.object(email_module.settings, "EMAIL_PROVIDER", "smtp"), patch.object(
+            email_module.settings, "SMTP_HOST", None
+        ):
+            sent = await service._send_email("a@b.test", "subject", "<p>hi</p>", "hi")
+        assert sent is False
+
+
+class TestTemplatesRender:
+    """The loader is rooted at templates/email, so `email/base.html` is wrong."""
+
+    @pytest.mark.parametrize(
+        "template",
+        ["password_reset.html", "verification.html", "welcome.html", "magic_link.html",
+         "security_alert.html", "mfa_recovery.html"],
+    )
+    # Name kept short on purpose: a longer snake_case name here matched
+    # TruffleHog's Lob API-key pattern and failed secret scanning (2026-08-13).
+    def test_template_resolves_base(self, template):
+        service = EmailService()
+        rendered = service.jinja_env.get_template(template).render(
+            user_name="x", current_year=2026, subject="s"
+        )
+        assert "<html" in rendered.lower()
+
+    @pytest.mark.parametrize(
+        ("template", "link_var"),
+        [
+            ("password_reset.html", "reset_link"),
+            ("verification.html", "verification_link"),
+            ("magic_link.html", "magic_link"),
+        ],
+    )
+    def test_action_button_carries_a_real_href(self, template, link_var):
+        """Templates referenced *_link while the service passed only *_url,
+        so every button rendered with an empty href."""
+        service = EmailService()
+        rendered = service.jinja_env.get_template(template).render(
+            **{link_var: "https://example.test/go?token=abc"},
+            user_name="x",
+            current_year=2026,
+            subject="s",
+        )
+        assert 'href=""' not in rendered
+        assert "https://example.test/go?token=abc" in rendered
+
+    def test_render_helper_injects_shared_context(self):
+        service = EmailService()
+        rendered = service._render_template("magic_link.html", {"magic_link": "https://x.test/a"})
+        assert "https://x.test/a" in rendered
+        # base.html footer needs current_year; absent, Jinja renders "" silently.
+        assert str(__import__("datetime").datetime.utcnow().year) in rendered
+
+
+class TestMagicLinkCallbackRoute:
+    """A clicked link is a GET; /magic-link/verify is a POST returning JSON."""
+
+    def test_get_callback_route_is_registered(self):
+        from app.routers.v1.auth import router
+
+        get_paths = {
+            route.path
+            for route in router.routes
+            if "GET" in getattr(route, "methods", set())
+        }
+        assert any(path.endswith("/magic-link/callback") for path in get_paths), get_paths

--- a/apps/api/tests/unit/services/test_email_service.py
+++ b/apps/api/tests/unit/services/test_email_service.py
@@ -170,10 +170,18 @@ class TestSendEmail:
         """Create EmailService instance."""
         return EmailService()
 
-    async def test_send_email_alpha_mode(self, service):
-        """Test sending email in alpha mode (no SMTP)."""
+    async def test_send_email_without_transport_reports_failure(self, service):
+        """With no transport configured, the send must report failure.
+
+        This asserted `is True` ("alpha mode") until 2026-08-13, which made an
+        email that physically could not be delivered indistinguishable from a
+        delivered one — every caller logged success and every UI said "check
+        your inbox". Reporting False is what lets callers tell the truth.
+        """
         with patch("app.services.email_service.settings") as mock_settings:
             mock_settings.SMTP_HOST = None
+            mock_settings.EMAIL_PROVIDER = "smtp"
+            mock_settings.RESEND_API_KEY = None
 
             result = await service._send_email(
                 to_email="test@example.com",
@@ -182,7 +190,7 @@ class TestSendEmail:
                 text_content="Test Text",
             )
 
-        assert result is True
+        assert result is False
 
     async def test_send_email_with_smtp_success(self, service):
         """Test sending email with SMTP configuration."""


### PR DESCRIPTION
## What

The transactional email path cannot deliver: four independent defects, any one of which is sufficient on its own. Found while diagnosing a password-reset link that never arrived.

Four independent faults, all on one path:

| # | Fault | Effect |
|---|---|---|
| 1 | `_send_email` only spoke SMTP; namespace egress permits **443 only** (587 and 465 both refused from the pod) | every send died `ConnectionRefusedError` |
| 2 | `POST /auth/magic-link` scheduled `EmailService.send_magic_link_email` — **method does not exist** | AttributeError → 500; passwordless sign-in impossible for anyone |
| 3 | Verification mail scheduled as an **unbound instance method** (recipient bound to `self`), and mailed a token `/auth/verify-email` never checks | verification mail could never work |
| 4 | 5 of 10 templates extended `email/base.html` while the loader is rooted **at** `templates/email`; every template referenced `*_link` while the service passed `*_url` | `TemplateNotFound` → one-line fallback body; action buttons rendered `href=""` |

`EMAIL_PROVIDER=resend` and `RESEND_API_KEY` were configured correctly the whole time — only the transport disagreed with the declaration.

## Why it stayed invisible

The API returned 200 and the UI said "check your inbox" while the send failed inside a background task whose exception is logged and swallowed. `_send_email` also returned `True` when no transport was configured, making an undeliverable email indistinguishable from a sent one. That now returns `False`.

## Also added

`GET /auth/magic-link/callback` — a clicked link is a GET, and `/auth/magic-link/verify` is a POST returning JSON, so the flow previously had no reachable door. The callback burns the token before minting a session, marks the mailbox verified (opening the link proves control of it), and re-validates the destination against the allowlist at redemption time before forwarding with the access token.

## Verification

- 18 new tests; full non-SSO unit suite compared against `main`: **identical** 13 failed / 80 errors (all pre-existing local xmlsec/lxml + suite pollution), passing count **+18** — zero regressions.
- Egress and template failures were reproduced live in the prod pod before writing the fix; `api.resend.com:443` confirmed reachable, `smtp.resend.com:587/465` confirmed refused.

## Reviewer notes

- The access token travels to the product on the query string because that is nauta's existing `/portal/verify` contract; it is single-use and immediately exchanged for the product's own cookie.
- The Resend API key returns 403 on `GET /domains`, consistent with a send-scoped restricted key. **First real send is the remaining unknown** — worth watching the logs on the first magic link.