### PR TITLE
fix(api): make policy CRUD and /evaluate work against the real schema

### DIFF
--- a/apps/api/alembic/versions/010_add_policy_authorization_columns.py
+++ b/apps/api/alembic/versions/010_add_policy_authorization_columns.py
@@ -1,0 +1,65 @@
+"""Add the authorization columns `policies` was always read and written with.
+
+`app/routers/v1/policies.py` and `app/services/policy_engine.py` have referenced
+`effect`, `priority`, `enabled`, `version`, `target_type`, `target_id`,
+`resource_type`, `resource_pattern`, `actions`, `conditions` and `expires_at`
+since they were written. None of them existed: alembic 000_init created
+`policies` with only (id, name, description, rules, organization_id, created_at,
+updated_at) and the SQLAlchemy model matched that. Every create/list/get/update
+/delete therefore raised before reaching the database, so the table stayed empty
+(verified 0 rows in production on 2026-08-13 before this migration was written).
+
+Because the table is empty everywhere, the new NOT NULL columns can take server
+defaults without a backfill step.
+
+`IF NOT EXISTS` keeps this idempotent against environments that ran
+`Base.metadata.create_all` instead of migrations (the test suite does).
+
+Revision ID: 010_add_policy_authorization_columns
+Revises: 009_add_legacy_webhook_events
+"""
+
+from alembic import op
+
+revision = "010_add_policy_authorization_columns"
+down_revision = "009_add_legacy_webhook_events"
+branch_labels = None
+depends_on = None
+
+
+# (column, DDL type + constraints)
+_COLUMNS = [
+    ("effect", "varchar(20) NOT NULL DEFAULT 'allow'"),
+    ("priority", "integer NOT NULL DEFAULT 0"),
+    ("enabled", "boolean NOT NULL DEFAULT true"),
+    ("version", "integer NOT NULL DEFAULT 1"),
+    ("target_type", "varchar(50)"),
+    ("target_id", "varchar(255)"),
+    ("resource_type", "varchar(255)"),
+    ("resource_pattern", "varchar(500)"),
+    ("actions", "jsonb DEFAULT '[]'::jsonb"),
+    ("conditions", "jsonb DEFAULT '{}'::jsonb"),
+    ("expires_at", "timestamp"),
+]
+
+
+def upgrade() -> None:
+    for name, ddl in _COLUMNS:
+        op.execute(f"ALTER TABLE policies ADD COLUMN IF NOT EXISTS {name} {ddl}")
+
+    # The engine's hot path filters enabled policies within one organization.
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_policies_organization_id_enabled "
+        "ON policies (organization_id, enabled)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_policies_target_type_target_id "
+        "ON policies (target_type, target_id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_policies_target_type_target_id")
+    op.execute("DROP INDEX IF EXISTS ix_policies_organization_id_enabled")
+    for name, _ in reversed(_COLUMNS):
+        op.execute(f"ALTER TABLE policies DROP COLUMN IF EXISTS {name}")

--- a/apps/api/alembic/versions/010_policy_authz_columns.py
+++ b/apps/api/alembic/versions/010_policy_authz_columns.py
@@ -15,13 +15,13 @@ defaults without a backfill step.
 `IF NOT EXISTS` keeps this idempotent against environments that ran
 `Base.metadata.create_all` instead of migrations (the test suite does).
 
-Revision ID: 010_add_policy_authorization_columns
+Revision ID: 010_policy_authz_columns
 Revises: 009_add_legacy_webhook_events
 """
 
 from alembic import op
 
-revision = "010_add_policy_authorization_columns"
+revision = "010_policy_authz_columns"
 down_revision = "009_add_legacy_webhook_events"
 branch_labels = None
 depends_on = None

--- a/apps/api/app/models/__init__.py
+++ b/apps/api/app/models/__init__.py
@@ -547,7 +547,7 @@ class Policy(Base):
     by `app/routers/v1/policies.py` and `app/services/policy_engine.py` from the
     day those modules were written, but existed on neither the model nor the
     table, so every policy CRUD call raised before touching the database. Added
-    in alembic 010_add_policy_authorization_columns.
+    in alembic 010_policy_authz_columns.
     """
 
     __tablename__ = "policies"

--- a/apps/api/app/models/__init__.py
+++ b/apps/api/app/models/__init__.py
@@ -537,6 +537,19 @@ organization_members = OrganizationMember.__table__
 
 
 class Policy(Base):
+    """Authorization policy.
+
+    `organization_id` is the tenancy column — there is no `policies.tenant_id`
+    and never has been (see alembic 000_init). Scope policies the same way
+    `Role` and `OrganizationMember` are scoped.
+
+    The authorization columns below (effect .. expires_at) were read and written
+    by `app/routers/v1/policies.py` and `app/services/policy_engine.py` from the
+    day those modules were written, but existed on neither the model nor the
+    table, so every policy CRUD call raised before touching the database. Added
+    in alembic 010_add_policy_authorization_columns.
+    """
+
     __tablename__ = "policies"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
@@ -544,6 +557,22 @@ class Policy(Base):
     description = Column(Text)
     rules = Column(JSONB, default={})
     organization_id = Column(UUID(as_uuid=True), ForeignKey("organizations.id"))
+
+    # Authorization semantics
+    effect = Column(String(20), nullable=False, default="allow", server_default="allow")
+    priority = Column(Integer, nullable=False, default=0, server_default="0")
+    enabled = Column(Boolean, nullable=False, default=True, server_default=sa.text("true"))
+    version = Column(Integer, nullable=False, default=1, server_default="1")
+
+    # Targeting
+    target_type = Column(String(50))  # user | role | organization | global
+    target_id = Column(String(255))
+    resource_type = Column(String(255))
+    resource_pattern = Column(String(500))
+    actions = Column(JSONB, default=list)
+    conditions = Column(JSONB, default=dict)
+    expires_at = Column(DateTime)
+
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 

--- a/apps/api/app/models/policy.py
+++ b/apps/api/app/models/policy.py
@@ -93,6 +93,7 @@ class PolicyCreate(BaseModel):
     rules: Dict[str, Any] = Field(default_factory=dict)
     effect: PolicyEffect = PolicyEffect.ALLOW
     priority: int = Field(default=0, ge=0, le=1000)
+    enabled: bool = True
     target_type: Optional[PolicyTargetType] = None
     target_id: Optional[str] = None
     resource_type: Optional[str] = None
@@ -100,6 +101,13 @@ class PolicyCreate(BaseModel):
     actions: List[str] = Field(default_factory=list)
     conditions: Dict[str, Any] = Field(default_factory=dict)
     expires_at: Optional[datetime] = None
+    organization_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Owning organization. Optional when the caller belongs to exactly one "
+            "organization; required otherwise. The caller must be a member of it."
+        ),
+    )
 
 
 class PolicyUpdate(BaseModel):
@@ -121,10 +129,16 @@ class PolicyUpdate(BaseModel):
 
 
 class PolicyResponse(BaseModel):
-    """Schema for policy response."""
+    """Schema for policy response.
+
+    `tenant_id` mirrors `organization_id` for wire compatibility, matching the
+    convention `RoleResponse` already uses. `policies.tenant_id` does not exist;
+    `organization_id` is the real tenancy column.
+    """
 
     id: str
     tenant_id: str
+    organization_id: Optional[str]
     name: str
     description: Optional[str]
     rules: Dict[str, Any]
@@ -148,17 +162,25 @@ class PolicyResponse(BaseModel):
 
     @classmethod
     def from_orm(cls, obj):
-        """Convert SQLAlchemy model to Pydantic schema."""
+        """Convert SQLAlchemy model to Pydantic schema.
+
+        Every attribute read here is a real column on `app.models.Policy`. The
+        previous `hasattr` guards on `enabled`/`version` silently degraded to
+        defaults for columns that did not exist at all, which hid the drift
+        instead of surfacing it.
+        """
+        organization_id = str(obj.organization_id) if obj.organization_id else None
         return cls(
             id=str(obj.id),
-            tenant_id=str(obj.tenant_id) if obj.tenant_id else "",
+            tenant_id=organization_id or "",
+            organization_id=organization_id,
             name=obj.name,
             description=obj.description,
             rules=obj.rules or {},
             effect=obj.effect,
             priority=obj.priority or 0,
-            enabled=obj.enabled if hasattr(obj, "enabled") else True,
-            version=obj.version if hasattr(obj, "version") else 1,
+            enabled=obj.enabled,
+            version=obj.version,
             target_type=obj.target_type,
             target_id=obj.target_id,
             resource_type=obj.resource_type,
@@ -172,7 +194,14 @@ class PolicyResponse(BaseModel):
 
 
 class PolicyEvaluateRequest(BaseModel):
-    """Schema for policy evaluation request."""
+    """Schema for policy evaluation request.
+
+    The wire format is structured (`subject_id`, `resource_type`, `resource_id`),
+    but `PolicyEngine` matches policies against flat `subject`/`resource`
+    strings. The two derived properties below are that adapter. They used to be
+    absent entirely, so `PolicyEngine.evaluate` raised `AttributeError` on
+    `request.subject` before it issued a single query.
+    """
 
     subject_id: Optional[str] = None  # user_id or role_id
     subject_type: str = Field(default="user", pattern="^(user|role)$")
@@ -180,6 +209,22 @@ class PolicyEvaluateRequest(BaseModel):
     resource_id: Optional[str] = None
     action: str = Field(..., min_length=1)
     context: Dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def subject(self) -> str:
+        """Flat subject identifier used for policy matching."""
+        return self.subject_id or ""
+
+    @property
+    def resource(self) -> str:
+        """Flat resource identifier, `type:id` when an id is supplied.
+
+        Policy `resource_pattern`s are wildcard globs, so `documents:*` matches
+        every document while `documents` still matches a type-only request.
+        """
+        if self.resource_id:
+            return f"{self.resource_type}:{self.resource_id}"
+        return self.resource_type
 
 
 class PolicyEvaluateResponse(BaseModel):

--- a/apps/api/app/routers/v1/policies.py
+++ b/apps/api/app/routers/v1/policies.py
@@ -9,6 +9,7 @@ declared first and the ``/{policy_id}`` handlers are kept last in this module.
 See ``tests/unit/routers/test_policies_route_order.py``.
 """
 
+import enum
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -39,6 +40,50 @@ from app.services.policy_engine import PolicyEngine
 router = APIRouter(prefix="/v1/policies", tags=["policies"])
 
 
+def _member_org_ids(user):
+    """Subquery of the organization ids `user` belongs to.
+
+    `organization_id` is the tenancy column on `policies`, `roles` and
+    `organization_members` alike — none of those tables has a `tenant_id`
+    column. Scoping every policy query through membership keeps one
+    organization's policies invisible to another's admins.
+    """
+    return select(OrganizationMember.organization_id).where(OrganizationMember.user_id == user.id)
+
+
+async def _resolve_organization_id(db, user, requested: Optional[str]) -> str:
+    """Pick (and authorize) the organization a new policy belongs to.
+
+    An explicit `organization_id` must be one the caller belongs to, otherwise
+    an admin of org A could plant a policy in org B. When omitted, it is only
+    unambiguous if the caller belongs to exactly one organization.
+    """
+    result = await db.execute(_member_org_ids(user))
+    org_ids = [str(row) for row in result.scalars().all()]
+
+    if requested:
+        if str(requested) not in org_ids:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Not a member of the requested organization",
+            )
+        return str(requested)
+
+    if len(org_ids) == 1:
+        return org_ids[0]
+
+    if not org_ids:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Caller belongs to no organization; organization_id is required",
+        )
+
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail="Caller belongs to multiple organizations; organization_id is required",
+    )
+
+
 @router.post("/", response_model=PolicyResponse, status_code=status.HTTP_201_CREATED)
 async def create_policy(
     policy_data: PolicyCreate, current_user=Depends(require_admin), db: Session = Depends(get_db)
@@ -46,14 +91,18 @@ async def create_policy(
     """
     Create a new policy (admin only).
     """
+    organization_id = await _resolve_organization_id(db, current_user, policy_data.organization_id)
+
     # Create new policy
     policy = Policy(
-        tenant_id=current_user.tenant_id,
+        organization_id=organization_id,
         name=policy_data.name,
         description=policy_data.description,
         rules=policy_data.rules,
         effect=policy_data.effect.value,
         priority=policy_data.priority,
+        enabled=policy_data.enabled,
+        version=1,
         target_type=policy_data.target_type.value if policy_data.target_type else None,
         target_id=policy_data.target_id,
         resource_type=policy_data.resource_type,
@@ -71,8 +120,9 @@ async def create_policy(
     audit_logger = AuditLogger(db)
     await audit_logger.log(
         event_type=AuditAction.POLICY_CREATE,
-        tenant_id=str(current_user.tenant_id) if hasattr(current_user, "tenant_id") else "",
+        tenant_id=organization_id,
         identity_id=str(current_user.id),
+        organization_id=organization_id,
         resource_type="policy",
         resource_id=str(policy.id),
         details={"policy_name": policy.name},
@@ -94,7 +144,7 @@ async def list_policies(
     """
     List all policies (admin only).
     """
-    stmt = select(Policy).where(Policy.tenant_id == current_user.tenant_id)
+    stmt = select(Policy).where(Policy.organization_id.in_(_member_org_ids(current_user)))
 
     if target_type:
         stmt = stmt.where(Policy.target_type == target_type)
@@ -124,6 +174,23 @@ async def evaluate_policies(
     cache = CacheService()
     engine = PolicyEngine(db, cache)
 
+    # Evaluation is scoped to one organization. `User` has no `organization_id`
+    # column (reading it here used to raise AttributeError); membership is the
+    # only link between a user and an organization.
+    result = await db.execute(_member_org_ids(current_user).limit(1))
+    organization_id = result.scalar_one_or_none()
+
+    if organization_id is None:
+        # Fail closed: no organization means no policies can apply.
+        return PolicyEvaluateResponse(
+            allowed=False,
+            reason="Caller belongs to no organization",
+        )
+
+    # Default the subject to the caller rather than evaluating an empty subject.
+    if not request.subject_id:
+        request.subject_id = str(current_user.id)
+
     # Add user context to request if not present
     if not request.context:
         request.context = {}
@@ -131,17 +198,13 @@ async def evaluate_policies(
     request.context.update(
         {
             "user_id": str(current_user.id),
-            "tenant_id": str(current_user.tenant_id),
-            "organization_id": str(current_user.organization_id)
-            if current_user.organization_id
-            else None,
+            "tenant_id": str(current_user.tenant_id) if current_user.tenant_id else None,
+            "organization_id": str(organization_id),
         }
     )
 
     # Evaluate policies
-    response = await engine.evaluate(request=request, tenant_id=str(current_user.tenant_id))
-
-    return response
+    return await engine.evaluate(request=request, organization_id=str(organization_id))
 
 
 # Role management endpoints
@@ -156,11 +219,17 @@ async def create_role(
 ):
     """
     Create a new role (admin only).
+
+    Scoped by `organization_id` for the same reason `list_roles` is: `roles` has
+    no `tenant_id` column, and `roles.organization_id` is NOT NULL, so the old
+    `organization_id=None` fallback could not have inserted a row either.
     """
-    # Check if role name already exists
+    organization_id = await _resolve_organization_id(db, current_user, role_data.organization_id)
+
+    # Check if role name already exists within the organization
     result = await db.execute(
         select(Role).where(
-            and_(Role.tenant_id == current_user.tenant_id, Role.name == role_data.name)
+            and_(Role.organization_id == organization_id, Role.name == role_data.name)
         )
     )
     existing_role = result.scalar_one_or_none()
@@ -172,8 +241,7 @@ async def create_role(
 
     # Create new role
     role = Role(
-        tenant_id=current_user.tenant_id,
-        organization_id=role_data.organization_id if role_data.organization_id else None,
+        organization_id=organization_id,
         name=role_data.name,
         description=role_data.description,
         permissions=role_data.permissions,
@@ -186,8 +254,10 @@ async def create_role(
     # Log audit event
     audit_logger = AuditLogger(db)
     await audit_logger.log(
-        action=AuditAction.ROLE_CREATE,
-        user_id=str(current_user.id),
+        event_type=AuditAction.ROLE_CREATE,
+        tenant_id=organization_id,
+        identity_id=str(current_user.id),
+        organization_id=organization_id,
         resource_type="role",
         resource_id=str(role.id),
         details={"role_name": role.name},
@@ -240,9 +310,14 @@ async def assign_role_to_user(
     """
     Assign a role to a user (admin only).
     """
-    # Verify role exists
+    # Verify the role exists inside an organization the caller belongs to.
     role_result = await db.execute(
-        select(Role).where(and_(Role.id == role_id, Role.tenant_id == current_user.tenant_id))
+        select(Role).where(
+            and_(
+                Role.id == role_id,
+                Role.organization_id.in_(_member_org_ids(current_user)),
+            )
+        )
     )
     role = role_result.scalar_one_or_none()
 
@@ -284,8 +359,10 @@ async def assign_role_to_user(
     # Log audit event
     audit_logger = AuditLogger(db)
     await audit_logger.log(
-        action=AuditAction.ROLE_ASSIGN,
-        user_id=str(current_user.id),
+        event_type=AuditAction.ROLE_ASSIGN,
+        tenant_id=str(role.organization_id) if role.organization_id else "",
+        identity_id=str(current_user.id),
+        organization_id=str(role.organization_id) if role.organization_id else None,
         resource_type="user_role",
         resource_id=str(user_role.id),
         details={"role_name": role.name, "assigned_to": user_id},
@@ -312,8 +389,12 @@ async def unassign_role_from_user(
             status_code=status.HTTP_404_NOT_FOUND, detail="Role assignment not found"
         )
 
-    # Delete assignment
-    db.delete(user_role)
+    # Capture before the row goes away — `user_role` is expired after commit.
+    user_role_id = str(user_role.id)
+    organization_id = str(user_role.organization_id) if user_role.organization_id else ""
+
+    # Delete assignment. `AsyncSession.delete` must be awaited.
+    await db.delete(user_role)
     await db.commit()
 
     # Clear permission cache for user
@@ -323,10 +404,12 @@ async def unassign_role_from_user(
     # Log audit event
     audit_logger = AuditLogger(db)
     await audit_logger.log(
-        action=AuditAction.ROLE_UNASSIGN,
-        user_id=str(current_user.id),
+        event_type=AuditAction.ROLE_UNASSIGN,
+        tenant_id=organization_id,
+        identity_id=str(current_user.id),
+        organization_id=organization_id or None,
         resource_type="user_role",
-        resource_id=str(user_role.id),
+        resource_id=user_role_id,
         details={"role_id": role_id, "unassigned_from": user_id},
     )
 
@@ -343,6 +426,28 @@ async def unassign_role_from_user(
 # ---------------------------------------------------------------------------
 
 
+async def _get_scoped_policy(db, current_user, policy_id: str) -> Policy:
+    """Load a policy the caller's organizations own, or 404.
+
+    A policy belonging to another organization is reported as missing rather
+    than forbidden, so the endpoint does not confirm that the id exists.
+    """
+    result = await db.execute(
+        select(Policy).where(
+            and_(
+                Policy.id == policy_id,
+                Policy.organization_id.in_(_member_org_ids(current_user)),
+            )
+        )
+    )
+    policy = result.scalar_one_or_none()
+
+    if not policy:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Policy not found")
+
+    return policy
+
+
 @router.get("/{policy_id}", response_model=PolicyResponse)
 async def get_policy(
     policy_id: str, current_user=Depends(require_admin), db: Session = Depends(get_db)
@@ -350,15 +455,7 @@ async def get_policy(
     """
     Get a specific policy by ID (admin only).
     """
-    result = await db.execute(
-        select(Policy).where(
-            and_(Policy.id == policy_id, Policy.tenant_id == current_user.tenant_id)
-        )
-    )
-    policy = result.scalar_one_or_none()
-
-    if not policy:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Policy not found")
+    policy = await _get_scoped_policy(db, current_user, policy_id)
 
     return PolicyResponse.from_orm(policy)
 
@@ -373,24 +470,18 @@ async def update_policy(
     """
     Update a policy (admin only).
     """
-    result = await db.execute(
-        select(Policy).where(
-            and_(Policy.id == policy_id, Policy.tenant_id == current_user.tenant_id)
-        )
-    )
-    policy = result.scalar_one_or_none()
+    policy = await _get_scoped_policy(db, current_user, policy_id)
 
-    if not policy:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Policy not found")
-
-    # Update fields
+    # Update fields. Enums arrive as PolicyEffect/PolicyTargetType; the columns
+    # are plain strings, so unwrap them before assigning.
     update_data = policy_update.dict(exclude_unset=True)
     for field, value in update_data.items():
-        if hasattr(policy, field):
-            setattr(policy, field, value)
+        if not hasattr(policy, field):
+            continue
+        setattr(policy, field, value.value if isinstance(value, enum.Enum) else value)
 
     # Increment version
-    policy.version += 1
+    policy.version = (policy.version or 0) + 1
 
     await db.commit()
     await db.refresh(policy)
@@ -402,8 +493,10 @@ async def update_policy(
     # Log audit event
     audit_logger = AuditLogger(db)
     await audit_logger.log(
-        action=AuditAction.POLICY_UPDATE,
-        user_id=str(current_user.id),
+        event_type=AuditAction.POLICY_UPDATE,
+        tenant_id=str(policy.organization_id) if policy.organization_id else "",
+        identity_id=str(current_user.id),
+        organization_id=str(policy.organization_id) if policy.organization_id else None,
         resource_type="policy",
         resource_id=str(policy.id),
         details={"updated_fields": list(update_data.keys())},
@@ -419,15 +512,11 @@ async def delete_policy(
     """
     Delete a policy (admin only).
     """
-    result = await db.execute(
-        select(Policy).where(
-            and_(Policy.id == policy_id, Policy.tenant_id == current_user.tenant_id)
-        )
-    )
-    policy = result.scalar_one_or_none()
+    policy = await _get_scoped_policy(db, current_user, policy_id)
 
-    if not policy:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Policy not found")
+    # Capture before the row goes away — `policy` is expired after commit.
+    policy_name = policy.name
+    organization_id = str(policy.organization_id) if policy.organization_id else ""
 
     # Delete policy evaluations first
     await db.execute(delete(PolicyEvaluation).where(PolicyEvaluation.policy_id == policy_id))
@@ -435,8 +524,9 @@ async def delete_policy(
     # Delete role-policy mappings
     await db.execute(delete(RolePolicy).where(RolePolicy.policy_id == policy_id))
 
-    # Delete the policy
-    db.delete(policy)
+    # Delete the policy. `AsyncSession.delete` is a coroutine — the un-awaited
+    # call this replaced left the row in place and only emitted a warning.
+    await db.delete(policy)
     await db.commit()
 
     # Clear cache
@@ -446,11 +536,13 @@ async def delete_policy(
     # Log audit event
     audit_logger = AuditLogger(db)
     await audit_logger.log(
-        action=AuditAction.POLICY_DELETE,
-        user_id=str(current_user.id),
+        event_type=AuditAction.POLICY_DELETE,
+        tenant_id=organization_id,
+        identity_id=str(current_user.id),
+        organization_id=organization_id or None,
         resource_type="policy",
         resource_id=str(policy_id),
-        details={"policy_name": policy.name},
+        details={"policy_name": policy_name},
     )
 
     return None

--- a/apps/api/app/services/audit_logger.py
+++ b/apps/api/app/services/audit_logger.py
@@ -67,6 +67,18 @@ class AuditEventType(str, Enum):
     SECURITY_SUSPICIOUS_ACTIVITY = "security.suspicious"
     SECURITY_ACCESS_DENIED = "security.access_denied"
 
+    # Policy / RBAC events
+    # `app/routers/v1/policies.py` and `app/services/policy_engine.py` referenced
+    # these seven members before they were defined, so each handler raised
+    # AttributeError on the audit call even when the query above it succeeded.
+    POLICY_CREATE = "policy.create"
+    POLICY_UPDATE = "policy.update"
+    POLICY_DELETE = "policy.delete"
+    POLICY_EVALUATE = "policy.evaluate"
+    ROLE_CREATE = "role.create"
+    ROLE_ASSIGN = "role.assign"
+    ROLE_UNASSIGN = "role.unassign"
+
     # Billing events
     BILLING_SUBSCRIPTION_CREATE = "billing.subscription_create"
     BILLING_SUBSCRIPTION_UPDATE = "billing.subscription_update"

--- a/apps/api/app/services/policy_engine.py
+++ b/apps/api/app/services/policy_engine.py
@@ -11,7 +11,7 @@ from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple
 
 import structlog
-from sqlalchemy import and_
+from sqlalchemy import and_, select
 from sqlalchemy.orm import Session
 
 logger = structlog.get_logger(__name__)
@@ -41,15 +41,18 @@ class PolicyEngine:
         self.audit_logger = AuditLogger(db)
 
     async def evaluate(
-        self, request: PolicyEvaluateRequest, tenant_id: str
+        self, request: PolicyEvaluateRequest, organization_id: str
     ) -> PolicyEvaluateResponse:
         """
         Evaluate policies for a given request.
+
+        `organization_id` is the tenancy key — `policies` has no `tenant_id`
+        column, so the filters this replaced could never have run.
         """
         start_time = time.time()
 
         # Check cache first
-        cache_key = self._generate_cache_key(request, tenant_id)
+        cache_key = self._generate_cache_key(request, organization_id)
         if self.cache:
             cached_result = await self.cache.get(cache_key)
             if cached_result:
@@ -57,7 +60,7 @@ class PolicyEngine:
 
         # Get applicable policies
         policies = await self._get_applicable_policies(
-            tenant_id=tenant_id,
+            organization_id=organization_id,
             subject=request.subject,
             resource=request.resource,
             action=request.action,
@@ -65,10 +68,11 @@ class PolicyEngine:
 
         # Evaluate policies in priority order
         allowed = False
+        denied_by = None
         reasons = []
-        applied_policy_ids = []
+        matched_policy_ids = []
 
-        for policy in sorted(policies, key=lambda p: p.priority, reverse=True):
+        for policy in sorted(policies, key=lambda p: p.priority or 0, reverse=True):
             if not policy.enabled:
                 continue
 
@@ -77,30 +81,44 @@ class PolicyEngine:
 
             result, reason = await self._evaluate_single_policy(policy=policy, request=request)
 
-            applied_policy_ids.append(str(policy.id))
+            if not result:
+                continue
+
+            matched_policy_ids.append(str(policy.id))
             reasons.append(f"{policy.name}: {reason}")
 
-            if policy.effect == PolicyEffect.DENY and result:
-                # Explicit deny takes precedence
+            if policy.effect == PolicyEffect.DENY:
+                # Explicit deny takes precedence and short-circuits.
                 allowed = False
+                denied_by = str(policy.id)
                 reasons.append(f"Explicitly denied by policy: {policy.name}")
                 break
-            elif policy.effect == PolicyEffect.ALLOW and result:
+            elif policy.effect == PolicyEffect.ALLOW:
                 allowed = True
 
         # Calculate evaluation time
         evaluation_time_ms = int((time.time() - start_time) * 1000)
 
-        # Create response
+        # Create response. These are the fields PolicyEvaluateResponse actually
+        # declares; the previous call passed `reasons`/`applied_policies`/
+        # `evaluation_time_ms`, which pydantic dropped as extras, so reading
+        # them back in _log_evaluation raised AttributeError.
         response = PolicyEvaluateResponse(
             allowed=allowed,
-            reasons=reasons,
-            applied_policies=applied_policy_ids,
-            evaluation_time_ms=evaluation_time_ms,
+            matched_policies=matched_policy_ids,
+            denied_by=denied_by,
+            reason="; ".join(reasons) if reasons else "No applicable policy matched",
+            metadata={
+                "evaluation_time_ms": evaluation_time_ms,
+                "organization_id": str(organization_id),
+                "policies_considered": len(policies),
+            },
         )
 
         # Log evaluation
-        await self._log_evaluation(request=request, response=response, tenant_id=tenant_id)
+        await self._log_evaluation(
+            request=request, response=response, organization_id=organization_id
+        )
 
         # Cache result
         if self.cache:
@@ -113,69 +131,58 @@ class PolicyEngine:
         return response
 
     async def _get_applicable_policies(
-        self, tenant_id: str, subject: str, resource: str, action: str
+        self, organization_id: str, subject: str, resource: str, action: str
     ) -> List[Policy]:
         """
         Get all policies that could apply to this request.
+
+        Every branch is constrained to `organization_id`, including the
+        role-derived one — a role-policy mapping must not pull a policy in from
+        another organization.
         """
+        in_org = and_(Policy.organization_id == organization_id, Policy.enabled.is_(True))
+
         # Get user's roles
-        user_roles = self.db.query(UserRole).filter(UserRole.user_id == subject).all()
-        role_ids = [ur.role_id for ur in user_roles]
+        role_ids = []
+        if subject:
+            result = await self.db.execute(
+                select(UserRole.role_id).where(UserRole.user_id == subject)
+            )
+            role_ids = list(result.scalars().all())
 
         # Get policies directly assigned to user
-        user_policies = (
-            self.db.query(Policy)
-            .filter(
-                and_(
-                    Policy.tenant_id == tenant_id,
-                    Policy.target_type == "user",
-                    Policy.target_id == subject,
-                    Policy.enabled == True,
-                )
+        result = await self.db.execute(
+            select(Policy).where(
+                and_(in_org, Policy.target_type == "user", Policy.target_id == subject)
             )
-            .all()
         )
+        user_policies = list(result.scalars().all())
 
         # Get policies assigned to user's roles
         role_policies = []
         if role_ids:
-            role_policy_mappings = (
-                self.db.query(RolePolicy).filter(RolePolicy.role_id.in_(role_ids)).all()
+            result = await self.db.execute(
+                select(RolePolicy.policy_id).where(RolePolicy.role_id.in_(role_ids))
             )
-            policy_ids = [rp.policy_id for rp in role_policy_mappings]
+            policy_ids = list(result.scalars().all())
 
             if policy_ids:
-                role_policies = (
-                    self.db.query(Policy)
-                    .filter(and_(Policy.id.in_(policy_ids), Policy.enabled == True))
-                    .all()
+                result = await self.db.execute(
+                    select(Policy).where(and_(in_org, Policy.id.in_(policy_ids)))
                 )
+                role_policies = list(result.scalars().all())
 
         # Get organization-wide policies
-        org_policies = (
-            self.db.query(Policy)
-            .filter(
-                and_(
-                    Policy.tenant_id == tenant_id,
-                    Policy.target_type == "organization",
-                    Policy.enabled == True,
-                )
-            )
-            .all()
+        result = await self.db.execute(
+            select(Policy).where(and_(in_org, Policy.target_type == "organization"))
         )
+        org_policies = list(result.scalars().all())
 
         # Get resource-specific policies
-        resource_policies = (
-            self.db.query(Policy)
-            .filter(
-                and_(
-                    Policy.tenant_id == tenant_id,
-                    Policy.resource_type != None,
-                    Policy.enabled == True,
-                )
-            )
-            .all()
+        result = await self.db.execute(
+            select(Policy).where(and_(in_org, Policy.resource_type.is_not(None)))
         )
+        resource_policies = list(result.scalars().all())
 
         # Filter resource policies by pattern matching
         matching_resource_policies = []
@@ -334,36 +341,46 @@ class PolicyEngine:
         return f"policy:eval:{hashlib.sha256(key_data.encode()).hexdigest()}"
 
     async def _log_evaluation(
-        self, request: PolicyEvaluateRequest, response: PolicyEvaluateResponse, tenant_id: str
+        self, request: PolicyEvaluateRequest, response: PolicyEvaluateResponse, organization_id: str
     ):
         """
         Log policy evaluation for audit trail.
-        """
-        evaluation = PolicyEvaluation(
-            policy_id=response.applied_policies[0] if response.applied_policies else None,
-            subject=request.subject,
-            action=request.action,
-            resource=request.resource,
-            context=request.context,
-            allowed=response.allowed,
-            reasons=response.reasons,
-            applied_policies=response.applied_policies,
-            evaluation_time_ms=response.evaluation_time_ms,
-        )
 
-        self.db.add(evaluation)
-        self.db.commit()
+        Only the kwargs below are real columns on `PolicyEvaluation`; the call
+        this replaced passed six that do not exist (`subject`, `resource`,
+        `allowed`, `reasons`, `applied_policies`, `evaluation_time_ms`) and
+        would have raised TypeError in the declarative constructor.
+        """
+        # `policy_evaluations.policy_id` is NOT NULL, so a no-match evaluation
+        # cannot be recorded as a row — it is captured in the audit log only.
+        if response.matched_policies:
+            evaluation = PolicyEvaluation(
+                policy_id=response.matched_policies[0],
+                subject_id=request.subject_id,
+                resource_type=request.resource_type,
+                resource_id=request.resource_id,
+                action=request.action,
+                result=response.allowed,
+                context=request.context or {},
+            )
+
+            self.db.add(evaluation)
+            await self.db.commit()
 
         # Also log to audit system
         await self.audit_logger.log(
-            action=AuditAction.POLICY_EVALUATE,
-            user_id=request.subject,
+            event_type=AuditAction.POLICY_EVALUATE,
+            tenant_id=str(organization_id),
+            identity_id=request.subject_id,
+            organization_id=str(organization_id),
             resource_type="policy",
-            resource_id=request.resource,
+            resource_id=request.resource_id,
             details={
                 "allowed": response.allowed,
                 "action": request.action,
-                "evaluation_time_ms": response.evaluation_time_ms,
+                "resource": request.resource,
+                "matched_policies": response.matched_policies,
+                "evaluation_time_ms": response.metadata.get("evaluation_time_ms"),
             },
             ip_address=request.context.get("client_ip") if request.context else None,
         )
@@ -372,10 +389,18 @@ class PolicyEngine:
         """
         Compile policy to WASM for edge evaluation.
         Requires OPA CLI installed and configured.
+
+        NOTE: `rego_code` is not a column on `Policy` and never has been, so for
+        a persisted policy this returns None. Nothing in the application calls
+        this method; it is kept for the OPA integration it was written for.
         """
         import os
         import subprocess
         import tempfile
+
+        if not getattr(policy, "rego_code", None):
+            logger.warning("Policy has no rego_code; nothing to compile")
+            return None
 
         try:
             # Check if OPA is available

--- a/apps/api/tests/unit/routers/test_policies_schema_drift.py
+++ b/apps/api/tests/unit/routers/test_policies_schema_drift.py
@@ -1,0 +1,576 @@
+"""The `policies` table was missing every column the policy API works with.
+
+`app/routers/v1/policies.py` and `app/services/policy_engine.py` read and wrote
+`effect`, `priority`, `enabled`, `version`, `target_type`, `target_id`,
+`resource_type`, `resource_pattern`, `actions`, `conditions` and `expires_at`,
+and filtered on `Policy.tenant_id`. None of the eleven columns existed and
+`policies.tenant_id` never has — alembic 000_init created the table with only
+(id, name, description, rules, organization_id, created_at, updated_at) and the
+SQLAlchemy model matched it exactly. Model and migration agreed; the *callers*
+were the drift. Every create/list/get/update/delete raised before reaching the
+database, which is why the production table held 0 rows.
+
+The existing engine suite passed throughout, because it drives the engine with
+`MagicMock` requests and policies — a MagicMock answers to any attribute name,
+so it cannot tell a real column from a missing one. These tests use real model
+instances and a real session for exactly that reason.
+
+Style follows `test_policies_route_order.py` (janua#525): assert against
+executable source with docstrings stripped, so prose cannot satisfy a scan.
+"""
+
+import ast
+import inspect
+import uuid
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base, Organization, OrganizationMember, Policy, User
+from app.models.policy import (
+    PolicyCreate,
+    PolicyEffect,
+    PolicyEvaluateRequest,
+    PolicyResponse,
+    PolicyTargetType,
+)
+from app.routers.v1 import policies as policies_router
+from app.services import policy_engine as policy_engine_module
+from app.services.audit_logger import AuditAction
+
+pytestmark = pytest.mark.asyncio
+
+# Tables this module touches. Creating only these keeps the fixture independent
+# of unrelated models that fail to map under SQLite.
+_TABLES = [
+    "users",
+    "organizations",
+    "organization_members",
+    "policies",
+    "roles",
+    "user_roles",
+    "role_policies",
+    "policy_evaluations",
+]
+
+# Every field PolicyCreate accepts that lands on a policy row, with a value
+# distinguishable from the column default so a dropped write is visible.
+ROUND_TRIP_FIELDS = {
+    "name": "round-trip-policy",
+    "description": "every field this API claims to support",
+    "rules": {"allow": {"action": "read"}},
+    "effect": PolicyEffect.DENY,
+    "priority": 42,
+    "enabled": False,
+    "target_type": PolicyTargetType.ROLE,
+    "target_id": "target-abc",
+    "resource_type": "documents",
+    "resource_pattern": "documents:*",
+    "actions": ["read", "write"],
+    "conditions": {"mfa_required": True},
+    "expires_at": datetime(2030, 1, 1, 12, 30),
+}
+
+
+@pytest.fixture(autouse=True)
+def stub_io():
+    """Stub the two collaborators that do network I/O.
+
+    Both are instantiated inside the handlers, and both are awaited, so the
+    default `MagicMock` return value is not awaitable.
+    """
+    audit_cls = MagicMock()
+    audit_cls.return_value.log = AsyncMock()
+
+    cache_cls = MagicMock()
+    cache_cls.return_value.get = AsyncMock(return_value=None)
+    for method in ("set", "delete", "delete_pattern"):
+        setattr(cache_cls.return_value, method, AsyncMock())
+
+    with (
+        patch.object(policies_router, "AuditLogger", audit_cls),
+        patch.object(policies_router, "CacheService", cache_cls),
+        patch.object(policy_engine_module, "AuditLogger", audit_cls),
+        patch.object(policy_engine_module, "CacheService", cache_cls),
+    ):
+        yield
+
+
+@pytest_asyncio.fixture
+async def db():
+    """An isolated in-memory database per test.
+
+    Deliberately not the session-scoped `real_db_session` fixture: these tests
+    assert on row visibility, so they must not see another test's rows.
+    """
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    tables = [Base.metadata.tables[name] for name in _TABLES]
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all, tables=tables)
+
+    session_factory = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+async def _make_org_with_admin(db, name):
+    """Create an organization plus an admin who is a member of it."""
+    org = Organization(id=uuid.uuid4(), name=name, slug=name)
+    user = User(id=uuid.uuid4(), email=f"admin@{name}.test", is_admin=True)
+    db.add_all([org, user])
+    await db.flush()
+    db.add(OrganizationMember(id=uuid.uuid4(), organization_id=org.id, user_id=user.id))
+    await db.commit()
+    # The routers receive the authenticated principal, not an ORM instance.
+    return org, SimpleNamespace(id=user.id, tenant_id=None)
+
+
+def _executable_source(obj) -> str:
+    """Source of `obj` with docstrings stripped, so prose can't satisfy a scan."""
+    tree = ast.parse(inspect.getsource(obj))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Module)):
+            if ast.get_docstring(node):
+                node.body = node.body[1:]
+    return ast.unparse(tree)
+
+
+def _attributes_accessed_on(module, name: str) -> set:
+    """Every `name.<attr>` referenced in `module`'s executable source."""
+    tree = ast.parse(_executable_source(module))
+    return {
+        node.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == name
+    }
+
+
+# ---------------------------------------------------------------------------
+# The model is the one the router and engine actually use
+# ---------------------------------------------------------------------------
+
+
+def test_router_and_engine_share_one_policy_class():
+    """`app.models.policy.Policy` is a re-export, not a second model.
+
+    `app/models/policy.py` does `from . import Policy as PolicyModel`, so the
+    router's import and the model defined in `app/models/__init__.py` are the
+    same class. Any conclusion drawn from reading one of them applies to both.
+    """
+    from app.models import Policy as PolicyFromPackage
+    from app.models.policy import Policy as PolicyFromModule
+
+    assert PolicyFromModule is PolicyFromPackage
+    assert policies_router.Policy is PolicyFromPackage
+    assert policy_engine_module.Policy is PolicyFromPackage
+    assert PolicyFromPackage.__table__.name == "policies"
+
+
+def test_policies_are_scoped_by_a_column_that_exists():
+    """The `Policy.tenant_id` half of the drift, mirroring #525's Role check."""
+    assert hasattr(Policy, "organization_id")
+    assert "tenant_id" not in Policy.__table__.columns, (
+        "policies has no tenant_id column; organization_id is the tenancy key, "
+        "consistent with Role and OrganizationMember."
+    )
+
+    for module in (policies_router, policy_engine_module):
+        assert "Policy.tenant_id" not in _executable_source(
+            module
+        ), f"{module.__name__} filters on Policy.tenant_id, which does not exist."
+
+
+def test_every_policy_attribute_the_code_touches_is_a_real_column():
+    """The structural guard: no caller may reference a column that isn't there.
+
+    This is what a mock-driven suite cannot check, and what let eleven missing
+    columns survive review.
+    """
+    columns = set(Policy.__table__.columns.keys())
+    referenced = set()
+    for module in (policies_router, policy_engine_module):
+        referenced |= _attributes_accessed_on(module, "Policy")
+        referenced |= _attributes_accessed_on(module, "policy")
+
+    # `rego_code` is read only by PolicyEngine.compile_to_wasm, which nothing
+    # calls and which now returns None when the attribute is absent. It is
+    # deliberately not a column.
+    referenced -= {"rego_code"}
+
+    missing = sorted(referenced - columns)
+    assert not missing, f"Referenced on Policy but not columns: {missing}"
+
+
+def test_audit_actions_the_handlers_emit_exist():
+    """Each handler's audit call used a member that was never defined."""
+    for member in (
+        "POLICY_CREATE",
+        "POLICY_UPDATE",
+        "POLICY_DELETE",
+        "POLICY_EVALUATE",
+        "ROLE_CREATE",
+        "ROLE_ASSIGN",
+        "ROLE_UNASSIGN",
+    ):
+        assert hasattr(AuditAction, member), f"AuditAction.{member} is missing"
+
+
+# ---------------------------------------------------------------------------
+# Round trip
+# ---------------------------------------------------------------------------
+
+
+async def test_policy_round_trips_every_field_it_claims_to_support(db):
+    """Write every supported field, read it back from the database, compare."""
+    org, admin = await _make_org_with_admin(db, "roundtrip")
+
+    created = await policies_router.create_policy(
+        PolicyCreate(organization_id=str(org.id), **ROUND_TRIP_FIELDS),
+        current_user=admin,
+        db=db,
+    )
+
+    db.expunge_all()
+    stored = await db.get(Policy, uuid.UUID(created.id))
+
+    assert stored is not None, "create_policy did not persist a row"
+    assert str(stored.organization_id) == str(org.id)
+    assert stored.version == 1
+
+    expected = dict(ROUND_TRIP_FIELDS)
+    expected["effect"] = PolicyEffect.DENY.value
+    expected["target_type"] = PolicyTargetType.ROLE.value
+
+    for field, value in expected.items():
+        assert getattr(stored, field) == value, f"{field} did not survive the round trip"
+
+
+async def test_policy_response_exposes_every_field_it_declares(db):
+    """`PolicyResponse.from_orm` used to read attributes that did not exist."""
+    org, admin = await _make_org_with_admin(db, "response")
+
+    created = await policies_router.create_policy(
+        PolicyCreate(organization_id=str(org.id), **ROUND_TRIP_FIELDS),
+        current_user=admin,
+        db=db,
+    )
+
+    stored = await db.get(Policy, uuid.UUID(created.id))
+    response = PolicyResponse.from_orm(stored)
+
+    assert response.effect == PolicyEffect.DENY.value
+    assert response.priority == 42
+    assert response.enabled is False
+    assert response.version == 1
+    assert response.target_type == PolicyTargetType.ROLE.value
+    assert response.target_id == "target-abc"
+    assert response.resource_pattern == "documents:*"
+    assert response.actions == ["read", "write"]
+    assert response.conditions == {"mfa_required": True}
+    assert response.expires_at == ROUND_TRIP_FIELDS["expires_at"]
+    assert response.organization_id == str(org.id)
+    # tenant_id is kept as an alias of organization_id, as RoleResponse does.
+    assert response.tenant_id == str(org.id)
+
+
+async def test_update_policy_increments_version_and_persists(db):
+    org, admin = await _make_org_with_admin(db, "update")
+
+    created = await policies_router.create_policy(
+        PolicyCreate(organization_id=str(org.id), name="v1"),
+        current_user=admin,
+        db=db,
+    )
+
+    from app.models.policy import PolicyUpdate
+
+    updated = await policies_router.update_policy(
+        created.id,
+        PolicyUpdate(name="v2", effect=PolicyEffect.DENY, priority=7),
+        current_user=admin,
+        db=db,
+    )
+
+    assert updated.version == 2
+    assert updated.name == "v2"
+    # The enum must be unwrapped to its string value, not stored as PolicyEffect.
+    assert updated.effect == "deny"
+
+    db.expunge_all()
+    stored = await db.get(Policy, uuid.UUID(created.id))
+    assert stored.effect == "deny"
+    assert stored.priority == 7
+
+
+async def test_delete_policy_actually_removes_the_row(db):
+    """`AsyncSession.delete` is a coroutine; the un-awaited call left the row."""
+    org, admin = await _make_org_with_admin(db, "delete")
+
+    created = await policies_router.create_policy(
+        PolicyCreate(organization_id=str(org.id), name="doomed"),
+        current_user=admin,
+        db=db,
+    )
+
+    await policies_router.delete_policy(created.id, current_user=admin, db=db)
+
+    db.expunge_all()
+    assert await db.get(Policy, uuid.UUID(created.id)) is None
+
+
+# ---------------------------------------------------------------------------
+# Organization scoping
+# ---------------------------------------------------------------------------
+
+
+async def test_org_a_policy_is_invisible_to_org_b(db):
+    """Cross-tenant isolation: list, get, update and delete must all miss."""
+    from fastapi import HTTPException
+
+    org_a, admin_a = await _make_org_with_admin(db, "orga")
+    org_b, admin_b = await _make_org_with_admin(db, "orgb")
+
+    secret = await policies_router.create_policy(
+        PolicyCreate(organization_id=str(org_a.id), name="org-a-secret"),
+        current_user=admin_a,
+        db=db,
+    )
+
+    # skip/limit are passed explicitly: calling the handler directly bypasses
+    # FastAPI's dependency resolution, so their defaults are `Query` objects.
+    a_listed = await policies_router.list_policies(skip=0, limit=100, current_user=admin_a, db=db)
+    b_listed = await policies_router.list_policies(skip=0, limit=100, current_user=admin_b, db=db)
+
+    assert [p.id for p in a_listed] == [secret.id]
+    assert b_listed == [], "org B can list org A's policies"
+
+    with pytest.raises(HTTPException) as exc:
+        await policies_router.get_policy(secret.id, current_user=admin_b, db=db)
+    assert exc.value.status_code == 404
+
+    with pytest.raises(HTTPException):
+        await policies_router.delete_policy(secret.id, current_user=admin_b, db=db)
+
+    db.expunge_all()
+    assert await db.get(Policy, uuid.UUID(secret.id)) is not None
+
+
+async def test_create_policy_rejects_a_foreign_organization(db):
+    """An admin must not be able to plant a policy in someone else's org."""
+    from fastapi import HTTPException
+
+    org_a, admin_a = await _make_org_with_admin(db, "planter")
+    org_b, _ = await _make_org_with_admin(db, "victim")
+
+    with pytest.raises(HTTPException) as exc:
+        await policies_router.create_policy(
+            PolicyCreate(organization_id=str(org_b.id), name="planted"),
+            current_user=admin_a,
+            db=db,
+        )
+
+    assert exc.value.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+
+def _engine(db):
+    cache = AsyncMock()
+    cache.get = AsyncMock(return_value=None)
+    cache.set = AsyncMock()
+    return policy_engine_module.PolicyEngine(db=db, cache=cache)
+
+
+async def test_evaluate_does_not_raise_with_no_policies(db):
+    """The engine issued `self.db.query(...)` against an AsyncSession, which has
+    no `.query`, and read `request.subject`, which the schema did not define."""
+    org, _ = await _make_org_with_admin(db, "evalempty")
+    engine = _engine(db)
+
+    response = await engine.evaluate(
+        request=PolicyEvaluateRequest(resource_type="documents", action="read"),
+        organization_id=str(org.id),
+    )
+
+    assert response.allowed is False
+    assert response.matched_policies == []
+    assert response.reason
+
+
+async def test_evaluate_allows_on_a_matching_allow_policy(db):
+    org, admin = await _make_org_with_admin(db, "evalallow")
+
+    db.add(
+        Policy(
+            id=uuid.uuid4(),
+            organization_id=org.id,
+            name="allow-doc-read",
+            effect="allow",
+            priority=10,
+            enabled=True,
+            version=1,
+            target_type="organization",
+            actions=["read"],
+            rules={},
+            conditions={},
+        )
+    )
+    await db.commit()
+
+    engine = _engine(db)
+    response = await engine.evaluate(
+        request=PolicyEvaluateRequest(
+            subject_id=str(admin.id), resource_type="documents", action="read"
+        ),
+        organization_id=str(org.id),
+    )
+
+    assert response.allowed is True
+    assert len(response.matched_policies) == 1
+    assert response.metadata["evaluation_time_ms"] >= 0
+
+
+async def test_evaluate_deny_beats_allow_regardless_of_order(db):
+    """Explicit deny wins; priority orders evaluation, deny short-circuits."""
+    org, admin = await _make_org_with_admin(db, "evaldeny")
+
+    common = {
+        "organization_id": org.id,
+        "enabled": True,
+        "version": 1,
+        "target_type": "organization",
+        "actions": ["read"],
+        "rules": {},
+        "conditions": {},
+    }
+    db.add(Policy(id=uuid.uuid4(), name="allow-all", effect="allow", priority=1, **common))
+    db.add(Policy(id=uuid.uuid4(), name="deny-docs", effect="deny", priority=99, **common))
+    await db.commit()
+
+    engine = _engine(db)
+    response = await engine.evaluate(
+        request=PolicyEvaluateRequest(
+            subject_id=str(admin.id), resource_type="documents", action="read"
+        ),
+        organization_id=str(org.id),
+    )
+
+    assert response.allowed is False
+    assert response.denied_by is not None
+
+
+async def test_evaluate_ignores_disabled_and_expired_policies(db):
+    org, admin = await _make_org_with_admin(db, "evalskip")
+
+    common = {
+        "organization_id": org.id,
+        "effect": "allow",
+        "priority": 5,
+        "version": 1,
+        "target_type": "organization",
+        "actions": ["read"],
+        "rules": {},
+        "conditions": {},
+    }
+    db.add(Policy(id=uuid.uuid4(), name="disabled", enabled=False, **common))
+    db.add(
+        Policy(
+            id=uuid.uuid4(),
+            name="expired",
+            enabled=True,
+            expires_at=datetime.utcnow() - timedelta(days=1),
+            **common,
+        )
+    )
+    await db.commit()
+
+    engine = _engine(db)
+    response = await engine.evaluate(
+        request=PolicyEvaluateRequest(
+            subject_id=str(admin.id), resource_type="documents", action="read"
+        ),
+        organization_id=str(org.id),
+    )
+
+    assert response.allowed is False
+    assert response.matched_policies == []
+
+
+async def test_evaluate_does_not_see_another_organizations_policy(db):
+    """Org scoping on the evaluation path, not just on CRUD."""
+    org_a, _ = await _make_org_with_admin(db, "evala")
+    org_b, admin_b = await _make_org_with_admin(db, "evalb")
+
+    db.add(
+        Policy(
+            id=uuid.uuid4(),
+            organization_id=org_a.id,
+            name="org-a-allow",
+            effect="allow",
+            priority=10,
+            enabled=True,
+            version=1,
+            target_type="organization",
+            actions=["read"],
+            rules={},
+            conditions={},
+        )
+    )
+    await db.commit()
+
+    engine = _engine(db)
+    response = await engine.evaluate(
+        request=PolicyEvaluateRequest(
+            subject_id=str(admin_b.id), resource_type="documents", action="read"
+        ),
+        organization_id=str(org_b.id),
+    )
+
+    assert response.allowed is False, "org B was allowed by org A's policy"
+    assert response.matched_policies == []
+
+
+async def test_evaluate_endpoint_returns_a_response(db):
+    """End to end through the router handler, including the context it builds.
+
+    `current_user.organization_id` was read here and `User` has no such column.
+    """
+    org, admin = await _make_org_with_admin(db, "evalroute")
+
+    response = await policies_router.evaluate_policies(
+        PolicyEvaluateRequest(resource_type="documents", action="read"),
+        current_user=admin,
+        db=db,
+    )
+
+    assert response.allowed is False
+    assert response.reason
+
+
+async def test_evaluate_request_derives_flat_subject_and_resource():
+    """The adapter between the wire schema and the engine's matching vocabulary."""
+    request = PolicyEvaluateRequest(
+        subject_id="user-1", resource_type="documents", resource_id="42", action="read"
+    )
+    assert request.subject == "user-1"
+    assert request.resource == "documents:42"
+
+    type_only = PolicyEvaluateRequest(resource_type="documents", action="read")
+    assert type_only.subject == ""
+    assert type_only.resource == "documents"


### PR DESCRIPTION
Follow-up to #525, which fixed the route shadowing and `list_roles` but deliberately left the wider drift.

## What was actually wrong

The reported drift was real, but the shape was different from the report, and it was larger.

**The model and the migration were never the problem — they agreed exactly.** `app/models/__init__.py` `Policy` and alembic `000_init` both define the same seven columns, and production matches both (verified read-only):

```
policies: id, name, description, rules, organization_id, created_at, updated_at
```

The *callers* were the drift. Also worth stating plainly: `app/models/policy.py` is a separate module but **not** a separate class — it does `from . import Policy as PolicyModel` and re-exports it, so the router, the engine and `app/models/__init__.py:539` have always shared one class. A test now pins that.

### Three-way inventory

| Attribute | Model | Migration `000_init` | Prod DB | Referenced by router/engine/schema |
|---|---|---|---|---|
| id, name, description, rules, organization_id, created_at, updated_at | yes | yes | yes | yes |
| `tenant_id` | **no** | **no** | **no** | yes — 5 router queries + 3 engine queries |
| effect, priority, enabled, version | **no** | **no** | **no** | yes |
| target_type, target_id, resource_type, resource_pattern | **no** | **no** | **no** | yes |
| actions, conditions, expires_at | **no** | **no** | **no** | yes |
| `rego_code` | **no** | **no** | **no** | yes — `compile_to_wasm` only |

### Defects the report did not mention

Fixing only the columns and the `tenant_id` filters would still have left `/evaluate` at 500:

1. `PolicyEngine._get_applicable_policies` and `get_user_permissions` call `self.db.query(...)`. `get_db` yields an `AsyncSession`, which has no `.query`.
2. `PolicyEngine.evaluate` read `request.subject` and `request.resource`. `PolicyEvaluateRequest` defines `subject_id` / `resource_type` / `resource_id` and neither of those two. It raised inside `_generate_cache_key`, **before any query ran** — so the `Policy.tenant_id` filters were never even reached.
3. `PolicyEvaluateResponse` was built with `reasons`, `applied_policies`, `evaluation_time_ms`. The schema declares `matched_policies`, `denied_by`, `reason`, `metadata`. Pydantic dropped the extras, then `_log_evaluation` read them back.
4. `PolicyEvaluation(...)` was constructed with six kwargs that are not columns (`subject`, `resource`, `allowed`, `reasons`, `applied_policies`, `evaluation_time_ms`).
5. **All seven `AuditAction` members the handlers emit were undefined** — `POLICY_CREATE/UPDATE/DELETE/EVALUATE`, `ROLE_CREATE/ASSIGN/UNASSIGN`. Confirmed at runtime.
6. Five audit calls used `action=` / `user_id=`; the signature is `event_type=` / `tenant_id=` / `identity_id=`.
7. `db.delete(...)` was not awaited. `AsyncSession.delete` is a coroutine, so `delete_policy` and `unassign_role_from_user` left the row in place.
8. `evaluate_policies` read `current_user.organization_id`. `User` has `tenant_id`, not `organization_id`.
9. `create_role` and `assign_role_to_user` still filtered on `Role.tenant_id` — the same defect #525 fixed in `list_roles` only. `create_role` also passed `organization_id=None` into a NOT NULL column.

So the net claim holds: **policy CRUD and `/evaluate` have never worked.** Fail-closed, and the empty production table is the evidence.

## Production row counts (read-only)

| table | rows |
|---|---|
| policies | 0 |
| roles | 0 |
| role_policies | 0 |
| user_roles | 0 |
| policy_evaluations | 0 |

Empty everywhere, so the new NOT NULL columns take server defaults with no backfill.

## What changed

**Added** (alembic `010_add_policy_authorization_columns`, `ADD COLUMN IF NOT EXISTS`): `effect`, `priority`, `enabled`, `version`, `target_type`, `target_id`, `resource_type`, `resource_pattern`, `actions`, `conditions`, `expires_at`, plus two indexes on the engine's hot path.

**Tenancy**: `organization_id` everywhere, scoped through `OrganizationMember` exactly as #525's `list_roles` does. `create_policy` takes an optional `organization_id`, requires membership (403 otherwise), and requires it explicitly when the caller belongs to more than one organization.

**Not added, justified:**

- `Policy.tenant_id` — a rename, not a missing column. `organization_id` already existed and is the convention across `Role`, `Permission`, `OrganizationMember`.
- `rego_code` — read only by `compile_to_wasm`, which nothing in the application calls. Rather than invent a column for a dead OPA path, it now returns `None` when the attribute is absent.
- `PolicyResponse.tenant_id` — kept, populated from `organization_id`, matching the alias convention `RoleResponse` already uses. Dropping it would be a wire break for no gain.

**`PolicyEvaluateRequest.subject` / `.resource`** are now derived properties mapping the structured wire format to the flat strings the engine matches on. This keeps the public API schema unchanged.

## Tests

New `tests/unit/routers/test_policies_schema_drift.py` (17 tests), styled after `test_policies_route_order.py`: round-trip of every supported field through a real session, `PolicyResponse` field coverage, version increment, delete actually removing the row, cross-org invisibility for list/get/delete, foreign-org create rejection, `/evaluate` returning without raising, deny-beats-allow, disabled/expired skipping, cross-org evaluation isolation, plus an AST guard asserting no `Policy.<attr>` referenced in the router or engine is absent from the table.

The existing 62-test engine suite passes **unchanged**. It could never have caught any of this: it drives the engine with `MagicMock` requests and policies, and a MagicMock answers to any attribute name.

### Baseline

`tests/unit/routers/ tests/unit/services/ tests/unit/models/`, compared by test name against clean `main` (`git stash -u`):

| | main | branch |
|---|---|---|
| failed | 13 | 13 |
| errors | 80 | 80 |
| passed | 1789 | 1806 |

Failure and error sets are **identical by name** — zero regressions, +17 new passing tests. The pre-existing 13/80 are the known xmlsec/lxml environment and test-pollution failures.

## Blocker for production — needs a separate decision

**This migration cannot currently run, for a reason that predates this PR.** The alembic chain is severed: `003_add_product_tiers.py` declares `revision = '003'`, but `004_add_guest_invites.py` declares `down_revision = "003_add_product_tiers"`, an id that does not exist. `alembic history` fails on clean `main`.

That is why **production is stamped at revision `002`** with migrations 004-009 never applied. Until the chain is repaired, the fixed code would still fail in production — with `UndefinedColumn` instead of `AttributeError`.

I did not fix it here: repairing the chain makes seven unapplied migrations eligible to run against the production auth database, which deserves an explicit operator decision rather than being bundled into a policy PR.

## Out of scope

`app/graphql/schema.py` also consumes `PolicyEngine` and is broken independently — it builds `PolicyEvaluateRequest(subject=..., resource=...)`, which raises `ValidationError` for every input, and uses sync `db.query()` throughout. It is moot: the router fails to import at all (`No module named 'app.models.organization'`), so it is not registered. Left untouched and unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
