### PR TITLE
fix(auth): magic-link verification queried a column that does not exist

### DIFF
--- a/apps/api/app/routers/v1/auth.py
+++ b/apps/api/app/routers/v1/auth.py
@@ -1825,7 +1825,7 @@ async def magic_link_callback(
     result = await db.execute(
         select(MagicLink).where(
             MagicLink.token == token,
-            MagicLink.used == False,  # noqa: E712 — SQL identity, not a bool test
+            MagicLink.used_at.is_(None),
             MagicLink.expires_at > datetime.utcnow(),
         )
     )
@@ -1842,7 +1842,6 @@ async def magic_link_callback(
 
     # Burn the token before minting anything: a link that has produced a
     # session must never produce a second one.
-    magic_link.used = True
     magic_link.used_at = datetime.utcnow()
 
     access_token, _refresh_token, _session = await AuthService.create_session(
@@ -1884,7 +1883,7 @@ async def verify_magic_link(
     result = await db.execute(
         select(MagicLink).where(
             MagicLink.token == request.token,
-            MagicLink.used == False,
+            MagicLink.used_at.is_(None),
             MagicLink.expires_at > datetime.utcnow(),
         )
     )
@@ -1903,7 +1902,6 @@ async def verify_magic_link(
         raise HTTPException(status_code=400, detail="User not found")
 
     # Mark magic link as used
-    magic_link.used = True
     magic_link.used_at = datetime.utcnow()
 
     # Create session

--- a/apps/api/tests/unit/routers/test_magic_link_model_fields.py
+++ b/apps/api/tests/unit/routers/test_magic_link_model_fields.py
@@ -1,0 +1,38 @@
+"""Both magic-link paths queried a column that does not exist.
+
+`MagicLink` tracks consumption with a nullable `used_at` timestamp; there is
+no boolean `used`. `MagicLink.used == False` therefore raised AttributeError
+at request time, so every real token 500'd — in the pre-existing POST verify
+endpoint as well as the GET callback added on 2026-08-13.
+
+A route-registration test does not catch this: the route existed and answered
+correctly when called WITHOUT a token, because the query is never reached on
+that path. These assert the query itself.
+"""
+
+import inspect
+
+from app.models import MagicLink
+from app.routers.v1 import auth
+
+
+def test_model_tracks_consumption_with_used_at():
+    assert hasattr(MagicLink, "used_at")
+    assert not hasattr(MagicLink, "used"), (
+        "If a boolean `used` column is ever added, revisit both magic-link "
+        "queries — they filter on used_at IS NULL."
+    )
+
+
+def test_no_handler_filters_on_a_nonexistent_used_column():
+    source = inspect.getsource(auth)
+    assert "MagicLink.used ==" not in source
+    assert "magic_link.used = True" not in source
+
+
+def test_both_paths_filter_unconsumed_links():
+    """The GET callback and the POST verify must both exclude spent links."""
+    for handler in (auth.magic_link_callback, auth.verify_magic_link):
+        source = inspect.getsource(handler)
+        assert "MagicLink.used_at.is_(None)" in source, handler.__name__
+        assert "magic_link.used_at = " in source, handler.__name__


### PR DESCRIPTION
## Symptom

`GET /api/v1/auth/magic-link/callback?token=…` returns **500** in prod:

```
AttributeError: type object 'MagicLink' has no attribute 'used'
```

## Cause

`MagicLink` marks consumption with a nullable `used_at` timestamp — there is no boolean `used` column. Both paths filtered on `MagicLink.used == False`, which raises before the query is built:

- `magic_link_callback` (GET) — added earlier today in #522
- `verify_magic_link` (POST) — **pre-existing**; this endpoint has never worked either

`magic_link.used = True` had the same problem in reverse: it set a Python attribute no column persists, so only `used_at` was actually marking links spent.

## Why the tests missed it

My guard in #522 asserted the route was *registered*. The no-token path returns the "link expired" page before touching the query, so the route answered correctly while being unable to work. Probing with `?token=…` is what surfaced it. The new guards assert the query itself and pin the model contract.

## Verification

3 new tests; 28 green across the magic-link, OAuth-restart, and email-delivery suites. Fix confirmed against the deployed model definition (`used_at` present, `used` absent).