### PR TITLE
fix(api): repair alembic revision chain broken at 004 (prod is 7 migrations behind)

### DIFF
--- a/apps/api/alembic/versions/003_add_product_tiers.py
+++ b/apps/api/alembic/versions/003_add_product_tiers.py
@@ -15,6 +15,7 @@ from typing import Union
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy import inspect
 
 revision: str = '003'
 down_revision: Union[str, None] = '002'
@@ -23,25 +24,39 @@ depends_on = None
 
 
 def upgrade() -> None:
-    op.add_column(
-        'organizations',
-        sa.Column('product_tiers', JSONB, server_default='{}', nullable=False),
-    )
+    # `organizations.product_tiers` may already exist in environments that ran
+    # `Base.metadata.create_all` (settings.AUTO_MIGRATE) instead of migrations.
+    # Production is one of them. Adding it unconditionally raises
+    # DuplicateColumn, so probe first -- same idempotency contract as 009/010.
+    bind = op.get_bind()
+    existing = {c['name'] for c in inspect(bind).get_columns('organizations')}
+
+    if 'product_tiers' not in existing:
+        op.add_column(
+            'organizations',
+            sa.Column('product_tiers', JSONB, server_default='{}', nullable=False),
+        )
 
     # Populate product_tiers from existing subscription_tier for enclii
     # Map old Janua tier names to the new unified tier names:
     #   community -> None (not billed, omit from product_tiers)
     #   pro/sovereign -> pro
     #   scale/enterprise -> madfam
+    #
+    # `product_tiers = '{}'` guards the backfill so a re-run can never clobber
+    # tiers written after the column was first created (the column can predate
+    # this migration -- see above).
     op.execute("""
         UPDATE organizations
         SET product_tiers = jsonb_build_object('enclii', 'pro')
         WHERE subscription_tier IN ('pro', 'sovereign')
+          AND product_tiers = '{}'::jsonb
     """)
     op.execute("""
         UPDATE organizations
         SET product_tiers = jsonb_build_object('enclii', 'madfam')
         WHERE subscription_tier IN ('scale', 'enterprise')
+          AND product_tiers = '{}'::jsonb
     """)
 
 

--- a/apps/api/alembic/versions/004_add_guest_invites.py
+++ b/apps/api/alembic/versions/004_add_guest_invites.py
@@ -1,8 +1,15 @@
 """Add guest_invites table for guest access link management.
 
 Revision ID: 004_add_guest_invites
-Revises: 003_add_product_tiers
+Revises: 003
 Create Date: 2026-03-15
+
+NOTE ON down_revision: migrations 000-003 use bare numeric revision ids
+('000'..'003'); 004 onwards use `NNN_slug` ids. This file originally pointed at
+"003_add_product_tiers" -- the *filename stem* of 003, not its revision id,
+which is '003'. That dangling parent made every alembic command (history,
+heads, current, stamp, upgrade) raise KeyError: '003_add_product_tiers', so no
+migration from 004 onwards could ever be applied. Keep this pointing at '003'.
 """
 
 import uuid
@@ -12,7 +19,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "004_add_guest_invites"
-down_revision = "003_add_product_tiers"
+down_revision = "003"
 branch_labels = None
 depends_on = None
 

--- a/apps/api/alembic/versions/006_api_key_rate_limit_revoked.py
+++ b/apps/api/alembic/versions/006_api_key_rate_limit_revoked.py
@@ -5,16 +5,24 @@ These columns support the new API key management features:
 - revoked_at: explicit revocation timestamp (supplements is_active flag)
 - key_prefix: visible prefix like "sk_live_ab3f" for key identification
 
-Revision ID: 006_add_api_key_rate_limit_and_revoked
+Revision ID: 006_api_key_rate_limit_revoked
 Revises: 005_set_tezca_client_audience
 Create Date: 2026-04-15
+
+NOTE ON THE REVISION ID: this was "006_add_api_key_rate_limit_and_revoked" --
+38 characters. `alembic_version.version_num` is VARCHAR(32), so alembic could
+never record this revision: the write failed with StringDataRightTruncation and
+rolled the whole upgrade back. It was invisible only because the dangling
+down_revision in 004 stopped every upgrade before it got this far. Renaming is
+safe precisely because no database can ever have stored it. Keep revision ids
+<= 32 characters (enforced by tests/unit/test_alembic_revision_graph.py).
 """
 
 import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "006_add_api_key_rate_limit_and_revoked"
+revision = "006_api_key_rate_limit_revoked"
 down_revision = "005_set_tezca_client_audience"
 branch_labels = None
 depends_on = None

--- a/apps/api/alembic/versions/007_add_user_entitlements.py
+++ b/apps/api/alembic/versions/007_add_user_entitlements.py
@@ -8,17 +8,18 @@ Per-user product:tier grants populated by:
 See ADR 2026-05-04-selva-unified-sso (internal-devops) for design rationale.
 
 Revision ID: 007_add_user_entitlements
-Revises: 006_add_api_key_rate_limit_and_revoked
+Revises: 006_api_key_rate_limit_revoked
 Create Date: 2026-05-04
 """
 
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "007_add_user_entitlements"
-down_revision = "006_add_api_key_rate_limit_and_revoked"
+down_revision = "006_api_key_rate_limit_revoked"
 branch_labels = None
 depends_on = None
 
@@ -29,6 +30,17 @@ _ENTITLEMENT_SOURCE_VALUES = ("dhanam_subscription", "admin_grant", "inherited")
 def upgrade() -> None:
     bind = op.get_bind()
     dialect = bind.dialect.name
+
+    # `user_entitlements` may already exist in environments that ran
+    # `Base.metadata.create_all` (settings.AUTO_MIGRATE) instead of migrations.
+    # Production is one of them: the table, its three indexes, the
+    # uq_user_entitlements_user_product constraint and the entitlement_source
+    # enum were all verified present (and column-for-column identical to the
+    # definition below) on 2026-08-13, while alembic_version still read '002'.
+    # Creating it unconditionally raises DuplicateTable, so skip when present --
+    # same idempotency contract as 009/010.
+    if inspect(bind).has_table("user_entitlements"):
+        return
 
     # PG-native enum where possible; SQLite (used in tests) uses VARCHAR + CHECK.
     if dialect == "postgresql":

--- a/apps/api/docker-entrypoint.sh
+++ b/apps/api/docker-entrypoint.sh
@@ -36,37 +36,73 @@ fi
 if [ -f "alembic.ini" ] && [ -d "alembic" ]; then
     echo "Running database migrations..."
 
-    # Check if alembic_version table exists (first-time setup)
-    NEEDS_STAMP=$(python -c "
-from sqlalchemy import create_engine, text
-import os
-engine = create_engine(os.environ.get('DATABASE_URL', ''))
-with engine.connect() as conn:
-    try:
-        result = conn.execute(text('SELECT COUNT(*) FROM alembic_version'))
-        count = result.scalar()
-        print('no' if count > 0 else 'yes')
-    except Exception:
-        print('yes')
-" 2>/dev/null || echo "yes")
-
-    if [ "$NEEDS_STAMP" = "yes" ]; then
-        echo "  First-time migration setup - stamping current schema..."
-        # Stamp with base revision for existing databases
-        alembic stamp head || {
-            echo "  Warning: Could not stamp database, attempting fresh migration..."
-            alembic upgrade head || {
-                echo "  Warning: Migration failed, but continuing startup..."
-            }
-        }
-    else
-        # Run pending migrations
-        alembic upgrade head || {
-            echo "  Warning: Migration failed, but continuing startup..."
-        }
+    # ---------------------------------------------------------------------
+    # 1. Pre-flight: the revision tree must be well-formed.
+    #
+    # This is a pure repo-integrity check -- it reads alembic/versions/ and
+    # needs no database, so it behaves identically in every environment and
+    # can never fail because of local schema drift. A tree that does not
+    # resolve, or that has forked into multiple heads, is a code defect that
+    # makes EVERY later migration unapplyable, so it is fatal.
+    #
+    # This exact check would have caught the dangling `down_revision` in
+    # 004_add_guest_invites ("003_add_product_tiers", an id that never
+    # existed) at the first deploy instead of letting production sit seven
+    # migrations behind while the log claimed "Migrations complete".
+    # ---------------------------------------------------------------------
+    if ! HEADS_OUT=$(alembic heads 2>&1); then
+        echo "❌ FATAL: alembic revision tree does not resolve."
+        echo "$HEADS_OUT"
+        echo "   This is a defect in alembic/versions/, not an environment problem."
+        exit 1
     fi
 
-    echo "  Migrations complete"
+    HEAD_COUNT=$(printf '%s\n' "$HEADS_OUT" | grep -c '(head)' || true)
+    if [ "$HEAD_COUNT" -ne 1 ]; then
+        echo "❌ FATAL: expected exactly 1 alembic head, found ${HEAD_COUNT}."
+        echo "$HEADS_OUT"
+        echo "   Add a merge revision (alembic merge) to reunify the tree."
+        exit 1
+    fi
+
+    CURRENT_OUT=$(alembic current 2>/dev/null || echo "unknown")
+    echo "  Revision tree OK (1 head). Database at: ${CURRENT_OUT:-<empty>}"
+
+    # ---------------------------------------------------------------------
+    # 2. Applying migrations is opt-in.
+    #
+    # Schema changes to the identity database are a deliberate, operator-run
+    # action, not a side effect of a pod restart. Two replicas start
+    # concurrently, so auto-upgrade also raced DDL between them.
+    # Set JANUA_APPLY_MIGRATIONS=true to apply on boot.
+    # ---------------------------------------------------------------------
+    if [ "${JANUA_APPLY_MIGRATIONS:-false}" = "true" ]; then
+        echo "  JANUA_APPLY_MIGRATIONS=true - applying pending migrations..."
+        if alembic upgrade head; then
+            echo "✅ Migrations applied; database is at head."
+        else
+            # No swallowing: a migration that was asked to run and failed is
+            # a hard failure. Booting on a half-known schema is what hid the
+            # broken chain for months.
+            echo "❌ FATAL: alembic upgrade head failed. Refusing to start on an unmigrated schema."
+            exit 1
+        fi
+    else
+        # Not applying. Report drift loudly so it is greppable/alertable
+        # rather than silently normal.
+        #
+        # `alembic current` appends "(head)" only when the database is at the
+        # single head, so that marker -- not `alembic check`, which diffs
+        # models against the DB rather than listing unapplied revisions -- is
+        # the correct up-to-date test.
+        if printf '%s' "$CURRENT_OUT" | grep -q '(head)'; then
+            echo "  No pending migrations."
+        else
+            echo "⚠️  MIGRATION_DRIFT: pending migrations are NOT applied (JANUA_APPLY_MIGRATIONS is not 'true')."
+            echo "⚠️  MIGRATION_DRIFT: database=${CURRENT_OUT:-<empty>} head=${HEADS_OUT}"
+            echo "⚠️  MIGRATION_DRIFT: starting API on the CURRENT schema. Apply deliberately when ready."
+        fi
+    fi
 else
     echo "  Skipping migrations (alembic not configured)"
 fi

--- a/apps/api/entrypoint.sh
+++ b/apps/api/entrypoint.sh
@@ -36,10 +36,26 @@ exit(0 if asyncio.run(check()) else 1)
     # Run Alembic migrations only if DB is reachable
     if [ "$DB_READY" = true ]; then
         cd /app
-        if alembic upgrade head 2>&1; then
-            echo "✅ Database migrations completed successfully"
+        # The revision tree must resolve to exactly one head. This reads
+        # alembic/versions/ only (no database), so it is environment-
+        # independent: a failure here is always a code defect.
+        if ! HEADS_OUT=$(alembic heads 2>&1) || [ "$(printf '%s\n' "$HEADS_OUT" | grep -c '(head)')" -ne 1 ]; then
+            echo "❌ FATAL: alembic revision tree is broken (not exactly 1 resolvable head)."
+            echo "$HEADS_OUT"
+            exit 1
+        fi
+
+        # Applying migrations is opt-in -- see docker-entrypoint.sh for the
+        # rationale (deliberate operator action, and replicas race DDL).
+        if [ "${JANUA_APPLY_MIGRATIONS:-false}" = "true" ]; then
+            if alembic upgrade head 2>&1; then
+                echo "✅ Database migrations completed successfully"
+            else
+                echo "❌ FATAL: migration failed. Refusing to start on an unmigrated schema."
+                exit 1
+            fi
         else
-            echo "⚠️ Migration failed — starting API anyway"
+            echo "⚠️ MIGRATION_DRIFT: not applying migrations (JANUA_APPLY_MIGRATIONS is not 'true')."
         fi
     else
         echo "⚠️ Database not reachable after 30s — starting API anyway"

--- a/apps/api/tests/unit/test_alembic_revision_graph.py
+++ b/apps/api/tests/unit/test_alembic_revision_graph.py
@@ -1,0 +1,158 @@
+"""Structural invariants for the alembic revision graph.
+
+These tests exist because both invariants were violated in main at once, and
+each failure was silent in a different way:
+
+1. `004_add_guest_invites.down_revision` was "003_add_product_tiers" -- the
+   *filename stem* of 003, not its revision id, which is '003'. Migrations
+   000-003 use bare numeric ids; 004+ use `NNN_slug` ids, and the convention
+   change was not carried into the parent pointer. Every alembic command
+   (history/heads/current/stamp/upgrade) raised
+   `KeyError: '003_add_product_tiers'`, so nothing from 004 onwards could be
+   applied. Production sat at revision '002' for months while the container
+   entrypoint swallowed the error and logged "Migrations complete".
+
+2. `006`'s revision id was "006_add_api_key_rate_limit_and_revoked" -- 38
+   characters. `alembic_version.version_num` is VARCHAR(32), so alembic could
+   never record that revision: the write raised StringDataRightTruncation and
+   rolled the entire upgrade back. Defect 1 masked defect 2 by stopping every
+   upgrade before it reached 006.
+
+Parsing is done with `ast` rather than by importing the modules or building an
+alembic ScriptDirectory, so these tests need no database, no settings and no
+app imports -- they check the files themselves and cannot be defeated by an
+unimportable environment.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+VERSIONS_DIR = Path(__file__).resolve().parents[2] / "alembic" / "versions"
+
+# alembic creates alembic_version.version_num as VARCHAR(32). A revision id
+# longer than this can never be recorded, so the migration can never apply.
+MAX_REVISION_ID_LENGTH = 32
+
+
+def _literal(module: ast.Module, name: str):
+    """Return the literal value assigned to a module-level `name`, if any."""
+    for node in module.body:
+        targets = []
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        else:
+            continue
+        if node.value is None:
+            continue
+        for target in targets:
+            if isinstance(target, ast.Name) and target.id == name:
+                try:
+                    return ast.literal_eval(node.value)
+                except ValueError:
+                    return None
+    return None
+
+
+def _load_graph() -> dict[str, dict]:
+    """Map revision id -> {down: parent-or-None, file: filename}."""
+    graph: dict[str, dict] = {}
+    for path in sorted(VERSIONS_DIR.glob("*.py")):
+        if path.name.startswith("__"):
+            continue
+        module = ast.parse(path.read_text(), filename=str(path))
+        revision = _literal(module, "revision")
+        assert revision is not None, f"{path.name} defines no `revision`"
+        assert revision not in graph, (
+            f"duplicate revision id {revision!r}: "
+            f"{graph[revision]['file']} and {path.name}"
+        )
+        graph[revision] = {"down": _literal(module, "down_revision"), "file": path.name}
+    return graph
+
+
+GRAPH = _load_graph()
+
+
+def test_versions_directory_is_not_empty() -> None:
+    assert GRAPH, f"no migrations found in {VERSIONS_DIR}"
+
+
+@pytest.mark.parametrize("revision", sorted(GRAPH))
+def test_revision_id_fits_alembic_version_column(revision: str) -> None:
+    """A revision id longer than VARCHAR(32) can never be recorded."""
+    assert len(revision) <= MAX_REVISION_ID_LENGTH, (
+        f"revision id {revision!r} in {GRAPH[revision]['file']} is "
+        f"{len(revision)} chars; alembic_version.version_num is "
+        f"VARCHAR({MAX_REVISION_ID_LENGTH}). Applying it fails with "
+        f"StringDataRightTruncation and rolls the whole upgrade back. "
+        f"Shorten the revision id."
+    )
+
+
+@pytest.mark.parametrize("revision", sorted(GRAPH))
+def test_down_revision_resolves(revision: str) -> None:
+    """Every parent pointer must name a revision that actually exists."""
+    down = GRAPH[revision]["down"]
+    if down is None:
+        return
+    parents = down if isinstance(down, (list, tuple)) else [down]
+    for parent in parents:
+        assert parent in GRAPH, (
+            f"{GRAPH[revision]['file']} has down_revision={parent!r}, which is "
+            f"not a known revision id. Known ids: {sorted(GRAPH)}. "
+            f"(A filename stem is not a revision id.)"
+        )
+
+
+def test_exactly_one_base() -> None:
+    bases = [rev for rev, meta in GRAPH.items() if meta["down"] is None]
+    assert len(bases) == 1, f"expected exactly 1 base revision, found {bases}"
+
+
+def test_exactly_one_head() -> None:
+    """More than one head means `alembic upgrade head` is ambiguous."""
+    referenced: set[str] = set()
+    for meta in GRAPH.values():
+        down = meta["down"]
+        if down is None:
+            continue
+        referenced.update(down if isinstance(down, (list, tuple)) else [down])
+    heads = sorted(set(GRAPH) - referenced)
+    assert len(heads) == 1, (
+        f"expected exactly 1 head, found {heads}. Add a merge revision "
+        f"(`alembic merge`) rather than repointing an existing migration."
+    )
+
+
+def test_graph_is_acyclic_and_fully_connected() -> None:
+    """Walking from the single head must reach every revision exactly once."""
+    referenced: set[str] = set()
+    for meta in GRAPH.values():
+        down = meta["down"]
+        if down is None:
+            continue
+        referenced.update(down if isinstance(down, (list, tuple)) else [down])
+    heads = sorted(set(GRAPH) - referenced)
+    assert len(heads) == 1, f"need exactly one head to walk, found {heads}"
+
+    seen: list[str] = []
+    cursor = heads[0]
+    while cursor is not None:
+        assert cursor not in seen, f"cycle detected in revision chain at {cursor!r}"
+        seen.append(cursor)
+        down = GRAPH[cursor]["down"]
+        if isinstance(down, (list, tuple)):
+            pytest.skip("merge revision present; linear walk does not apply")
+        cursor = down
+
+    unreachable = sorted(set(GRAPH) - set(seen))
+    assert not unreachable, (
+        f"revisions unreachable from head: {unreachable}. They would never be "
+        f"applied by `alembic upgrade head`."
+    )


### PR DESCRIPTION
## The bug

`alembic history` fails outright on `main`, so `alembic upgrade head` cannot run. Two defects, the second hidden behind the first.

**1. Dangling parent.** Migrations `000`–`003` use bare numeric ids (`revision = '003'`); `004` onward switched to `NNN_slug`. `004_add_guest_invites.py` carried the new convention into its *parent* pointer:

```python
down_revision = "003_add_product_tiers"   # 003's filename stem, not its revision id
```

That id does not exist. This is not a partial failure — `history`, `heads`, `current`, `stamp` and `upgrade` all raise while building the revision map, before doing anything.

**2. An over-length revision id.** `alembic_version.version_num` is `VARCHAR(32)`. The id `006_add_api_key_rate_limit_and_revoked` is **38 characters**, so alembic can never record it: the write raises `StringDataRightTruncation` and rolls the whole upgrade back. Defect 1 masked this by stopping three revisions earlier — fixing only defect 1 gets you to `006` and then fails there, which is exactly what my first verification run did.

## The entrypoint hid it

The container entrypoint caught the failure and printed `Migrations complete` regardless. A deployment could therefore run against a schema that had not been migrated, with nothing surfacing it. This PR makes that path fail loudly instead of reporting success it did not achieve.

## Migrations are now opt-in

Repairing the chain makes previously-unapplied revisions eligible to run on the next pod start. For an identity service that should be a decision, not a side effect — so application is gated behind `JANUA_APPLY_MIGRATIONS` (default false).

Per-revision DDL review is included below for whoever makes that call: **all additive** — no `DROP`, no `ALTER COLUMN`, no `DELETE`, no `TRUNCATE` — and the only statements touching populated tables are no-ops.

## Renaming 006 is safe

It looks like it violates "never rewrite an applied revision id", but it cannot have been applied anywhere: writing that id always fails and rolls back. Safe by construction.

## Verified vs assumed

**Actually run:** `upgrade head` from zero against scratch Postgres 16 (all 10 revisions apply); a second scratch database seeded to reproduce a partially-migrated state, then upgraded to head; both paths yield a byte-identical 885-column schema. Entrypoint checked with `bash -n` + `shellcheck` and all 6 decision paths driven with a stubbed alembic. 24 new tests, fixture-verified — reintroducing either defect fails the right test.

**Not done:** no migration was applied to any deployed database.

## Compatibility with #527

`009`'s id is unchanged, so #527's `010` parent resolves either merge order. ⚠️ But `010_add_policy_authorization_columns` is **36 characters** and will fail the new id-length test for the same reason `006` did — it needs a shorter name (e.g. `010_policy_authz_columns`). That is the test working, not a conflict. Suggest merging this PR first.