### PR TITLE
fix(api): unshadow GET /policies/roles from /{policy_id}

### DIFF
--- a/apps/api/app/routers/v1/policies.py
+++ b/apps/api/app/routers/v1/policies.py
@@ -1,15 +1,23 @@
 """
 Policy management and evaluation API endpoints.
+
+Route declaration order is load-bearing here. FastAPI/Starlette match routes in
+declaration order and return the FIRST full match, so a parametric route such as
+``GET /{policy_id}`` will swallow every sibling literal path declared after it
+(``/roles`` would be parsed as a policy id). All literal paths are therefore
+declared first and the ``/{policy_id}`` handlers are kept last in this module.
+See ``tests/unit/routers/test_policies_route_order.py``.
 """
 
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import and_, delete, or_, select
+from sqlalchemy import and_, delete, select
 from sqlalchemy.orm import Session
 
 from app.database import get_db
 from app.dependencies import get_current_user, require_admin
+from app.models import OrganizationMember
 from app.models.policy import (
     Policy,
     PolicyCreate,
@@ -101,6 +109,238 @@ async def list_policies(
     policies = result.scalars().all()
 
     return [PolicyResponse.from_orm(p) for p in policies]
+
+
+@router.post("/evaluate", response_model=PolicyEvaluateResponse)
+async def evaluate_policies(
+    request: PolicyEvaluateRequest,
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    Evaluate policies for a given request.
+    """
+    # Initialize policy engine
+    cache = CacheService()
+    engine = PolicyEngine(db, cache)
+
+    # Add user context to request if not present
+    if not request.context:
+        request.context = {}
+
+    request.context.update(
+        {
+            "user_id": str(current_user.id),
+            "tenant_id": str(current_user.tenant_id),
+            "organization_id": str(current_user.organization_id)
+            if current_user.organization_id
+            else None,
+        }
+    )
+
+    # Evaluate policies
+    response = await engine.evaluate(request=request, tenant_id=str(current_user.tenant_id))
+
+    return response
+
+
+# Role management endpoints
+#
+# These literal paths MUST stay above the `/{policy_id}` handlers at the bottom
+# of this module, otherwise `/policies/roles` is matched as a policy id.
+
+
+@router.post("/roles", response_model=RoleResponse, status_code=status.HTTP_201_CREATED)
+async def create_role(
+    role_data: RoleCreate, current_user=Depends(require_admin), db: Session = Depends(get_db)
+):
+    """
+    Create a new role (admin only).
+    """
+    # Check if role name already exists
+    result = await db.execute(
+        select(Role).where(
+            and_(Role.tenant_id == current_user.tenant_id, Role.name == role_data.name)
+        )
+    )
+    existing_role = result.scalar_one_or_none()
+
+    if existing_role:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Role with this name already exists"
+        )
+
+    # Create new role
+    role = Role(
+        tenant_id=current_user.tenant_id,
+        organization_id=role_data.organization_id if role_data.organization_id else None,
+        name=role_data.name,
+        description=role_data.description,
+        permissions=role_data.permissions,
+    )
+
+    db.add(role)
+    await db.commit()
+    await db.refresh(role)
+
+    # Log audit event
+    audit_logger = AuditLogger(db)
+    await audit_logger.log(
+        action=AuditAction.ROLE_CREATE,
+        user_id=str(current_user.id),
+        resource_type="role",
+        resource_id=str(role.id),
+        details={"role_name": role.name},
+    )
+
+    return RoleResponse.from_orm(role)
+
+
+@router.get("/roles", response_model=List[RoleResponse])
+async def list_roles(
+    skip: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=1000),
+    organization_id: Optional[str] = None,
+    current_user=Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """
+    List roles visible to the current user.
+
+    Scoping goes through organization membership because `organization_id` is
+    the only tenancy column that exists on the `roles` table (see
+    `app.models.Role` and alembic 000_init). The previous `Role.tenant_id`
+    filter referenced a column that has never existed and raised AttributeError
+    at request time, so this handler could not have returned 200 even once it
+    was reachable.
+    """
+    member_org_ids = select(OrganizationMember.organization_id).where(
+        OrganizationMember.user_id == current_user.id
+    )
+
+    stmt = select(Role).where(Role.organization_id.in_(member_org_ids))
+
+    if organization_id:
+        stmt = stmt.where(Role.organization_id == organization_id)
+
+    result = await db.execute(stmt.offset(skip).limit(limit))
+    roles = result.scalars().all()
+
+    return [RoleResponse.from_orm(r) for r in roles]
+
+
+@router.post("/roles/{role_id}/assign")
+async def assign_role_to_user(
+    role_id: str,
+    user_id: str,
+    organization_id: Optional[str] = None,
+    current_user=Depends(require_admin),
+    db: Session = Depends(get_db),
+):
+    """
+    Assign a role to a user (admin only).
+    """
+    # Verify role exists
+    role_result = await db.execute(
+        select(Role).where(and_(Role.id == role_id, Role.tenant_id == current_user.tenant_id))
+    )
+    role = role_result.scalar_one_or_none()
+
+    if not role:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Role not found")
+
+    # Check if assignment already exists
+    existing_result = await db.execute(
+        select(UserRole).where(
+            and_(
+                UserRole.user_id == user_id,
+                UserRole.role_id == role_id,
+                UserRole.organization_id == organization_id,
+            )
+        )
+    )
+    existing = existing_result.scalar_one_or_none()
+
+    if existing:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Role already assigned to user"
+        )
+
+    # Create assignment
+    user_role = UserRole(
+        user_id=user_id,
+        role_id=role_id,
+        organization_id=organization_id,
+        scope="organization" if organization_id else "tenant",
+    )
+
+    db.add(user_role)
+    await db.commit()
+
+    # Clear permission cache for user
+    cache = CacheService()
+    await cache.delete(f"user:permissions:{user_id}")
+
+    # Log audit event
+    audit_logger = AuditLogger(db)
+    await audit_logger.log(
+        action=AuditAction.ROLE_ASSIGN,
+        user_id=str(current_user.id),
+        resource_type="user_role",
+        resource_id=str(user_role.id),
+        details={"role_name": role.name, "assigned_to": user_id},
+    )
+
+    return {"message": "Role assigned successfully"}
+
+
+@router.delete("/roles/{role_id}/unassign")
+async def unassign_role_from_user(
+    role_id: str, user_id: str, current_user=Depends(require_admin), db: Session = Depends(get_db)
+):
+    """
+    Remove a role from a user (admin only).
+    """
+    # Find assignment
+    result = await db.execute(
+        select(UserRole).where(and_(UserRole.user_id == user_id, UserRole.role_id == role_id))
+    )
+    user_role = result.scalar_one_or_none()
+
+    if not user_role:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Role assignment not found"
+        )
+
+    # Delete assignment
+    db.delete(user_role)
+    await db.commit()
+
+    # Clear permission cache for user
+    cache = CacheService()
+    await cache.delete(f"user:permissions:{user_id}")
+
+    # Log audit event
+    audit_logger = AuditLogger(db)
+    await audit_logger.log(
+        action=AuditAction.ROLE_UNASSIGN,
+        user_id=str(current_user.id),
+        resource_type="user_role",
+        resource_id=str(user_role.id),
+        details={"role_id": role_id, "unassigned_from": user_id},
+    )
+
+    return {"message": "Role unassigned successfully"}
+
+
+# ---------------------------------------------------------------------------
+# Parametric single-policy routes.
+#
+# KEEP THESE LAST. `/{policy_id}` matches any single path segment, so every
+# literal sibling route (`/roles`, `/evaluate`, ...) declared BELOW one of these
+# becomes permanently unreachable — Starlette returns the first full match in
+# declaration order. Add new literal `/policies/<name>` routes above this block.
+# ---------------------------------------------------------------------------
 
 
 @router.get("/{policy_id}", response_model=PolicyResponse)
@@ -214,216 +454,3 @@ async def delete_policy(
     )
 
     return None
-
-
-@router.post("/evaluate", response_model=PolicyEvaluateResponse)
-async def evaluate_policies(
-    request: PolicyEvaluateRequest,
-    current_user=Depends(get_current_user),
-    db: Session = Depends(get_db),
-):
-    """
-    Evaluate policies for a given request.
-    """
-    # Initialize policy engine
-    cache = CacheService()
-    engine = PolicyEngine(db, cache)
-
-    # Add user context to request if not present
-    if not request.context:
-        request.context = {}
-
-    request.context.update(
-        {
-            "user_id": str(current_user.id),
-            "tenant_id": str(current_user.tenant_id),
-            "organization_id": str(current_user.organization_id)
-            if current_user.organization_id
-            else None,
-        }
-    )
-
-    # Evaluate policies
-    response = await engine.evaluate(request=request, tenant_id=str(current_user.tenant_id))
-
-    return response
-
-
-# Role management endpoints
-
-
-@router.post("/roles", response_model=RoleResponse, status_code=status.HTTP_201_CREATED)
-async def create_role(
-    role_data: RoleCreate, current_user=Depends(require_admin), db: Session = Depends(get_db)
-):
-    """
-    Create a new role (admin only).
-    """
-    # Check if role name already exists
-    result = await db.execute(
-        select(Role).where(
-            and_(Role.tenant_id == current_user.tenant_id, Role.name == role_data.name)
-        )
-    )
-    existing_role = result.scalar_one_or_none()
-
-    if existing_role:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Role with this name already exists"
-        )
-
-    # Create new role
-    role = Role(
-        tenant_id=current_user.tenant_id,
-        organization_id=role_data.organization_id if role_data.organization_id else None,
-        name=role_data.name,
-        description=role_data.description,
-        permissions=role_data.permissions,
-    )
-
-    db.add(role)
-    await db.commit()
-    await db.refresh(role)
-
-    # Log audit event
-    audit_logger = AuditLogger(db)
-    await audit_logger.log(
-        action=AuditAction.ROLE_CREATE,
-        user_id=str(current_user.id),
-        resource_type="role",
-        resource_id=str(role.id),
-        details={"role_name": role.name},
-    )
-
-    return RoleResponse.from_orm(role)
-
-
-@router.get("/roles", response_model=List[RoleResponse])
-async def list_roles(
-    skip: int = Query(0, ge=0),
-    limit: int = Query(100, ge=1, le=1000),
-    organization_id: Optional[str] = None,
-    current_user=Depends(get_current_user),
-    db: Session = Depends(get_db),
-):
-    """
-    List all roles.
-    """
-    stmt = select(Role).where(Role.tenant_id == current_user.tenant_id)
-
-    if organization_id:
-        stmt = stmt.where(
-            or_(
-                Role.organization_id == organization_id,
-                Role.organization_id.is_(None),  # Include tenant-level roles
-            )
-        )
-
-    result = await db.execute(stmt.offset(skip).limit(limit))
-    roles = result.scalars().all()
-
-    return [RoleResponse.from_orm(r) for r in roles]
-
-
-@router.post("/roles/{role_id}/assign")
-async def assign_role_to_user(
-    role_id: str,
-    user_id: str,
-    organization_id: Optional[str] = None,
-    current_user=Depends(require_admin),
-    db: Session = Depends(get_db),
-):
-    """
-    Assign a role to a user (admin only).
-    """
-    # Verify role exists
-    role_result = await db.execute(
-        select(Role).where(and_(Role.id == role_id, Role.tenant_id == current_user.tenant_id))
-    )
-    role = role_result.scalar_one_or_none()
-
-    if not role:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Role not found")
-
-    # Check if assignment already exists
-    existing_result = await db.execute(
-        select(UserRole).where(
-            and_(
-                UserRole.user_id == user_id,
-                UserRole.role_id == role_id,
-                UserRole.organization_id == organization_id,
-            )
-        )
-    )
-    existing = existing_result.scalar_one_or_none()
-
-    if existing:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST, detail="Role already assigned to user"
-        )
-
-    # Create assignment
-    user_role = UserRole(
-        user_id=user_id,
-        role_id=role_id,
-        organization_id=organization_id,
-        scope="organization" if organization_id else "tenant",
-    )
-
-    db.add(user_role)
-    await db.commit()
-
-    # Clear permission cache for user
-    cache = CacheService()
-    await cache.delete(f"user:permissions:{user_id}")
-
-    # Log audit event
-    audit_logger = AuditLogger(db)
-    await audit_logger.log(
-        action=AuditAction.ROLE_ASSIGN,
-        user_id=str(current_user.id),
-        resource_type="user_role",
-        resource_id=str(user_role.id),
-        details={"role_name": role.name, "assigned_to": user_id},
-    )
-
-    return {"message": "Role assigned successfully"}
-
-
-@router.delete("/roles/{role_id}/unassign")
-async def unassign_role_from_user(
-    role_id: str, user_id: str, current_user=Depends(require_admin), db: Session = Depends(get_db)
-):
-    """
-    Remove a role from a user (admin only).
-    """
-    # Find assignment
-    result = await db.execute(
-        select(UserRole).where(and_(UserRole.user_id == user_id, UserRole.role_id == role_id))
-    )
-    user_role = result.scalar_one_or_none()
-
-    if not user_role:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Role assignment not found"
-        )
-
-    # Delete assignment
-    db.delete(user_role)
-    await db.commit()
-
-    # Clear permission cache for user
-    cache = CacheService()
-    await cache.delete(f"user:permissions:{user_id}")
-
-    # Log audit event
-    audit_logger = AuditLogger(db)
-    await audit_logger.log(
-        action=AuditAction.ROLE_UNASSIGN,
-        user_id=str(current_user.id),
-        resource_type="user_role",
-        resource_id=str(user_role.id),
-        details={"role_id": role_id, "unassigned_from": user_id},
-    )
-
-    return {"message": "Role unassigned successfully"}

--- a/apps/api/tests/unit/routers/test_policies_route_order.py
+++ b/apps/api/tests/unit/routers/test_policies_route_order.py
@@ -1,0 +1,108 @@
+"""`GET /policies/roles` was permanently shadowed by `GET /policies/{policy_id}`.
+
+Starlette matches routes in declaration order and dispatches to the FIRST full
+match. `/{policy_id}` matches any single path segment, so while it was declared
+above `/roles`, every request for `/api/v1/policies/roles` was routed into
+`get_policy` with `policy_id="roles"`. The roles handler had never run once
+since it was written; the endpoint 500'd in production on 2026-08-13.
+
+A route-registration test does not catch this. Both routes were registered, both
+appeared in the OpenAPI schema, and `len(router.routes)` was correct the entire
+time. Only resolving a path to a *handler* exposes the shadowing, so that is
+what these assert.
+"""
+
+import ast
+import inspect
+
+from starlette.routing import Match
+
+from app.models import Role
+from app.routers.v1 import policies
+from app.routers.v1.policies import list_roles, router
+
+
+def _resolve(method: str, path: str):
+    """Return the route Starlette would dispatch to, mirroring real routing."""
+    scope = {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "path_params": {},
+        "root_path": "",
+        "headers": [],
+    }
+    for route in router.routes:
+        match, _ = route.matches(scope)
+        if match == Match.FULL:
+            return route
+    return None
+
+
+def _executable_source(func) -> str:
+    """Source of `func` with its docstring stripped, so prose can't satisfy a scan."""
+    tree = ast.parse(inspect.getsource(func))
+    node = tree.body[0]
+    if ast.get_docstring(node):
+        node.body = node.body[1:]
+    return ast.unparse(node)
+
+
+def test_get_roles_resolves_to_the_roles_handler():
+    """The regression: this resolved to `get_policy` with policy_id='roles'."""
+    resolved = _resolve("GET", "/v1/policies/roles")
+
+    assert resolved is not None, "/v1/policies/roles does not resolve at all"
+    assert resolved.endpoint is list_roles, (
+        f"/v1/policies/roles resolves to {resolved.endpoint.__name__!r} "
+        f"(path {resolved.path!r}), not list_roles. A parametric route is "
+        "declared above the literal /roles route and is swallowing it."
+    )
+
+
+def test_no_literal_route_is_shadowed_by_a_parametric_one():
+    """Every literal path in this router must reach its own handler.
+
+    Guards future additions: a new `/policies/<name>` route declared below the
+    `/{policy_id}` block would be dead on arrival, exactly as `/roles` was.
+    """
+    for route in router.routes:
+        if "{" in route.path:
+            continue  # parametric routes are not shadowing targets
+        for method in sorted(route.methods - {"HEAD", "OPTIONS"}):
+            resolved = _resolve(method, route.path)
+            assert resolved is route, (
+                f"{method} {route.path} resolves to "
+                f"{resolved.endpoint.__name__ if resolved else None!r} instead of "
+                f"{route.endpoint.__name__!r}. Move this literal route above the "
+                "parametric routes that shadow it."
+            )
+
+
+def test_parametric_policy_routes_are_declared_last():
+    """The structural invariant that keeps the above true."""
+    paths = [route.path for route in router.routes]
+    first_parametric = next(i for i, p in enumerate(paths) if p == "/v1/policies/{policy_id}")
+    literal_after = [p for p in paths[first_parametric:] if "{" not in p]
+
+    assert not literal_after, (
+        f"Literal routes {literal_after} are declared after /{{policy_id}} and "
+        "are therefore unreachable."
+    )
+
+
+def test_roles_are_scoped_by_a_column_that_exists():
+    """The second half of the prod 500: `Role.tenant_id` never existed.
+
+    Un-shadowing the route alone would have swapped one AttributeError 500 for
+    another, so the scoping column is asserted too.
+    """
+    assert hasattr(Role, "organization_id")
+    assert not hasattr(Role, "tenant_id"), (
+        "If a tenant_id column is ever added to roles, revisit list_roles — it "
+        "currently scopes through organization membership."
+    )
+
+    code = _executable_source(policies.list_roles)
+    assert "Role.tenant_id" not in code
+    assert "Role.organization_id" in code


### PR DESCRIPTION
## The bug

`GET /api/v1/policies/roles` has returned **500 since the endpoint was written**. Confirmed broken in production on 2026-08-13.

Starlette matches routes in **declaration order** and dispatches to the first full match. `/{policy_id}` matches any single path segment, and it was declared above `/roles`:

```
index 2   GET /v1/policies/{policy_id}   -> get_policy      <-- won every time
index 7   GET /v1/policies/roles         -> list_roles      <-- unreachable
```

So every request for `/policies/roles` landed in `get_policy()` with `policy_id="roles"`. `list_roles()` had never executed once.

The 500 came from the *next* line: `get_policy` filters on `Policy.tenant_id`, which does not exist (`AttributeError` at request time).

## Why nothing caught it

Both routes were registered, both appeared in the OpenAPI schema, and `len(router.routes)` was correct throughout. Route-registration tests pass on shadowed routes. Only resolving a path to a **handler** exposes it.

## Changes

**1. Route order.** The three parametric `/{policy_id}` handlers moved to the end of the module, so every literal sibling path is declared first. Nine of the ten handlers are relocated **verbatim** (verified by AST comparison against `main` — byte-identical), so the large diff is almost entirely a move.

**2. `list_roles` scoping.** It filtered on `Role.tenant_id`, a column that exists on neither `app.models.Role` nor the `roles` table:

```python
# alembic/versions/000_init.py
op.create_table('roles',
    sa.Column('organization_id', postgresql.UUID(as_uuid=True), nullable=False),
    ...   # no tenant_id
```

Un-shadowing the route alone would have traded one `AttributeError` 500 for another, so scoping now goes through `OrganizationMember`, matching `require_org_admin` and `api_keys.py`. The dropped `Role.organization_id.is_(None)` "include tenant-level roles" branch was unreachable — the column is `NOT NULL`, so no role can be tenant-level.

`RoleResponse.from_orm` reads only columns that exist (`id`, `organization_id`, `name`, `description`, `permissions`, `is_system`, timestamps), so `GET /policies/roles` now returns 200.

**3. Regression test** — `tests/unit/routers/test_policies_route_order.py`, 4 tests using Starlette's own `route.matches()`:

- `/v1/policies/roles` resolves to `list_roles`
- no literal route in the router is shadowed by a parametric one (guards future `/policies/<name>` additions)
- parametric routes are declared last
- roles are scoped by a column that exists

All 4 **fail** on the unfixed router and pass on the fixed one (verified by stashing the router fix).

## Verification

| | `main` baseline | this branch |
|---|---|---|
| `tests/unit/routers/` | 2 failed, 427 passed, 13 skipped, 23 errors | 2 failed, **431** passed, 13 skipped, 23 errors |

Same 2 failures and same 23 errors, by name — all pre-existing (xmlsec/lxml environment issue and test pollution, unrelated to this change). The +4 are the new tests. **No new failures.**

`ruff check` and `ruff format --check` clean. Resolution verified through the real mounted app: `/api/v1/policies/roles -> list_roles`.

## Known remaining breakage (deliberately NOT in this PR)

Verifying the model turned up drift far wider than the route order. **The Policy CRUD endpoints are still broken and this PR does not fix them:**

- `app.models.Policy` has only `id, name, description, rules, organization_id, created_at, updated_at`. The router reads and writes `tenant_id, effect, priority, enabled, version, target_type, target_id, resource_type, resource_pattern, actions, conditions, expires_at` — none exist, on the model or in `000_init`.
- `create_policy` passes 10 invalid kwargs to `Policy(...)` -> `TypeError`.
- `PolicyResponse.from_orm` reads `obj.effect` / `obj.priority` unguarded -> `AttributeError`.
- `create_role` would insert `NULL` into `roles.organization_id` (`NOT NULL`).
- `app/services/policy_engine.py:130,159,172` also filters on `Policy.tenant_id`, so `POST /policies/evaluate` fails the same way.

Renaming `tenant_id` in those places would relocate the error rather than fix it, and would silently change authorization scoping on admin endpoints. That needs its own reviewed change against a decided tenancy model — filed separately rather than smuggled into a route-ordering fix. The currently-failing state is fail-closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)