### PR TITLE
fix(oauth): restart at the client instead of forging an authorize request

### DIFF
--- a/apps/api/app/routers/v1/auth.py
+++ b/apps/api/app/routers/v1/auth.py
@@ -6,7 +6,7 @@ import json
 import secrets
 from datetime import datetime, timedelta
 from typing import Dict, Optional
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 from fastapi import APIRouter, BackgroundTasks, Depends, Form, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -527,7 +527,20 @@ def _oauth_context_hidden_fields_html(
 
 
 async def _recover_authorize_url_from_client(client_id: str, db) -> Optional[str]:
-    """Rebuild a minimal /oauth/authorize URL when Redis pre-login state expired."""
+    """Send the user back to the CLIENT so it can start a fresh flow.
+
+    This used to rebuild a synthetic /oauth/authorize URL from the client's
+    registration. That URL carried no `state`, no `nonce` and no PKCE
+    challenge, because the server cannot know them — only the client that
+    started the flow does. Every modern OIDC client validates `state` and a
+    PKCE verifier against its own cookies, so the callback produced by such a
+    fabricated request could never be accepted: Auth.js rejects it with
+    `response parameter "state" missing` (observed in prod 2026-08-13).
+
+    A recovery that cannot succeed is worse than an honest restart. Returning
+    the client's own origin lets it mint a new state + verifier pair the way
+    it always does.
+    """
     from ...models import OAuthClient as _OAuthClient
 
     stmt = select(_OAuthClient).where(_OAuthClient.client_id == client_id)
@@ -545,14 +558,13 @@ async def _recover_authorize_url_from_client(client_id: str, db) -> Optional[str
     if not redirect_uris:
         return None
 
-    fallback_scope = " ".join(oauth_client.allowed_scopes or ["openid"])
-    query_params = {
-        "response_type": "code",
-        "client_id": client_id,
-        "redirect_uri": redirect_uris[0],
-        "scope": fallback_scope,
-    }
-    return f"/api/v1/oauth/authorize?{urlencode(query_params)}"
+    # The origin of the registered callback is the product itself. Landing
+    # there re-enters the product's own sign-in entry point, which starts a
+    # complete authorize request (state + PKCE) that its callback can verify.
+    parsed = urlparse(redirect_uris[0])
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}/"
 
 
 # GET /login - Render login form for OAuth flows

--- a/apps/api/app/routers/v1/oauth_provider.py
+++ b/apps/api/app/routers/v1/oauth_provider.py
@@ -1503,6 +1503,12 @@ async def _handle_authorization_code_grant(
 
     # Validate client matches
     if code_data["client_id"] != client.client_id:
+        logger.warning(
+            "token.rejected",
+            reason="client_mismatch",
+            client_id=client.client_id,
+            code_client_id=code_data["client_id"],
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="invalid_grant: Code was not issued to this client",
@@ -1510,6 +1516,13 @@ async def _handle_authorization_code_grant(
 
     # Validate redirect_uri matches
     if redirect_uri and code_data["redirect_uri"] != redirect_uri:
+        logger.warning(
+            "token.rejected",
+            reason="redirect_uri_mismatch",
+            client_id=client.client_id,
+            presented=redirect_uri,
+            issued_for=code_data["redirect_uri"],
+        )
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="invalid_grant: redirect_uri mismatch",
@@ -1519,6 +1532,11 @@ async def _handle_authorization_code_grant(
     # Verify PKCE if code_challenge was provided during authorization
     if code_data.get("code_challenge"):
         if not code_verifier:
+            logger.warning(
+                "token.rejected",
+                reason="code_verifier_missing",
+                client_id=client.client_id,
+            )
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="invalid_request: code_verifier required",
@@ -1528,6 +1546,18 @@ async def _handle_authorization_code_grant(
             code_data["code_challenge"],
             code_data.get("code_challenge_method", "S256"),
         ):
+            # The client's verifier belongs to a different authorize request
+            # than the one that issued this code. Logging the challenge (a
+            # public, single-use hash — never the verifier) is what makes that
+            # diagnosable; without it a 400 here is indistinguishable from
+            # every other 400 and costs hours to chase.
+            logger.warning(
+                "token.rejected",
+                reason="pkce_mismatch",
+                client_id=client.client_id,
+                issued_challenge=code_data["code_challenge"],
+                method=code_data.get("code_challenge_method", "S256"),
+            )
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="invalid_grant: PKCE verification failed",

--- a/apps/api/tests/unit/routers/test_oauth_restart.py
+++ b/apps/api/tests/unit/routers/test_oauth_restart.py
@@ -1,0 +1,81 @@
+"""When pre-login state is gone, restart at the client — never fabricate.
+
+Janua used to rebuild a synthetic /oauth/authorize URL from the client's
+registration whenever the Redis pre-login blob had expired or been consumed.
+That URL necessarily carried no `state`, no `nonce` and no PKCE challenge:
+the authorization server cannot know them, only the client that started the
+flow can. Any OIDC client that validates `state` (all of them) rejects the
+resulting callback — Auth.js reports `response parameter "state" missing`.
+
+Observed in prod 2026-08-13: a second sign-in click always landed on this
+path, so the retry failed differently from the first attempt and the operator
+was stuck in a loop that looked like "the login button needs two clicks".
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.routers.v1.auth import _recover_authorize_url_from_client
+
+
+class _Result:
+    def __init__(self, obj):
+        self._obj = obj
+
+    def scalar_one_or_none(self):
+        return self._obj
+
+
+class _DB:
+    def __init__(self, obj):
+        self._obj = obj
+
+    async def execute(self, _stmt):
+        return _Result(self._obj)
+
+
+def _client(**overrides):
+    base = {
+        "client_id": "jnc_test",
+        "is_active": True,
+        "redirect_uris": ["https://cto.madfam.io/api/auth/callback/janua"],
+        "allowed_scopes": ["openid", "profile"],
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+@pytest.mark.asyncio
+async def test_restarts_at_the_client_origin():
+    url = await _recover_authorize_url_from_client("jnc_test", _DB(_client()))
+    assert url == "https://cto.madfam.io/"
+
+
+@pytest.mark.asyncio
+async def test_never_fabricates_an_authorize_request():
+    """The regression itself: a server-built authorize request cannot carry
+    the client's state or verifier, so it must not be built at all."""
+    url = await _recover_authorize_url_from_client("jnc_test", _DB(_client()))
+    assert "/oauth/authorize" not in url
+    assert "state" not in url
+    assert "code_challenge" not in url
+    assert "response_type" not in url
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "client",
+    [None, _client(is_active=False), _client(redirect_uris=[]), _client(redirect_uris=["notaurl"])],
+)
+async def test_declines_when_no_usable_origin(client):
+    assert await _recover_authorize_url_from_client("jnc_test", _DB(client)) is None
+
+
+@pytest.mark.asyncio
+async def test_json_encoded_redirect_uris_are_understood():
+    """Some rows store redirect_uris as a JSON string rather than a list."""
+    client = _client(redirect_uris='["https://crea.madfam.io/api/auth/callback/janua"]')
+    assert await _recover_authorize_url_from_client("jnc_test", _DB(client)) == (
+        "https://crea.madfam.io/"
+    )


### PR DESCRIPTION
## Symptom

Operator reported the cockpit "log in" button needing **two clicks**, and then `Invalid or expired CSRF token` on Accept.

## What was actually happening

Reconstructed from prod logs (18:29 on 2026-08-13):

| time | event |
|---|---|
| 18:29:25 | authorize starts, browser sends `code_challenge=cQDWDvhB…` |
| 18:29:37 | first login submit → code issued **with that exact challenge** → callback |
| 18:29:38 | nauta's token exchange → **400** (PKCE), Auth.js bounces back to login |
| 18:29:44 | second login submit → pre-login blob already consumed → **fabricated authorize** |
| 18:29:46 | consent OK, but callback carries **no `state`** → Auth.js: `response parameter "state" missing` |
| 18:29:49 | stale consent form resubmitted → CSRF token already consumed → the 403 the operator saw |

The CSRF error was the *last* symptom in a chain, not the cause.

## Fix

`_recover_authorize_url_from_client` rebuilt an authorize request from the client's registration whenever the pre-login blob was gone. Such a URL **cannot** carry `state`, `nonce`, or a PKCE challenge — only the client that started the flow knows them — so every callback it produced was invalid by construction. It now returns the client's **origin**, letting the product start a real flow with its own state and verifier.

## Also

The token endpoint discarded the reason for every rejection, so a 400 was indistinguishable from any other 400 and diagnosing one meant reading leftover Redis keys. It now logs the branch (`client_mismatch`, `redirect_uri_mismatch`, `code_verifier_missing`, `pkce_mismatch`) plus the public single-use challenge — **never** the verifier.

## What this does NOT fix

The original 18:29:38 PKCE failure is **client-side**. I verified from the logs that Janua carries the challenge byte-for-byte from the authorize request into the issued code, so the server is faithful here; the verifier the client presented belonged to a different authorize request. The new log line is what will name it on the next attempt.

## Verification

7 new tests. `tests/unit/routers` + `tests/unit/security` compared against `main`: **identical** 2 failed / 23 errors (pre-existing), passing count **+7** — zero regressions.