### PR TITLE
feat(api): localize transactional email per recipient (es-MX + en)

### DIFF
--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -215,6 +215,14 @@ class Settings(BaseSettings):
     EMAIL_FROM_ADDRESS: str = Field(default="noreply@janua.dev")
     EMAIL_FROM_NAME: str = Field(default="Janua")
     RESEND_API_KEY: Optional[str] = Field(default=None)
+    # Language for transactional mail when the recipient has no stored locale
+    # and the caller did not specify one. Defaults to Spanish: this platform's
+    # users are predominantly Mexican, and mail was English-only before.
+    DEFAULT_EMAIL_LOCALE: str = Field(
+        default="es",
+        pattern="^[a-z]{2}(-[A-Za-z0-9]{2,8})?$",
+        description="Default language for transactional email (BCP 47 tag, e.g. es, es-MX, en)",
+    )
 
     # SMTP Configuration (for development/self-hosted)
     SMTP_HOST: Optional[str] = Field(default=None)

--- a/apps/api/app/routers/v1/auth.py
+++ b/apps/api/app/routers/v1/auth.py
@@ -289,7 +289,10 @@ async def sign_up(
         await db.commit()
 
         background_tasks.add_task(
-            send_verification_email_task, user.email, verification_token
+            send_verification_email_task,
+            user.email,
+            verification_token,
+            locale=getattr(user, "locale", None),
         )
 
     return SignInResponse(
@@ -1296,7 +1299,11 @@ async def _dispatch_password_reset(
     # URL than the one stored in password_resets. Recovery could never
     # complete by construction.
     background_tasks.add_task(
-        send_password_reset_email_task, user.email, reset_token, redirect_base
+        send_password_reset_email_task,
+        user.email,
+        reset_token,
+        redirect_base,
+        locale=getattr(user, "locale", None),
     )
 
 
@@ -1729,7 +1736,10 @@ async def resend_verification_email(
 
     # Send email in background
     background_tasks.add_task(
-        send_verification_email_task, current_user.email, verification_token
+        send_verification_email_task,
+        current_user.email,
+        verification_token,
+        locale=getattr(current_user, "locale", None),
     )
 
     return {"message": "Verification email sent"}
@@ -1786,7 +1796,11 @@ async def send_magic_link(
 
     # Send email in background
     background_tasks.add_task(
-        send_magic_link_email_task, user.email, magic_token, safe_redirect_url
+        send_magic_link_email_task,
+        user.email,
+        magic_token,
+        safe_redirect_url,
+        locale=getattr(user, "locale", None),
     )
 
     return {"message": "Magic link sent to email"}

--- a/apps/api/app/services/email_i18n.py
+++ b/apps/api/app/services/email_i18n.py
@@ -1,0 +1,242 @@
+"""Locale resolution and localized strings for transactional email.
+
+The mail path had no notion of language at all: subjects were string literals
+at each call site and every template was English-only. That made English the
+first thing every recipient saw, regardless of who they are — which is wrong
+for a user base that is predominantly Mexican.
+
+Three moving parts live here so the email service stays about *sending*:
+
+1. `resolve_locale` — per-recipient language with an explicit precedence.
+2. `subject_for`   — the subject line, keyed by message rather than hardcoded.
+3. `template_candidates` — the localized template name, with English as the
+   fallback so a locale that has not been translated yet still sends a real
+   message instead of failing.
+
+Locale tags are normalized to a bare language subtag (`es-MX`, `es_419`,
+`ES-mx` all mean `es`), because a translation set is per-language; regional
+variants share it. The Spanish copy is written for es-MX specifically.
+"""
+
+from typing import Any, Dict, List, Optional
+
+from jinja2 import Environment, FileSystemLoader, pass_context
+
+# Languages that have a full translation set. Order is not significant.
+SUPPORTED_LOCALES: tuple = ("es", "en")
+
+# English is the fallback for any string a locale has not translated yet —
+# never an empty body.
+FALLBACK_LOCALE = "en"
+
+# Client-facing mail defaults to Spanish: this platform's users are
+# predominantly Mexican, so English is the wrong default even though it was
+# the only option before. Overridable per-deployment via DEFAULT_EMAIL_LOCALE
+# and per-message via the `locale` argument.
+DEFAULT_LOCALE = "es"
+
+
+def normalize_locale(raw: Any) -> Optional[str]:
+    """Reduce a locale tag to a supported bare language subtag.
+
+    Accepts the shapes that actually show up in stored user profiles and
+    Accept-Language headers: `es`, `es-MX`, `es_MX`, `ES-mx`, `es-419`.
+    Returns None for anything unsupported or unparseable so callers can fall
+    through to the next precedence tier rather than silently picking a
+    language nobody asked for.
+    """
+    if not raw or not isinstance(raw, str):
+        return None
+    # Split on both separators; BCP 47 uses "-", POSIX-style profiles use "_".
+    language = raw.strip().replace("_", "-").split("-", 1)[0].lower()
+    if language in SUPPORTED_LOCALES:
+        return language
+    return None
+
+
+def resolve_locale(
+    explicit: Any = None,
+    user: Any = None,
+    default: Any = None,
+) -> str:
+    """Resolve the language for one recipient, highest precedence first.
+
+    1. `explicit` — what the caller passed. A caller that knows the audience
+       (an invitation addressed to a specific person, an operator-triggered
+       resend) always wins.
+    2. `user.locale` — the recipient's stored preference. `users.locale`
+       exists on the model and in the schema, so this is a real column and
+       not an aspiration; it is nullable and unset for most rows today.
+    3. `default` — the deployment default (DEFAULT_EMAIL_LOCALE).
+    4. `DEFAULT_LOCALE` — es-MX.
+
+    Each tier is skipped when it is absent OR unsupported, so a stored
+    `fr-CA` does not shadow the configured default with an untranslated
+    language.
+    """
+    for candidate in (
+        explicit,
+        getattr(user, "locale", None) if user is not None else None,
+        default,
+    ):
+        normalized = normalize_locale(candidate)
+        if normalized:
+            return normalized
+    return DEFAULT_LOCALE
+
+
+def template_candidates(template_name: str, locale: str) -> List[str]:
+    """Template names to try, most specific first.
+
+    Localized templates live in a per-language subdirectory
+    (`templates/email/es/magic_link.html`); English stays at the root, where
+    it already is. The loader is rooted at `templates/email`, so a template
+    under `es/` still resolves `{% extends "base.html" %}` to the one shared
+    base — the subdirectory changes nothing about inheritance.
+
+    English is always appended last: a message with no translation yet sends
+    in English rather than raising.
+    """
+    if locale == FALLBACK_LOCALE:
+        return [template_name]
+    return [f"{locale}/{template_name}", template_name]
+
+
+# --------------------------------------------------------------------------
+# Subjects
+#
+# Keyed by message so the call sites stop carrying English string literals.
+# es-MX business register: usted-form, "correo electrónico", "iniciar sesión".
+# --------------------------------------------------------------------------
+SUBJECTS: Dict[str, Dict[str, str]] = {
+    "verification": {
+        "en": "Verify your Janua account",
+        "es": "Verifique su cuenta de Janua",
+    },
+    "password_reset": {
+        "en": "Reset your Janua password",
+        "es": "Restablezca su contraseña de Janua",
+    },
+    "magic_link": {
+        "en": "Your Janua sign-in link",
+        "es": "Su enlace de acceso a Janua",
+    },
+    "welcome": {
+        "en": "Welcome to Janua!",
+        "es": "Le damos la bienvenida a Janua",
+    },
+    "invitation": {
+        "en": "You're invited to join {organization_name} on Janua",
+        "es": "Le invitaron a unirse a {organization_name} en Janua",
+    },
+}
+
+
+def subject_for(message_key: str, locale: Optional[str] = None, **fields: Any) -> str:
+    """Return the localized subject for a message.
+
+    Falls back to English when the locale has no translation for this
+    message, and to the message key itself only if the key is unknown — an
+    unknown key is a programming error, and a visible one beats an email with
+    an empty subject line.
+    """
+    per_locale = SUBJECTS.get(message_key)
+    if not per_locale:
+        return message_key
+    resolved = normalize_locale(locale) or FALLBACK_LOCALE
+    template = per_locale.get(resolved) or per_locale[FALLBACK_LOCALE]
+    if fields:
+        try:
+            return template.format(**fields)
+        except (KeyError, IndexError):
+            return template
+    return template
+
+
+# --------------------------------------------------------------------------
+# Shared chrome
+#
+# base.html's header and footer are outside every {% block content %}, so
+# localized bodies would otherwise sit inside an English frame. These strings
+# are exposed to templates as `t('key')` rather than duplicating base.html.
+# --------------------------------------------------------------------------
+CHROME: Dict[str, Dict[str, str]] = {
+    "en": {
+        "tagline": "Secure Identity Platform",
+        "rights": "All rights reserved.",
+        "privacy": "Privacy Policy",
+        "terms": "Terms of Service",
+        "support": "Support",
+        "why_received": "You received this email because you have an account with Janua.",
+        "location": "Innovaciones MADFAM (MADFAM) • Mexico City, Mexico",
+    },
+    "es": {
+        "tagline": "Plataforma de identidad segura",
+        "rights": "Todos los derechos reservados.",
+        "privacy": "Aviso de privacidad",
+        "terms": "Términos del servicio",
+        "support": "Soporte",
+        "why_received": "Recibió este correo electrónico porque tiene una cuenta en Janua.",
+        "location": "Innovaciones MADFAM (MADFAM) • Ciudad de México, México",
+    },
+}
+
+
+def chrome_string(key: str, locale: Optional[str] = None) -> str:
+    """Look up a shared header/footer string.
+
+    Defaults to English when no locale is in scope so that rendering a
+    template directly — without going through the service, as the template
+    guards in the test suite do — produces exactly the frame it produced
+    before localization existed.
+    """
+    resolved = normalize_locale(locale) or FALLBACK_LOCALE
+    return CHROME.get(resolved, CHROME[FALLBACK_LOCALE]).get(
+        key, CHROME[FALLBACK_LOCALE].get(key, "")
+    )
+
+
+def html_lang(locale: Optional[str] = None) -> str:
+    """The `lang` attribute for <html>, so screen readers and clients that
+    offer translation see the real language of the message."""
+    resolved = normalize_locale(locale) or FALLBACK_LOCALE
+    return "es-MX" if resolved == "es" else "en"
+
+
+@pass_context
+def _chrome_global(ctx, key: str) -> str:
+    """`t('key')` inside a template: the shared header/footer strings.
+
+    Context-aware so base.html renders in the same language as the body
+    without every template forwarding the locale explicitly. With no locale in
+    context — a template rendered directly rather than through a service —
+    this yields the English frame the templates had before localization.
+    """
+    return chrome_string(key, ctx.get("locale"))
+
+
+@pass_context
+def _lang_global(ctx) -> str:
+    """`lang()` inside a template: the <html lang> attribute value."""
+    return html_lang(ctx.get("locale"))
+
+
+def install_template_globals(env: Environment) -> Environment:
+    """Register the globals `templates/email/base.html` depends on.
+
+    base.html calls `t()` and `lang()`, and Jinja raises on calling an
+    undefined name — so any environment that loads these templates must have
+    them. Three services build their own environment over this same
+    directory; routing them all through `build_email_environment` keeps that
+    from being something a fourth one can forget.
+    """
+    env.globals["t"] = _chrome_global
+    env.globals["lang"] = _lang_global
+    return env
+
+
+def build_email_environment(template_dir: Any) -> Environment:
+    """The Jinja environment for `templates/email`, globals included."""
+    return install_template_globals(
+        Environment(loader=FileSystemLoader(template_dir), autoescape=True)
+    )

--- a/apps/api/app/services/email_service.py
+++ b/apps/api/app/services/email_service.py
@@ -16,9 +16,15 @@ from typing import Any, Dict, Optional
 import httpx
 import redis.asyncio as redis
 import structlog
-from jinja2 import Environment, FileSystemLoader
 
 from app.config import settings
+from app.services.email_i18n import (
+    FALLBACK_LOCALE,
+    build_email_environment,
+    resolve_locale,
+    subject_for,
+    template_candidates,
+)
 
 logger = structlog.get_logger()
 
@@ -39,12 +45,22 @@ class EmailService:
     def __init__(self, redis_client: Optional[redis.Redis] = None):
         self.redis_client = redis_client
         self.template_dir = Path(__file__).parent.parent / "templates" / "email"
-        self.jinja_env = Environment(loader=FileSystemLoader(self.template_dir), autoescape=True)
+        # Shared factory: base.html's localized chrome sits outside every
+        # content block, so the globals backing it must exist on every
+        # environment that loads this directory.
+        self.jinja_env = build_email_environment(self.template_dir)
 
     async def send_verification_email(
-        self, email: str, user_name: str = None, user_id: str = None
+        self,
+        email: str,
+        user_name: str = None,
+        user_id: str = None,
+        locale: Optional[str] = None,
+        user: Any = None,
     ) -> str:
         """Send email verification email and return verification token"""
+
+        recipient_locale = resolve_locale(locale, user=user, default=self._default_locale())
 
         # Generate verification token
         verification_token = self._generate_verification_token()
@@ -81,9 +97,9 @@ class EmailService:
         }
 
         # Render email template
-        subject = "Verify your Janua account"
-        html_content = self._render_template("verification.html", template_data)
-        text_content = self._render_template("verification.txt", template_data)
+        subject = subject_for("verification", recipient_locale)
+        html_content = self._render_template("verification.html", template_data, recipient_locale)
+        text_content = self._render_template("verification.txt", template_data, recipient_locale)
 
         # Send email
         success = await self._send_email(
@@ -144,6 +160,8 @@ class EmailService:
         reset_token: str,
         user_name: str = None,
         redirect_base: str = None,
+        locale: Optional[str] = None,
+        user: Any = None,
     ) -> str:
         """Send password reset email for an already-issued token.
 
@@ -152,6 +170,8 @@ class EmailService:
         generated its own token here, so the emailed link could never match
         the stored one.
         """
+
+        recipient_locale = resolve_locale(locale, user=user, default=self._default_locale())
 
         # Mirror to Redis for observability (audit 2026-04-23 M2: JSON).
         if self.redis_client:
@@ -188,9 +208,9 @@ class EmailService:
         }
 
         # Render email template
-        subject = "Reset your Janua password"
-        html_content = self._render_template("password_reset.html", template_data)
-        text_content = self._render_template("password_reset.txt", template_data)
+        subject = subject_for("password_reset", recipient_locale)
+        html_content = self._render_template("password_reset.html", template_data, recipient_locale)
+        text_content = self._render_template("password_reset.txt", template_data, recipient_locale)
 
         # Send email
         success = await self._send_email(
@@ -204,8 +224,16 @@ class EmailService:
             logger.error("Failed to send password reset email", email=_redact_email(email))
             raise Exception("Failed to send password reset email")
 
-    async def send_welcome_email(self, email: str, user_name: str = None) -> bool:
+    async def send_welcome_email(
+        self,
+        email: str,
+        user_name: str = None,
+        locale: Optional[str] = None,
+        user: Any = None,
+    ) -> bool:
         """Send welcome email to new user"""
+
+        recipient_locale = resolve_locale(locale, user=user, default=self._default_locale())
 
         template_data = {
             "user_name": user_name or email.split("@")[0],
@@ -217,9 +245,9 @@ class EmailService:
         }
 
         # Render email template
-        subject = "Welcome to Janua!"
-        html_content = self._render_template("welcome.html", template_data)
-        text_content = self._render_template("welcome.txt", template_data)
+        subject = subject_for("welcome", recipient_locale)
+        html_content = self._render_template("welcome.html", template_data, recipient_locale)
+        text_content = self._render_template("welcome.txt", template_data, recipient_locale)
 
         # Send email
         success = await self._send_email(
@@ -241,40 +269,105 @@ class EmailService:
         token_hash = hashlib.sha256(random_bytes).hexdigest()
         return token_hash[:64]  # 64-char hex string
 
-    def _render_template(self, template_name: str, data: Dict[str, Any]) -> str:
-        """Render email template with data.
+    def _render_template(
+        self, template_name: str, data: Dict[str, Any], locale: Optional[str] = None
+    ) -> str:
+        """Render email template with data, in the recipient's language.
 
         Injects the context every template inherits from base.html. Jinja
         renders an undefined variable as empty string, so a missing value here
         does not fail loudly — it silently ships a mail with a blank footer or,
         worse, a blank button href. Callers supply the `*_link` names the
         templates actually reference.
+
+        `template_name` is always the English name; the localized file is
+        selected here. `select_template` walks the candidates in order and
+        takes the first that exists, so a language with no translation for
+        this particular message still sends — in English — rather than
+        raising into the fallback text below.
         """
+        resolved_locale = resolve_locale(locale, default=self._default_locale())
         try:
-            template = self.jinja_env.get_template(template_name)
+            template = self.jinja_env.select_template(
+                template_candidates(template_name, resolved_locale)
+            )
+            # Chrome follows the template that actually won, not the language
+            # that was asked for. When a message has no translation yet, the
+            # English body is selected — and an English body inside a Spanish
+            # header and footer is a worse email than a consistently English
+            # one. Keeps "body language == frame language" always true.
+            body_locale = (
+                resolved_locale
+                if (template.name or "").startswith(f"{resolved_locale}/")
+                else FALLBACK_LOCALE
+            )
             context = {
                 "current_year": datetime.utcnow().year,
                 "subject": data.get("subject", "Janua"),
+                "locale": body_locale,
                 **data,
             }
             return template.render(**context)
         except Exception as e:
             logger.error(
-                "Template rendering failed", template=template_name, error_type=type(e).__name__
+                "Template rendering failed",
+                template=template_name,
+                locale=resolved_locale,
+                error_type=type(e).__name__,
             )
-            # Fallback to simple text
-            if "verification" in template_name:
-                return f"Please verify your email by clicking: {data.get('verification_url', '')}"
-            elif "magic_link" in template_name:
-                return f"Sign in to Janua by clicking: {data.get('magic_url', '')}"
-            elif "password_reset" in template_name:
-                return f"Reset your password by clicking: {data.get('reset_url', '')}"
-            elif "welcome" in template_name:
-                return f"Welcome to Janua, {data.get('user_name', 'there')}!"
-            return "Email content unavailable"
+            return self._fallback_body(template_name, data, resolved_locale)
+
+    @staticmethod
+    def _default_locale() -> Optional[str]:
+        """The deployment-wide default, read at call time so tests and
+        per-environment overrides of DEFAULT_EMAIL_LOCALE take effect."""
+        return getattr(settings, "DEFAULT_EMAIL_LOCALE", None)
+
+    @staticmethod
+    def _fallback_body(template_name: str, data: Dict[str, Any], locale: str) -> str:
+        """Last-resort plain text when the template itself failed to render.
+
+        Localized too: a recipient hitting the degraded path is no more
+        likely to read English than one hitting the happy path.
+        """
+        spanish = locale == "es"
+        if "verification" in template_name:
+            url = data.get("verification_url", "")
+            return (
+                f"Verifique su correo electrónico aquí: {url}"
+                if spanish
+                else f"Please verify your email by clicking: {url}"
+            )
+        if "magic_link" in template_name:
+            url = data.get("magic_url", "")
+            return (
+                f"Inicie sesión en Janua aquí: {url}"
+                if spanish
+                else f"Sign in to Janua by clicking: {url}"
+            )
+        if "password_reset" in template_name:
+            url = data.get("reset_url", "")
+            return (
+                f"Restablezca su contraseña aquí: {url}"
+                if spanish
+                else f"Reset your password by clicking: {url}"
+            )
+        if "welcome" in template_name:
+            name = data.get("user_name", "there")
+            return (
+                f"Le damos la bienvenida a Janua, {name}."
+                if spanish
+                else f"Welcome to Janua, {name}!"
+            )
+        return "Contenido no disponible" if spanish else "Email content unavailable"
 
     async def send_magic_link_email(
-        self, email: str, magic_token: str, redirect_url: Optional[str] = None
+        self,
+        email: str,
+        magic_token: str,
+        redirect_url: Optional[str] = None,
+        locale: Optional[str] = None,
+        user: Any = None,
     ) -> bool:
         """Send a passwordless sign-in link.
 
@@ -283,6 +376,7 @@ class EmailService:
         magic token for a session. The callback then forwards to redirect_url
         (already allowlist-validated when the link was requested).
         """
+        recipient_locale = resolve_locale(locale, user=user, default=self._default_locale())
         callback = f"{settings.API_BASE_URL or settings.BASE_URL}/api/v1/auth/magic-link/callback"
         magic_url = f"{callback}?token={magic_token}"
 
@@ -295,9 +389,9 @@ class EmailService:
             "support_email": settings.SUPPORT_EMAIL or "support@janua.dev",
         }
 
-        subject = "Your Janua sign-in link"
-        html_content = self._render_template("magic_link.html", template_data)
-        text_content = self._render_template("magic_link.txt", template_data)
+        subject = subject_for("magic_link", recipient_locale)
+        html_content = self._render_template("magic_link.html", template_data, recipient_locale)
+        text_content = self._render_template("magic_link.txt", template_data, recipient_locale)
 
         sent = await self._send_email(
             to_email=email, subject=subject, html_content=html_content, text_content=text_content
@@ -413,7 +507,10 @@ def get_email_service(redis_client: Optional[redis.Redis] = None) -> EmailServic
 
 
 async def send_password_reset_email_task(
-    email: str, reset_token: str, redirect_base: Optional[str] = None
+    email: str,
+    reset_token: str,
+    redirect_base: Optional[str] = None,
+    locale: Optional[str] = None,
 ) -> None:
     """Background-task entrypoint for the forgot-password flow.
 
@@ -421,11 +518,15 @@ async def send_password_reset_email_task(
     never raises — a mail failure must not surface into the request path.
     Without SMTP_HOST configured, _send_email already degrades to a logged
     no-op; the warning below makes that state visible instead of silent.
+
+    `locale` is read off the User row by the router: a background task has no
+    DB session of its own, so the recipient's stored language has to be
+    resolved while the request still holds one.
     """
     try:
         service = EmailService()
         sent = await service.send_password_reset_email(
-            email, reset_token, redirect_base=redirect_base
+            email, reset_token, redirect_base=redirect_base, locale=locale
         )
         if not sent:
             logger.warning(
@@ -437,7 +538,10 @@ async def send_password_reset_email_task(
 
 
 async def send_magic_link_email_task(
-    email: str, magic_token: str, redirect_url: Optional[str] = None
+    email: str,
+    magic_token: str,
+    redirect_url: Optional[str] = None,
+    locale: Optional[str] = None,
 ) -> None:
     """Background-task entrypoint for the magic-link flow.
 
@@ -450,7 +554,7 @@ async def send_magic_link_email_task(
     """
     try:
         service = EmailService()
-        sent = await service.send_magic_link_email(email, magic_token, redirect_url)
+        sent = await service.send_magic_link_email(email, magic_token, redirect_url, locale=locale)
         if not sent:
             logger.warning(
                 "Magic link email NOT sent — the recipient will never receive a sign-in link",
@@ -461,7 +565,10 @@ async def send_magic_link_email_task(
 
 
 async def send_verification_email_task(
-    email: str, verification_token: str, user_name: Optional[str] = None
+    email: str,
+    verification_token: str,
+    user_name: Optional[str] = None,
+    locale: Optional[str] = None,
 ) -> None:
     """Background-task entrypoint for email verification.
 
@@ -472,21 +579,30 @@ async def send_verification_email_task(
     """
     try:
         service = EmailService()
+        recipient_locale = resolve_locale(locale, default=service._default_locale())
         verification_url = (
             f"{settings.FRONTEND_URL}/auth/verify-email?token={verification_token}"
         )
         template_data = {
             "user_name": user_name or email.split("@")[0],
             "verification_url": verification_url,
+            # verification.html renders the button as href="{{ verification_link }}".
+            # This path passed only *_url, so the one email every new account
+            # receives shipped with an empty href.
+            "verification_link": verification_url,
             "base_url": settings.BASE_URL,
             "company_name": "Janua",
             "support_email": settings.SUPPORT_EMAIL or "support@janua.dev",
         }
         sent = await service._send_email(
             to_email=email,
-            subject="Verify your Janua email address",
-            html_content=service._render_template("verification.html", template_data),
-            text_content=service._render_template("verification.txt", template_data),
+            subject=subject_for("verification", recipient_locale),
+            html_content=service._render_template(
+                "verification.html", template_data, recipient_locale
+            ),
+            text_content=service._render_template(
+                "verification.txt", template_data, recipient_locale
+            ),
         )
         if not sent:
             logger.warning(

--- a/apps/api/app/services/enhanced_email_service.py
+++ b/apps/api/app/services/enhanced_email_service.py
@@ -15,11 +15,11 @@ from typing import Any, Dict, List, Optional
 
 import redis.asyncio as redis
 import structlog
-from jinja2 import Environment, FileSystemLoader
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Content, Email, Mail, To
 
 from app.config import settings
+from app.services.email_i18n import build_email_environment
 
 logger = structlog.get_logger()
 
@@ -64,7 +64,10 @@ class EnhancedEmailService:
     def __init__(self, redis_client: Optional[redis.Redis] = None):
         self.redis_client = redis_client
         self.template_dir = Path(__file__).parent.parent / "templates" / "email"
-        self.jinja_env = Environment(loader=FileSystemLoader(self.template_dir), autoescape=True)
+        # Shared factory: templates/email/base.html renders localized chrome
+        # via t()/lang(), which must be registered on every environment
+        # that loads this directory.
+        self.jinja_env = build_email_environment(self.template_dir)
 
         # Email provider configuration with priority order
         self.providers = self._configure_providers()

--- a/apps/api/app/services/resend_email_service.py
+++ b/apps/api/app/services/resend_email_service.py
@@ -13,9 +13,9 @@ from typing import Any, Dict, List, Optional
 
 import redis.asyncio as redis
 import structlog
-from jinja2 import Environment, FileSystemLoader
 
 from app.config import settings
+from app.services.email_i18n import build_email_environment
 
 # Optional import for resend - gracefully handle if not installed
 try:
@@ -64,7 +64,10 @@ class ResendEmailService:
     def __init__(self, redis_client: Optional[redis.Redis] = None):
         self.redis_client = redis_client
         self.template_dir = Path(__file__).parent.parent / "templates" / "email"
-        self.jinja_env = Environment(loader=FileSystemLoader(self.template_dir), autoescape=True)
+        # Shared factory: templates/email/base.html renders localized chrome
+        # via t()/lang(), which must be registered on every environment
+        # that loads this directory.
+        self.jinja_env = build_email_environment(self.template_dir)
 
         # Initialize Resend client
         if settings.RESEND_API_KEY:

--- a/apps/api/app/templates/email/base.html
+++ b/apps/api/app/templates/email/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ lang() }}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -107,7 +107,7 @@
                     </svg>
                 </div>
                 <h1 style="margin: 0; font-size: 24px; font-weight: 600;">Janua</h1>
-                <p style="margin: 5px 0 0 0; opacity: 0.9; font-size: 14px;">Secure Identity Platform</p>
+                <p style="margin: 5px 0 0 0; opacity: 0.9; font-size: 14px;">{{ t('tagline') }}</p>
             </div>
             
             <div class="content">
@@ -117,17 +117,17 @@
             
             <div class="footer">
                 <p style="margin: 0 0 10px 0;">
-                    © {{ current_year }} Janua by Innovaciones MADFAM. All rights reserved.
+                    © {{ current_year }} Janua by Innovaciones MADFAM. {{ t('rights') }}
                 </p>
                 <p style="margin: 0 0 10px 0;">
-                    <a href="https://janua.dev/privacy">Privacy Policy</a> • 
-                    <a href="https://janua.dev/terms">Terms of Service</a> • 
-                    <a href="https://janua.dev/support">Support</a>
+                    <a href="https://janua.dev/privacy">{{ t('privacy') }}</a> •
+                    <a href="https://janua.dev/terms">{{ t('terms') }}</a> •
+                    <a href="https://janua.dev/support">{{ t('support') }}</a>
                 </p>
                 <p style="margin: 0; color: #9ca3af; font-size: 11px;">
-                    You received this email because you have an account with Janua.
+                    {{ t('why_received') }}
                     <br>
-                    Innovaciones MADFAM (MADFAM) • Mexico City, Mexico
+                    {{ t('location') }}
                 </p>
             </div>
         </div>

--- a/apps/api/app/templates/email/es/invitation.html
+++ b/apps/api/app/templates/email/es/invitation.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h1 style="margin: 0 0 20px 0; font-size: 28px; color: #1f2937;">Le invitaron a colaborar</h1>
+
+<p style="margin: 0 0 15px 0; font-size: 16px; color: #4b5563;">
+    Hola:
+</p>
+
+<p style="margin: 0 0 15px 0; font-size: 16px; color: #4b5563;">
+    <strong>{{ inviter_name }}</strong> le invitó a unirse a <strong>{{ organization_name }}</strong> en Janua.
+</p>
+
+<div class="info" style="background-color: #dbeafe; border-left: 4px solid #3b82f6; padding: 15px; margin: 20px 0; border-radius: 4px;">
+    <p style="margin: 0 0 10px 0; font-weight: 600; color: #1e40af;">Detalles de la invitación</p>
+    <p style="margin: 0 0 5px 0; font-size: 14px; color: #1f2937;"><strong>Rol:</strong> {{ role }}</p>
+    {% if teams %}
+    <p style="margin: 0; font-size: 14px; color: #1f2937;"><strong>Equipos:</strong> {{ teams|join(', ') }}</p>
+    {% endif %}
+</div>
+
+<p style="text-align: center; margin: 30px 0;">
+    <a href="{{ invitation_url }}" class="button" style="display: inline-block; padding: 14px 32px; background-color: #3b82f6; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: 600; font-size: 16px;">Aceptar invitación</a>
+</p>
+
+<div class="warning" style="background-color: #fef3c7; border-left: 4px solid #f59e0b; padding: 15px; margin: 20px 0; border-radius: 4px;">
+    <p style="margin: 0; font-size: 14px; color: #92400e;">
+        <strong>⏰ Esta invitación expira el {{ expires_at }}</strong><br>
+        Le pedimos aceptarla antes de esa fecha.
+    </p>
+</div>
+
+<div style="margin-top: 40px; padding: 20px; background-color: #f9fafb; border-radius: 6px;">
+    <p style="margin: 0 0 10px 0; font-weight: 600; font-size: 14px; color: #1f2937;">¿Qué es Janua?</p>
+    <p style="margin: 0; font-size: 14px; color: #4b5563; line-height: 1.6;">
+        Janua es una plataforma de autenticación empresarial que ofrece administración segura de accesos,
+        integración con inicio de sesión único (SSO), autenticación de varios factores y funciones
+        completas de identidad de usuarios.
+    </p>
+</div>
+
+<p style="margin-top: 32px; font-size: 13px; color: #6b7280; line-height: 1.5;">
+    Si el botón anterior no funciona, copie y pegue esta dirección en su navegador:<br>
+    <span style="word-break: break-all; color: #3b82f6;">{{ invitation_url }}</span>
+</p>
+
+<p style="margin-top: 24px; font-size: 14px; color: #6b7280;">
+    ¿Tiene alguna duda? Escriba a <a href="mailto:{{ support_email }}" style="color: #3b82f6; text-decoration: none;">{{ support_email }}</a>
+</p>
+{% endblock %}

--- a/apps/api/app/templates/email/es/invitation.txt
+++ b/apps/api/app/templates/email/es/invitation.txt
@@ -1,0 +1,29 @@
+Le invitaron a unirse a {{ organization_name }}
+
+Hola:
+
+{{ inviter_name }} le invitó a unirse a {{ organization_name }} en Janua.
+
+DETALLES DE LA INVITACIÓN
+-------------------------
+Rol: {{ role }}
+{% if teams %}Equipos: {{ teams|join(', ') }}{% endif %}
+
+ACEPTAR LA INVITACIÓN
+---------------------
+Abra el siguiente enlace para aceptar su invitación:
+{{ invitation_url }}
+
+⏰ IMPORTANTE: esta invitación expira el {{ expires_at }}
+
+ACERCA DE JANUA
+---------------
+Janua es una plataforma de autenticación empresarial que ofrece administración
+segura de accesos, integración con inicio de sesión único (SSO), autenticación de
+varios factores y funciones completas de identidad de usuarios.
+
+¿Tiene alguna duda? Escríbanos a {{ support_email }}
+
+---
+Janua by Innovaciones MADFAM
+{{ base_url }}

--- a/apps/api/app/templates/email/es/magic_link.html
+++ b/apps/api/app/templates/email/es/magic_link.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2 style="color: #1f2937; margin: 0 0 20px 0;">Inicie sesión en Janua</h2>
+
+<p style="margin: 0 0 20px 0;">
+    Hola {{ user_name }}:
+</p>
+
+<p style="margin: 0 0 20px 0;">
+    Use el siguiente botón para iniciar sesión. No necesita contraseña: el enlace le da acceso directo.
+</p>
+
+<div style="text-align: center;">
+    <a href="{{ magic_link }}" class="button">Iniciar sesión</a>
+</div>
+
+<p style="margin: 20px 0 0 0; color: #6b7280; font-size: 14px;">
+    Este enlace funciona una sola vez y expira en 15 minutos.
+</p>
+
+<div class="warning">
+    <strong>⚠️ Aviso de seguridad</strong><br>
+    Si usted no solicitó iniciar sesión, puede ignorar este correo electrónico: el enlace
+    está ligado a su dirección y no hace nada hasta que se abre. Nunca lo reenvíe, ya que
+    cualquier persona que lo tenga podría entrar a su cuenta hasta que el enlace expire.
+</div>
+
+<p style="margin: 20px 0 0 0; color: #6b7280; font-size: 12px;">
+    Si el botón no funciona, copie esta dirección en su navegador:<br>
+    {{ magic_link }}
+</p>
+{% endblock %}

--- a/apps/api/app/templates/email/es/magic_link.txt
+++ b/apps/api/app/templates/email/es/magic_link.txt
@@ -1,0 +1,16 @@
+Hola {{ user_name }}:
+
+Inicie sesión en Janua con este enlace:
+{{ magic_url }}
+
+Este enlace funciona una sola vez y expira en 15 minutos.
+
+Si usted no solicitó iniciar sesión, puede ignorar este correo electrónico. Nunca
+reenvíe este enlace: cualquier persona que lo tenga podría entrar a su cuenta hasta
+que expire.
+
+¿Necesita ayuda? Escríbanos a {{ support_email }}
+
+---
+Equipo Janua
+{{ base_url }}

--- a/apps/api/app/templates/email/es/password_reset.html
+++ b/apps/api/app/templates/email/es/password_reset.html
@@ -1,0 +1,50 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2 style="color: #1f2937; margin: 0 0 20px 0;">Restablezca su contraseña</h2>
+
+<p style="margin: 0 0 20px 0;">
+    Hola {{ user_name }}:
+</p>
+
+<p style="margin: 0 0 20px 0;">
+    Recibimos una solicitud para restablecer la contraseña de su cuenta de Janua. Si usted hizo esta solicitud, use el código que aparece abajo o haga clic en el botón para crear una contraseña nueva.
+</p>
+
+{% if reset_code %}
+<div class="code-box">
+    <p style="margin: 0 0 10px 0; color: #6b7280; font-size: 14px;">
+        Su código para restablecer la contraseña:
+    </p>
+    <div class="code">{{ reset_code }}</div>
+    <p style="margin: 10px 0 0 0; color: #6b7280; font-size: 12px;">
+        Este código expira en 30 minutos
+    </p>
+</div>
+{% endif %}
+
+<div style="text-align: center;">
+    <a href="{{ reset_link }}" class="button">Restablecer contraseña</a>
+</div>
+
+<div class="warning">
+    <strong>⚠️ Aviso de seguridad</strong><br>
+    Si usted no solicitó restablecer su contraseña, es posible que alguien esté intentando acceder a su cuenta. Le recomendamos:
+    <ul style="margin: 10px 0 0 0; padding-left: 20px;">
+        <li>Cambiar su contraseña de inmediato</li>
+        <li>Activar la autenticación de dos factores</li>
+        <li>Revisar la actividad reciente de su cuenta</li>
+    </ul>
+</div>
+
+<p style="margin: 20px 0 0 0; color: #6b7280; font-size: 14px;">
+    Por seguridad, este enlace expira en 30 minutos. Si necesita un enlace nuevo, puede solicitarlo desde la página de inicio de sesión.
+</p>
+
+<p style="margin: 20px 0 0 0; color: #6b7280; font-size: 14px;">
+    <strong>Detalles de la solicitud:</strong><br>
+    Dirección IP: {{ request_ip }}<br>
+    Navegador: {{ request_browser }}<br>
+    Fecha y hora: {{ request_time }}
+</p>
+{% endblock %}

--- a/apps/api/app/templates/email/es/password_reset.txt
+++ b/apps/api/app/templates/email/es/password_reset.txt
@@ -1,0 +1,17 @@
+Hola {{ user_name }}:
+
+Recibimos una solicitud para restablecer la contraseña de su cuenta de Janua.
+
+Restablezca su contraseña con este enlace:
+{{ reset_url }}
+
+Este enlace expira en 1 hora.
+
+Si usted no solicitó restablecer su contraseña, puede ignorar este correo
+electrónico. Su contraseña no se modificará.
+
+¿Necesita ayuda? Escríbanos a {{ support_email }}
+
+---
+Equipo Janua
+{{ base_url }}

--- a/apps/api/app/templates/email/es/verification.html
+++ b/apps/api/app/templates/email/es/verification.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2 style="color: #1f2937; margin: 0 0 20px 0;">Verifique su correo electrónico</h2>
+
+<p style="margin: 0 0 20px 0;">
+    Hola {{ user_name }}:
+</p>
+
+<p style="margin: 0 0 20px 0;">
+    Le damos la bienvenida a Janua. Verifique su dirección de correo electrónico para terminar de configurar su cuenta y acceder a todas las funciones.
+</p>
+
+{% if verification_code %}
+<div class="code-box">
+    <p style="margin: 0 0 10px 0; color: #6b7280; font-size: 14px;">
+        Su código de verificación:
+    </p>
+    <div class="code">{{ verification_code }}</div>
+    <p style="margin: 10px 0 0 0; color: #6b7280; font-size: 12px;">
+        Este código expira en 15 minutos
+    </p>
+</div>
+{% endif %}
+
+<p style="margin: 0 0 20px 0; text-align: center;">
+    O haga clic en el siguiente botón para verificar su correo electrónico:
+</p>
+
+<div style="text-align: center;">
+    <a href="{{ verification_link }}" class="button">Verificar correo electrónico</a>
+</div>
+
+<div class="info">
+    <strong>¿Por qué verificar su correo electrónico?</strong><br>
+    La verificación nos ayuda a proteger su cuenta y habilita funciones importantes como la recuperación de contraseña y las notificaciones de seguridad.
+</div>
+
+<p style="margin: 20px 0 0 0; color: #6b7280; font-size: 14px;">
+    Si usted no creó una cuenta en Janua, puede ignorar este correo electrónico.
+</p>
+{% endblock %}

--- a/apps/api/app/templates/email/es/verification.txt
+++ b/apps/api/app/templates/email/es/verification.txt
@@ -1,0 +1,21 @@
+Hola {{ user_name }}:
+
+Le damos la bienvenida a Janua. Verifique su dirección de correo electrónico para
+terminar de configurar su cuenta y acceder a todas las funciones.
+
+Verifique su correo electrónico con este enlace:
+{{ verification_url }}
+
+Este enlace de verificación expira en 24 horas.
+
+¿Por qué verificar su correo electrónico?
+La verificación nos ayuda a proteger su cuenta y habilita funciones importantes
+como la recuperación de contraseña y las notificaciones de seguridad.
+
+Si usted no creó una cuenta en Janua, puede ignorar este correo electrónico.
+
+¿Necesita ayuda? Escríbanos a {{ support_email }}
+
+---
+Equipo Janua
+{{ base_url }}

--- a/apps/api/app/templates/email/es/welcome.html
+++ b/apps/api/app/templates/email/es/welcome.html
@@ -1,0 +1,69 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2 style="color: #1f2937; margin: 0 0 20px 0;">Le damos la bienvenida a Janua 🎉</h2>
+
+<p style="margin: 0 0 20px 0;">
+    Hola {{ user_name }}:
+</p>
+
+<p style="margin: 0 0 20px 0;">
+    Su cuenta de Janua se creó correctamente. Ya forma parte de una plataforma de identidad segura en la que confían organizaciones de todo el mundo.
+</p>
+
+<div class="info">
+    <strong>Datos de su cuenta:</strong><br>
+    Correo electrónico: {{ user_email }}<br>
+    Organización: {{ organization_name }}<br>
+    Plan: {{ plan_name }}<br>
+    Identificador de cuenta: {{ account_id }}
+</div>
+
+<h3 style="color: #1f2937; margin: 30px 0 15px 0;">Primeros pasos en Janua</h3>
+
+<p style="margin: 0 0 20px 0;">Le sugerimos empezar por aquí para aprovechar Janua al máximo:</p>
+
+<ol style="margin: 0 0 20px 0; padding-left: 20px;">
+    <li style="margin-bottom: 10px;">
+        <strong>Active la autenticación de dos factores</strong><br>
+        <span style="color: #6b7280; font-size: 14px;">Añada una capa adicional de seguridad a su cuenta</span>
+    </li>
+    <li style="margin-bottom: 10px;">
+        <strong>Configure su organización</strong><br>
+        <span style="color: #6b7280; font-size: 14px;">Invite a su equipo y defina roles y permisos</span>
+    </li>
+    <li style="margin-bottom: 10px;">
+        <strong>Intégrelo con su aplicación</strong><br>
+        <span style="color: #6b7280; font-size: 14px;">Use nuestros SDK para añadir autenticación a sus aplicaciones</span>
+    </li>
+    <li style="margin-bottom: 10px;">
+        <strong>Habilite las llaves de acceso</strong><br>
+        <span style="color: #6b7280; font-size: 14px;">Configure el acceso sin contraseña para mayor seguridad</span>
+    </li>
+</ol>
+
+<div style="text-align: center;">
+    <a href="{{ dashboard_link }}" class="button">Ir al panel</a>
+</div>
+
+<div style="background-color: #f9fafb; border-radius: 6px; padding: 20px; margin: 30px 0;">
+    <h4 style="margin: 0 0 10px 0; color: #1f2937;">¿Necesita ayuda?</h4>
+    <p style="margin: 0 0 10px 0; font-size: 14px;">
+        Nuestro equipo está a sus órdenes:
+    </p>
+    <ul style="margin: 10px 0 0 0; padding-left: 20px; font-size: 14px;">
+        <li><a href="https://docs.janua.dev" style="color: #3b82f6;">Documentación</a> - Guías y referencia de la API</li>
+        <li><a href="https://janua.dev/support" style="color: #3b82f6;">Centro de soporte</a> - Reciba ayuda de nuestro equipo</li>
+        <li><a href="https://github.com/madfam-io/janua" style="color: #3b82f6;">GitHub</a> - Ejemplos de código y SDK</li>
+    </ul>
+</div>
+
+<p style="margin: 20px 0 0 0; color: #6b7280; font-size: 14px;">
+    Gracias por elegir Janua. Nos da gusto acompañarle en la seguridad de su plataforma.
+</p>
+
+<p style="margin: 20px 0 0 0;">
+    Saludos cordiales,<br>
+    <strong>El equipo de Janua</strong>
+</p>
+{% endblock %}

--- a/apps/api/app/templates/email/es/welcome.txt
+++ b/apps/api/app/templates/email/es/welcome.txt
@@ -1,0 +1,20 @@
+Hola {{ user_name }}:
+
+Le damos la bienvenida a Janua. Su cuenta se creó y se verificó correctamente.
+
+Comience por su panel:
+{{ dashboard_url }}
+
+Lo que puede hacer con Janua:
+• Administrar su identidad digital
+• Conectarse con aplicaciones de forma segura
+• Controlar sus datos y su privacidad
+
+¿Necesita ayuda para empezar? Consulte nuestra documentación o escríbanos a
+{{ support_email }}
+
+Nos da mucho gusto tenerle con nosotros.
+
+---
+Equipo Janua
+{{ base_url }}

--- a/apps/api/tests/unit/services/test_email_delivery.py
+++ b/apps/api/tests/unit/services/test_email_delivery.py
@@ -11,12 +11,44 @@ UI said "check your inbox" — so these tests assert the things a 200 cannot.
 """
 
 import inspect
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from app.services import email_service as email_module
+from app.services.email_i18n import resolve_locale, subject_for
 from app.services.email_service import EmailService
+
+# Messages with a full Spanish translation. Parametrizing from one list keeps
+# a newly localized template from being added without a guard.
+LOCALIZED_TEMPLATES = [
+    "magic_link",
+    "password_reset",
+    "verification",
+    "welcome",
+    "invitation",
+]
+
+# Enough context that every action button in every template has an href.
+TEMPLATE_CONTEXT = {
+    "user_name": "Ana",
+    "magic_link": "https://example.test/go?token=abc",
+    "magic_url": "https://example.test/go?token=abc",
+    "reset_link": "https://example.test/go?token=abc",
+    "reset_url": "https://example.test/go?token=abc",
+    "verification_link": "https://example.test/go?token=abc",
+    "verification_url": "https://example.test/go?token=abc",
+    "dashboard_link": "https://example.test/go?token=abc",
+    "dashboard_url": "https://example.test/go?token=abc",
+    "invitation_url": "https://example.test/go?token=abc",
+    "inviter_name": "Luis",
+    "organization_name": "Acme",
+    "role": "admin",
+    "expires_at": "2026-09-01",
+    "support_email": "soporte@janua.dev",
+    "base_url": "https://janua.dev",
+}
 
 
 class TestSendersExist:
@@ -87,7 +119,12 @@ class TestTemplatesRender:
     @pytest.mark.parametrize(
         "template",
         ["password_reset.html", "verification.html", "welcome.html", "magic_link.html",
-         "security_alert.html", "mfa_recovery.html"],
+         "security_alert.html", "mfa_recovery.html",
+         # Localized templates live in a subdirectory but inherit the same
+         # base.html — the loader root, not the template's own folder, is
+         # what `{% extends %}` resolves against.
+         "es/password_reset.html", "es/verification.html", "es/welcome.html",
+         "es/magic_link.html", "es/invitation.html"],
     )
     # Name kept short on purpose: a longer snake_case name here matched
     # TruffleHog's Lob API-key pattern and failed secret scanning (2026-08-13).
@@ -104,6 +141,13 @@ class TestTemplatesRender:
             ("password_reset.html", "reset_link"),
             ("verification.html", "verification_link"),
             ("magic_link.html", "magic_link"),
+            ("welcome.html", "dashboard_link"),
+            ("invitation.html", "invitation_url"),
+            ("es/password_reset.html", "reset_link"),
+            ("es/verification.html", "verification_link"),
+            ("es/magic_link.html", "magic_link"),
+            ("es/welcome.html", "dashboard_link"),
+            ("es/invitation.html", "invitation_url"),
         ],
     )
     def test_action_button_carries_a_real_href(self, template, link_var):
@@ -125,6 +169,204 @@ class TestTemplatesRender:
         assert "https://x.test/a" in rendered
         # base.html footer needs current_year; absent, Jinja renders "" silently.
         assert str(__import__("datetime").datetime.utcnow().year) in rendered
+
+
+class TestLocaleResolution:
+    """Spanish-speaking recipients were getting English as their first
+    touchpoint; there was no locale concept in the mail path at all."""
+
+    def test_explicit_argument_wins_over_stored_preference(self):
+        user = SimpleNamespace(locale="en")
+        assert resolve_locale("es-MX", user=user, default="en") == "es"
+
+    def test_stored_user_locale_wins_over_deployment_default(self):
+        """`users.locale` is a real nullable column on the User model."""
+        user = SimpleNamespace(locale="en")
+        assert resolve_locale(None, user=user, default="es") == "en"
+
+    def test_deployment_default_used_when_recipient_has_no_preference(self):
+        assert resolve_locale(None, user=SimpleNamespace(locale=None), default="en") == "en"
+
+    def test_falls_back_to_spanish_when_nothing_is_configured(self):
+        """es-MX is the default for client-facing mail: this platform's users
+        are predominantly Mexican."""
+        assert resolve_locale(None, None, None) == "es"
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [("es", "es"), ("es-MX", "es"), ("es_MX", "es"), ("ES-mx", "es"), ("es-419", "es"),
+         ("en", "en"), ("en-US", "en")],
+    )
+    def test_regional_variants_share_one_translation_set(self, raw, expected):
+        assert resolve_locale(raw) == expected
+
+    @pytest.mark.parametrize("raw", ["fr-CA", "de", "", None, "  ", 42, "zz"])
+    def test_unsupported_tag_does_not_shadow_the_next_tier(self, raw):
+        """An untranslated stored locale must fall through, not win — otherwise
+        it selects a language with no templates behind it."""
+        assert resolve_locale(raw, default="en") == "en"
+
+
+class TestTemplateLocalization:
+    """A Spanish recipient must get the Spanish body, an English one English."""
+
+    @pytest.mark.parametrize("template", LOCALIZED_TEMPLATES)
+    @pytest.mark.parametrize("extension", ["html", "txt"])
+    def test_es_recipient_body(self, template, extension):
+        service = EmailService()
+        rendered = service._render_template(f"{template}.{extension}", TEMPLATE_CONTEXT, "es-MX")
+        english = service._render_template(f"{template}.{extension}", TEMPLATE_CONTEXT, "en")
+        assert rendered != english
+        assert "Email content unavailable" not in rendered
+        # A machine-translation smell test: es-MX transactional copy is
+        # usted-form and says "correo electrónico", never "email".
+        assert "Hola" in rendered or "Le invitaron" in rendered
+
+    @pytest.mark.parametrize("template", LOCALIZED_TEMPLATES)
+    def test_localized_html_still_renders_a_real_href(self, template):
+        """The localized copies must not lose the action button the English
+        ones only just got."""
+        service = EmailService()
+        rendered = service._render_template(f"{template}.html", TEMPLATE_CONTEXT, "es")
+        assert 'href=""' not in rendered
+        assert "https://example.test/go?token=abc" in rendered
+        assert "<html" in rendered.lower()
+
+    def test_english_is_still_available(self):
+        """This is localization, not replacement."""
+        service = EmailService()
+        rendered = service._render_template("magic_link.html", TEMPLATE_CONTEXT, "en")
+        assert "Sign in to Janua" in rendered
+        assert 'lang="en"' in rendered
+
+    def test_untranslated_message_falls_back_to_english_rather_than_failing(self):
+        """security_alert has no Spanish copy yet; it must still send."""
+        service = EmailService()
+        rendered = service._render_template("security_alert.html", TEMPLATE_CONTEXT, "es")
+        assert "<html" in rendered.lower()
+        assert "Email content unavailable" not in rendered
+
+    def test_frame_language_matches_body_language(self):
+        """base.html's header/footer sit outside every content block. A
+        Spanish body inside an English frame — or vice versa — is a worse
+        email than a consistent one."""
+        service = EmailService()
+        spanish = service._render_template("magic_link.html", TEMPLATE_CONTEXT, "es")
+        assert 'lang="es-MX"' in spanish
+        assert "Plataforma de identidad segura" in spanish
+        assert "Secure Identity Platform" not in spanish
+
+        # Untranslated body → English body → English frame, not a mix.
+        fallback = service._render_template("security_alert.html", TEMPLATE_CONTEXT, "es")
+        assert 'lang="en"' in fallback
+        assert "Secure Identity Platform" in fallback
+
+    def test_default_locale_setting_drives_unspecified_sends(self):
+        service = EmailService()
+        with patch.object(email_module.settings, "DEFAULT_EMAIL_LOCALE", "en"):
+            assert "Sign in to Janua" in service._render_template(
+                "magic_link.html", TEMPLATE_CONTEXT
+            )
+        with patch.object(email_module.settings, "DEFAULT_EMAIL_LOCALE", "es"):
+            assert "Inicie sesión en Janua" in service._render_template(
+                "magic_link.html", TEMPLATE_CONTEXT
+            )
+
+    def test_template_globals_registered_on_every_shared_environment(self):
+        """base.html calls t() and lang(); Jinja raises on calling an
+        undefined name, so an environment over this directory without them
+        cannot render anything."""
+        from app.services.resend_email_service import ResendEmailService
+
+        for env in (EmailService().jinja_env, ResendEmailService().jinja_env):
+            assert "t" in env.globals
+            assert "lang" in env.globals
+
+
+class TestSubjectLocalization:
+    """Subjects were English string literals at each call site."""
+
+    @pytest.mark.parametrize(
+        "message_key", ["verification", "password_reset", "magic_link", "welcome", "invitation"]
+    )
+    def test_every_message_has_both_languages(self, message_key):
+        spanish = subject_for(message_key, "es", organization_name="Acme")
+        english = subject_for(message_key, "en", organization_name="Acme")
+        assert spanish and english and spanish != english
+
+    def test_subject_resolves_through_the_same_mechanism_as_the_body(self):
+        assert subject_for("magic_link", "es-MX") == subject_for("magic_link", "es")
+
+    def test_unknown_locale_gets_english_subject_not_an_empty_one(self):
+        assert subject_for("magic_link", "fr") == subject_for("magic_link", "en")
+
+    def test_invitation_subject_interpolates_the_organization(self):
+        assert "Acme" in subject_for("invitation", "es", organization_name="Acme")
+
+    @pytest.mark.asyncio
+    async def test_sender_passes_the_localized_subject_to_the_transport(self):
+        """The subject a recipient sees must follow the same locale as the
+        body — it is the only part visible before opening."""
+        service = EmailService()
+        with patch.object(service, "_send_email", new=AsyncMock(return_value=True)) as send:
+            await service.send_magic_link_email("a@b.test", "tok", locale="es-MX")
+        assert send.await_args.kwargs["subject"] == subject_for("magic_link", "es")
+
+        with patch.object(service, "_send_email", new=AsyncMock(return_value=True)) as send:
+            await service.send_magic_link_email("a@b.test", "tok", locale="en")
+        assert send.await_args.kwargs["subject"] == "Your Janua sign-in link"
+
+
+class TestSendersAcceptLocale:
+    """Routers resolve the recipient's language while they still hold a DB
+    session; background tasks have none of their own."""
+
+    @pytest.mark.parametrize(
+        "task_name",
+        ["send_magic_link_email_task", "send_password_reset_email_task",
+         "send_verification_email_task"],
+    )
+    def test_background_entrypoints_take_a_locale(self, task_name):
+        task = getattr(email_module, task_name)
+        assert "locale" in inspect.signature(task).parameters
+
+    @pytest.mark.parametrize(
+        "method_name",
+        ["send_magic_link_email", "send_password_reset_email", "send_verification_email",
+         "send_welcome_email"],
+    )
+    def test_senders_take_an_explicit_locale_and_a_user(self, method_name):
+        params = inspect.signature(getattr(EmailService, method_name)).parameters
+        assert "locale" in params
+        assert "user" in params
+
+    def test_routers_pass_the_recipient_locale(self):
+        """Without this the stored preference never reaches the mailer, and
+        every recipient silently gets the deployment default.
+
+        Read defensively: the password-reset dispatch is the one path a
+        locked-out user depends on, so a recipient object without the
+        attribute must not raise there.
+        """
+        from app.routers.v1 import auth
+
+        source = inspect.getsource(auth)
+        assert 'getattr(user, "locale", None)' in source
+        assert 'getattr(current_user, "locale", None)' in source
+        assert "user.locale," not in source  # the unguarded read
+
+    @pytest.mark.asyncio
+    async def test_verification_task_sends_a_button_href(self):
+        """This path passed only verification_url, while the template renders
+        href="{{ verification_link }}" — so the mail every new account gets
+        shipped with an empty button."""
+        with patch.object(email_module.EmailService, "_send_email",
+                          new=AsyncMock(return_value=True)) as send:
+            await email_module.send_verification_email_task("a@b.test", "tok123", locale="es")
+        html = send.await_args.kwargs["html_content"]
+        assert 'href=""' not in html
+        assert "tok123" in html
+        assert "Verifique su correo electrónico" in html
 
 
 class TestMagicLinkCallbackRoute:

--- a/apps/api/tests/unit/services/test_email_service.py
+++ b/apps/api/tests/unit/services/test_email_service.py
@@ -153,13 +153,16 @@ class TestRenderTemplate:
         assert "TestUser" in result
 
     def test_render_unknown_template_fallback(self, service):
-        """Test unknown template fallback."""
+        """Test unknown template fallback.
+
+        The degraded path is localized too: a recipient who hits it is no more
+        likely to read English than one who does not.
+        """
         data = {}
 
         with patch.object(service.jinja_env, "get_template", side_effect=Exception("Template not found")):
-            result = service._render_template("unknown.html", data)
-
-        assert result == "Email content unavailable"
+            assert service._render_template("unknown.html", data, "en") == "Email content unavailable"
+            assert service._render_template("unknown.html", data, "es") == "Contenido no disponible"
 
 
 class TestSendEmail:

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -33,7 +33,7 @@ images:
 - digest: sha256:345c74afb017f6de8cd3fb2c40d2cddefad45f6245b02675e53dee50453f75c8
   name: ghcr.io/madfam-org/janua-admin
   newName: ghcr.io/madfam-org/janua-admin
-- digest: sha256:bc6ba6dae6b665b2f3ab499a598768f7c3ec264bfe7f39159c5d7fb0cd38acee
+- digest: sha256:342070a7ea0537316da0a2b0fdf640708a170387b73c9cf4485d70352a023df2
   name: ghcr.io/madfam-org/janua-api
   newName: ghcr.io/madfam-org/janua-api
 - digest: sha256:0c381ecdc0abe7ae846b5f9c428c14afd0436e70daa5db6642d84388c42aef74


### PR DESCRIPTION
## Defect

The transactional mail path had no notion of language. Subjects were English string literals at each call site, and every template under `apps/api/app/templates/email/` was English-only. English was therefore the first thing every recipient saw regardless of who they are — and there was no way to change that: not per user, not per deployment.

## Design

`apps/api/app/services/email_i18n.py` holds three pieces so the email service stays about *sending*:

**`resolve_locale(explicit, user, default)`** — precedence, highest first:

1. `explicit` — what the caller passed
2. `user.locale` — the recipient's stored preference (`users.locale` is a real nullable `String(10)` column on the `User` model and in `000_init.py`; unset for most rows today)
3. `default` — `DEFAULT_EMAIL_LOCALE`, new setting
4. `es` — client-facing mail defaults to Spanish

Each tier is skipped when absent **or unsupported**, so a stored `fr-CA` falls through to the default rather than selecting a language with no templates behind it. Tags normalize to a bare language subtag — `es-MX`, `es_MX`, `ES-mx`, `es-419` all resolve to `es`, since a translation set is per-language and regional variants share it. The Spanish copy is written for es-MX specifically.

**`subject_for(key, locale)`** — subjects keyed by message rather than hardcoded at the call site, with an English fallback for an untranslated one.

**`template_candidates()`** — localized templates live in a per-language subdirectory (`templates/email/es/`); English stays at the root where it already was. `select_template` takes the first that exists, so a message with no translation yet still sends in English instead of raising. The loader is rooted at `templates/email`, so a template under `es/` still resolves `{% extends "base.html" %}` to the one shared base.

## Templates

Spanish `.html` and `.txt` for **`magic_link`** (the first touchpoint), **`password_reset`**, **`verification`**, **`welcome`** and **`invitation`**. Natural es-MX business register: usted-form throughout, correct accents, "correo electrónico" not "email", "iniciar sesión" not "login".

`base.html` keeps its visual structure and gains localized chrome through `t()` / `lang()` globals — its header and footer sit outside every `{% block content %}`, so a localized body would otherwise render inside an English frame. The chrome follows the template that actually **won**, not the language requested, so an untranslated body never lands in a mismatched frame.

Three services build their own Jinja environment over this same directory. All now route through `build_email_environment()`, so an environment cannot exist without the globals `base.html` calls — `base.html` invokes `t()`, and Jinja raises on calling an undefined name.

## Wiring

Routers read the recipient's stored locale while they still hold a DB session and pass it to the background tasks, which have none of their own. That read is defensive (`getattr(user, "locale", None)`): the password-reset dispatch is the one path a locked-out user depends on, and it must not raise on a recipient object that lacks the attribute.

## Drive-by fix

`send_verification_email_task` passed only `verification_url`, while `verification.html` renders the button as `href="{{ verification_link }}"` — so the one email every new account receives shipped with an empty button. Now passes both names, matching every other sender, and guarded by a test.

## Not regressed

Resend HTTPS transport unchanged; `_send_email` still returns `False` with no transport configured; templates still extend `base.html` (not `email/base.html`); every action button still renders a real href — now asserted for the Spanish copies too. English remains fully available: this is localization, not replacement.

## Tests

Extends the existing guards in `tests/unit/services/test_email_delivery.py` rather than duplicating them — the base-resolution and href parametrizations now cover the `es/` templates alongside the English ones. New coverage: locale-resolution precedence (all four tiers, regional variants, unsupported-tag fall-through), Spanish body for an `es` recipient and English for `en`, frame language matching body language, English fallback for an untranslated message, `DEFAULT_EMAIL_LOCALE` driving unspecified sends, subject localization end-to-end through the sender, and that the shared globals are registered on every environment.

`tests/unit/services/test_email_service.py::test_render_unknown_template_fallback` was updated: it asserted the pre-localization English-only fallback string, and now asserts the localized contract in both languages.

**Baseline:** `pytest tests/unit --ignore=tests/unit/sso` on this branch vs clean `main`, compared by name.

| | main | branch |
|---|---|---|
| failed | 13 | 13 (identical set) |
| errors | 84 | 84 |
| passed | 2693 | 2761 |

**Zero new failures.** The pre-existing failures and errors are the known local xmlsec/lxml mismatch plus unrelated OAuth cases. Ruff on the touched files is unchanged from baseline (2 pre-existing findings in `auth.py`).

## Follow-ups (not in scope here)

- `InvitationService._send_invitation_email` builds its email inline as an f-string rather than using the `invitation` templates, and calls `self.email_service.send_email(...)`, which is not a method on `EmailService` — worth a separate look.
- `users.locale` is settable through `PATCH /api/v1/users/me`, but **no signup path captures it** — so it is NULL until a user goes and edits their profile, and in practice most recipients fall through to `DEFAULT_EMAIL_LOCALE`. Capturing it at registration (from `Accept-Language`, or from the product doing the signup) is what would make tier 2 carry real traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
