### PR TITLE
feat(oauth): issue legal:client-profile on nauta-legal-drafts

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -684,6 +684,7 @@ def openid_configuration():
             "cfdi:issue",
             "billing:events",
             "legal:draft",
+            "legal:client-profile",
         ],
         "token_endpoint_auth_methods_supported": [
             "client_secret_basic",

--- a/apps/api/scripts/seed_service_clients.py
+++ b/apps/api/scripts/seed_service_clients.py
@@ -68,12 +68,14 @@ SERVICE_CLIENTS: list[dict[str, Any]] = [
         "description": (
             "Nauta → Karafiel legal document generation service client "
             "(nauta docs/LEGAL_OPS_INTEGRATION_PLAN_2026-08-12.md, step "
-            "D3.5). Creates and compiles service-agreement drafts and reads "
-            "generated-document metadata; nothing else."
+            "D3.5). legal:draft creates and compiles service-agreement "
+            "drafts and reads generated-document metadata. "
+            "legal:client-profile creates and updates the client's own "
+            "legal-entity profile (karafiel PR #148). Nothing else."
         ),
         "audience": "karafiel-api",
         "redirect_uris": [],
-        "allowed_scopes": ["legal:draft"],
+        "allowed_scopes": ["legal:draft", "legal:client-profile"],
         "grant_types": ["client_credentials"],
         "is_confidential": True,
     },

--- a/apps/api/tests/unit/routers/test_service_token_clients.py
+++ b/apps/api/tests/unit/routers/test_service_token_clients.py
@@ -132,7 +132,7 @@ async def service_token_client():
                 client_id=NAUTA_CLIENT_ID,
                 secret=NAUTA_SECRET,
                 audience="karafiel-api",
-                allowed_scopes=["legal:draft"],
+                allowed_scopes=["legal:draft", "legal:client-profile"],
                 grant_types=["client_credentials"],
             )
         )
@@ -242,12 +242,84 @@ class TestServiceTokenIssuance:
         assert claims["actor_type"] == "service_account"
         assert claims["scope"] == "legal:draft"
 
+    async def test_nauta_client_receives_client_profile_scoped_token(self, service_token_client):
+        # karafiel PR #148: legal:client-profile lets Nauta create/update a
+        # client's OWN ClientProfile at /api/v1/legal/clients.
+        response = await _request_token(
+            service_token_client,
+            client_id=NAUTA_CLIENT_ID,
+            client_secret=NAUTA_SECRET,
+            scope="legal:client-profile",
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["scope"] == "legal:client-profile"
+        claims = jwt_manager.verify_token(
+            body["access_token"], token_type="access", audience="karafiel-api"
+        )
+        assert claims is not None
+        assert claims["sub"] == f"service-account:{NAUTA_CLIENT_ID}"
+        assert claims["actor_type"] == "service_account"
+        assert claims["scope"] == "legal:client-profile"
+
+    async def test_nauta_legal_scopes_are_independent(self, service_token_client):
+        """Neither legal scope implies the other — each token carries only
+        what it asked for, so Karafiel can guard drafts and client-profile
+        routes separately."""
+        draft_only = await _request_token(
+            service_token_client,
+            client_id=NAUTA_CLIENT_ID,
+            client_secret=NAUTA_SECRET,
+            scope="legal:draft",
+        )
+        assert draft_only.status_code == 200, draft_only.text
+        assert draft_only.json()["scope"] == "legal:draft"
+
+        profile_only = await _request_token(
+            service_token_client,
+            client_id=NAUTA_CLIENT_ID,
+            client_secret=NAUTA_SECRET,
+            scope="legal:client-profile",
+        )
+        assert profile_only.status_code == 200, profile_only.text
+        assert profile_only.json()["scope"] == "legal:client-profile"
+
+        # The grant is per-request, not per-client: holding both on the
+        # allowlist must not silently widen a single-scope token.
+        for issued, granted, withheld in (
+            (draft_only, "legal:draft", "legal:client-profile"),
+            (profile_only, "legal:client-profile", "legal:draft"),
+        ):
+            claims = jwt_manager.verify_token(
+                issued.json()["access_token"],
+                token_type="access",
+                audience="karafiel-api",
+            )
+            assert claims is not None
+            scopes = claims["scope"].split()
+            assert granted in scopes
+            assert withheld not in scopes
+
+    async def test_nauta_client_defaults_to_both_legal_scopes(self, service_token_client):
+        """Omitting scope grants the client's full allowlist — both legal scopes."""
+        response = await _request_token(
+            service_token_client,
+            client_id=NAUTA_CLIENT_ID,
+            client_secret=NAUTA_SECRET,
+            scope="",
+        )
+        assert response.status_code == 200, response.text
+        assert sorted(response.json()["scope"].split()) == [
+            "legal:client-profile",
+            "legal:draft",
+        ]
+
     def test_seed_list_pins_the_nauta_legal_drafts_contract(self):
         from scripts.seed_service_clients import SERVICE_CLIENTS
 
         entry = next(c for c in SERVICE_CLIENTS if c["name"] == "nauta-legal-drafts")
         assert entry["audience"] == "karafiel-api"
-        assert entry["allowed_scopes"] == ["legal:draft"]
+        assert entry["allowed_scopes"] == ["legal:draft", "legal:client-profile"]
         assert entry["grant_types"] == ["client_credentials"]
         assert entry["is_confidential"] is True
         assert entry["redirect_uris"] == []
@@ -290,6 +362,15 @@ class TestServiceTokenRejection:
         detail = _error_message(response)
         assert "invalid_scope" in detail
         assert "billing:events" in detail
+
+    async def test_legal_client_profile_scope_is_not_globally_grantable(self, service_token_client):
+        """Registering legal:client-profile in discovery must not make it
+        mintable by any client — only nauta-legal-drafts has it allowlisted."""
+        response = await _request_token(service_token_client, scope="legal:client-profile")
+        assert response.status_code == 400
+        detail = _error_message(response)
+        assert "invalid_scope" in detail
+        assert "legal:client-profile" in detail
 
     async def test_partially_escalated_scope_is_rejected(self, service_token_client):
         """One allowed + one foreign scope must still fail closed."""

--- a/docs/service-tokens.md
+++ b/docs/service-tokens.md
@@ -6,7 +6,7 @@ Cross-service identity for the RFC 0024 §P4 consolidations:
 |---|---|---|---|---|
 | Zavlo → Karafiel CFDI bridge (§P4.2) | `zavlo-cfdi-emitter` | `cfdi:issue` | `karafiel-api` | Karafiel API |
 | RouteCraft → Dhanam billing (§P4.3) | `routecraft-billing-relay` | `billing:events` | `dhanam-api` | Dhanam API |
-| Nauta → Karafiel legal drafts (D3.5) | `nauta-legal-drafts` | `legal:draft` | `karafiel-api` | Karafiel API |
+| Nauta → Karafiel legal drafts (D3.5) | `nauta-legal-drafts` | `legal:draft`, `legal:client-profile` | `karafiel-api` | Karafiel API |
 
 Both migration plans (`zavlo/docs/karafiel-cfdi-migration-plan.md`,
 `routecraft/docs/dhanam-payments-migration-plan.md`) are gated on this
@@ -189,6 +189,23 @@ Karafiel's CFDI billing bridge guards `POST` envelope ingestion with
 `required_scope="cfdi:issue"` and attributes the envelope to
 `claims["client_id"]` alongside the existing `source: "zavlo.*"`
 discriminator and idempotency key.
+
+Scope map on the Karafiel side:
+
+- `cfdi:issue` — Zavlo's CFDI envelope ingestion (above).
+- `legal:draft` — creates and compiles service-agreement drafts and reads
+  generated-document metadata.
+- `legal:client-profile` — creates and updates the calling client's **own**
+  legal-entity profile (`ClientProfile`) at `/api/v1/legal/clients`
+  (`POST`/`PUT`/`PATCH`/`GET`; `DELETE` is refused). Karafiel PR #148.
+
+`legal:draft` and `legal:client-profile` are **independent**: neither
+implies the other, and Karafiel enforces each separately on its own routes.
+A `legal:client-profile` token grants no access to drafts or generated
+documents, and a `legal:draft` token cannot write a client profile.
+`nauta-legal-drafts` is allowlisted for both because Nauta's
+`engagement.provision` needs both capabilities; each token still carries
+only the scopes that request asked for (omitting `scope` grants both).
 
 ## How Dhanam verifies (offline, JWKS)
 


### PR DESCRIPTION
Lets Janua **issue** the `legal:client-profile` scope that karafiel PR #148 introduces, so nauta's `engagement.provision` can create/update a client's own `ClientProfile` at `/api/v1/legal/clients` (POST/PUT/PATCH/GET; DELETE refused).

Mirrors janua#518 (which registered `legal:draft`) exactly.

## Why

`legal:client-profile` is deliberately **independent** of `legal:draft` — neither implies the other, so Karafiel can guard profile writes and draft generation separately. `nauta-legal-drafts` (audience `karafiel-api`) needs both capabilities, so it gets both on its allowlist, but each token still carries only the scopes that request asked for.

## Where scopes are declared

`grep -rn 'legal:draft'` enumerates the complete surface — 4 files, all updated:

| File | Change |
|---|---|
| `apps/api/app/main.py:687` | discovery `scopes_supported` += `legal:client-profile` |
| `apps/api/scripts/seed_service_clients.py` | `nauta-legal-drafts.allowed_scopes` → `["legal:draft", "legal:client-profile"]` + description |
| `docs/service-tokens.md` | contract table row + a Karafiel-side scope map (mirrors the existing Dhanam-side one) pinning the independence |
| `apps/api/tests/unit/routers/test_service_token_clients.py` | fixture allowlist, seed-contract assert, 4 new tests |

**There is no global scope allowlist to widen.** Enforcement is entirely per-client: `_parse_requested_scopes` (`apps/api/app/routers/v1/oauth_provider.py:548`) validates the request against `client.allowed_scopes` and nothing else. `scopes_supported` in `main.py` is discovery advertisement only. A test pins this: registering the scope in discovery must not make it mintable by a client that lacks it.

## Tests

4 new, all green:

- `test_nauta_client_receives_client_profile_scoped_token` — scoped issuance, machine-identity claim shape
- `test_nauta_legal_scopes_are_independent` — a `legal:draft` token does **not** carry `legal:client-profile` and vice versa (the grant is per-request, not per-client)
- `test_nauta_client_defaults_to_both_legal_scopes` — omitting `scope` grants the full allowlist
- `test_legal_client_profile_scope_is_not_globally_grantable` — zavlo requesting it fails closed with `invalid_scope`

### Baseline discipline

Compared **by name** against clean `origin/main`, same paths, same interpreter:

```
cd apps/api && python -m pytest tests/unit/routers/test_service_token_clients.py \
  tests/integration/test_health_endpoints.py tests/integration/test_oidc_discovery.py -q --no-cov
```

| | baseline (`origin/main`) | this branch |
|---|---|---|
| failed | 7 | 7 (**identical names**) |
| errors | 2 | 2 (**identical names**) |
| passed | 29 | 33 (+4 new) |

`diff` of the sorted `FAILED`/`ERROR` name lists is empty — **zero new failures**. The 9 pre-existing ones are local env/config noise (e.g. `test_openid_configuration` asserts `issuer == https://janua.dev` but the local env yields `https://api.janua.dev`; the `oidc_discovery` errors are the known xmlsec/lxml pollution). `test_service_token_clients.py` alone: **15/15 passed**. `ruff` and `black` clean.

## Operator action — apply the scope in prod

**Not done in this PR**: OAuth-client mutations are operator-gated per `AGENTS.md`. Read-only confirmation of the starting state (no writes performed):

```
client_id : jnc_Rk11…(masked)   audience: karafiel-api   is_active: True
allowed_scopes : ['legal:draft']   (JSONB encoding depth 1 — plain array)
```

Run this after merge. Idempotent — re-running after success changes nothing. Prints BEFORE/AFTER. Modelled on `internal-devops/scripts/janua-fix-phynd-client.sh`:

```bash
ssh ssh.madfam.io "sudo -n kubectl exec -i -n janua deploy/janua-api -- python3 -" <<'PY'
import asyncio, json, os

NAME = "nauta-legal-drafts"
WANT = ["legal:draft", "legal:client-profile"]

async def main():
    import asyncpg
    url = os.environ["DATABASE_URL"].replace("postgresql+asyncpg://", "postgresql://")
    # statement_cache_size=0 is the shared-pg house rule: harmless on a direct
    # connection, mandatory if this URL is ever repointed at pgbouncer.
    conn = await asyncpg.connect(url, statement_cache_size=0)
    row = await conn.fetchrow(
        "SELECT client_id, allowed_scopes FROM oauth_clients WHERE name=$1", NAME
    )
    if row is None:
        raise SystemExit(f"NO ROW named {NAME} — aborting, nothing changed")

    # allowed_scopes can be stored double-encoded depending on which writer
    # created the row (cf. redirect_uris in janua-fix-phynd-client.sh), so
    # detect the nesting depth and mirror it back exactly.
    raw, depth, scopes = row["allowed_scopes"], 0, row["allowed_scopes"]
    while isinstance(scopes, str):
        scopes = json.loads(scopes); depth += 1

    print("client_id :", row["client_id"][:8] + "...(masked)")
    print("BEFORE    :", scopes)
    if set(WANT).issubset(scopes):
        print("AFTER     : unchanged — both scopes already present")
        await conn.close(); return

    encoded = scopes + [s for s in WANT if s not in scopes]
    for _ in range(max(depth, 1)):
        encoded = json.dumps(encoded)

    await conn.execute(
        "UPDATE oauth_clients SET allowed_scopes=$2, updated_at=now() WHERE name=$1",
        NAME, encoded,
    )
    after = await conn.fetchval(
        "SELECT allowed_scopes FROM oauth_clients WHERE name=$1", NAME
    )
    while isinstance(after, str):
        after = json.loads(after)
    print("AFTER     :", after)
    assert set(WANT).issubset(after), "scope widening did not take"
    await conn.close()

asyncio.run(main())
PY
```

Expected output:

```
client_id : jnc_Rk11...(masked)
BEFORE    : ['legal:draft']
AFTER     : ['legal:draft', 'legal:client-profile']
```

No pod restart needed — `_parse_requested_scopes` reads `allowed_scopes` from the DB per token request. The existing `client_secret` is untouched, so nauta needs no credential change.

### Notes for the operator

- **The seed script is a valid alternative, but only after this lands in the prod image.** `_seed_clients` (`seed_core_clients.py:296`) is genuinely idempotent for an existing client: it matches on name-or-client_id and `UPDATE`s `allowed_scopes` in place, preserving `client_secret_hash` (no secret rotation). But the pod runs the *deployed* image, whose seed list still says `["legal:draft"]` — re-running it before promotion would re-assert the old single scope. It also rewrites zavlo and routecraft rows. The targeted snippet above avoids both issues and works immediately.
- **janua-api does not go through pgbouncer.** Its `DATABASE_URL` points straight at `postgres.data.svc.cluster.local:5432`. `statement_cache_size=0` is kept anyway as the house rule and as future-proofing.
- Verify afterwards: `curl -s https://auth.madfam.io/.well-known/openid-configuration | jq '.scopes_supported'` should list `legal:client-profile` once the API image ships this commit (discovery advertisement is separate from the DB row — the DB row is what actually gates issuance).

## Blast radius

Additive only. No migration, no behavior change for existing tokens, no secret rotation. Until the operator command runs, requesting `legal:client-profile` fails closed with `400 invalid_scope`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
