### PR TITLE
fix(api): capture signup locale and repair the invitation email path

### DIFF
--- a/apps/api/app/core/locale.py
+++ b/apps/api/app/core/locale.py
@@ -1,0 +1,148 @@
+"""Locale negotiation for inbound requests.
+
+`users.locale` has existed on the model and in the schema since 000_init, and
+`PATCH /api/v1/users/me` can write it — but no signup path ever set it, so the
+column is NULL for essentially every row and every downstream consumer falls
+through to a deployment default. This module is the piece that was missing:
+turning what a client already tells us into a stored preference.
+
+Two rules govern everything here:
+
+1. **Only store a language we actually support.** Persisting `fr-CA` because a
+   browser asked for it manufactures a user whose experience is *worse* than
+   the default — the default has translations, `fr` does not. Unsupported tags
+   resolve to None so the caller stores NULL and the configured default
+   applies.
+2. **Never make locale required.** A missing or malformed `Accept-Language`
+   header returns None. Signup must not care.
+
+Note on regional variants: a tag is reduced to its bare language subtag
+(`es-MX`, `es_419`, `ES-mx` all mean `es`) because a translation set is
+per-language and regional variants share it.
+"""
+
+from typing import Any, List, Optional, Tuple
+
+# Languages with a real translation set behind them. Keep this in step with
+# whatever renders user-facing copy; storing a tag no renderer can honor is
+# the failure mode this module exists to prevent.
+SUPPORTED_LOCALES: Tuple[str, ...] = ("es", "en")
+
+# Accept-Language is attacker-controlled and unbounded. Parse a sane prefix
+# rather than walking a megabyte of comma-separated junk.
+_MAX_HEADER_CHARS = 512
+_MAX_HEADER_ENTRIES = 32
+
+
+def normalize_locale(raw: Any) -> Optional[str]:
+    """Reduce a locale tag to a supported bare language subtag.
+
+    Accepts the shapes that actually appear in stored profiles and in
+    Accept-Language headers: ``es``, ``es-MX``, ``es_MX``, ``ES-mx``,
+    ``es-419``. Returns None for anything unsupported or unparseable so
+    callers fall through to the next tier instead of silently committing to a
+    language nobody can render.
+    """
+    if not raw or not isinstance(raw, str):
+        return None
+    # BCP 47 separates with "-"; POSIX-style profile values use "_".
+    language = raw.strip().replace("_", "-").split("-", 1)[0].lower()
+    if language in SUPPORTED_LOCALES:
+        return language
+    return None
+
+
+def _parse_accept_language(header: str) -> List[str]:
+    """Return the header's language tags ordered by declared preference.
+
+    Implements the parts of RFC 9110 §12.5.4 that change the outcome:
+    q-values order the list, ``q=0`` means "explicitly not acceptable" and is
+    dropped entirely, and ties keep their original left-to-right order (a
+    stable sort), which is what makes ``en-US,en`` behave as written.
+    Malformed q-values are treated as a rejection rather than a preference —
+    a client that cannot format a float is not expressing a language it wants.
+    """
+    ranked: List[Tuple[float, int, str]] = []
+
+    for index, part in enumerate(header[:_MAX_HEADER_CHARS].split(",")):
+        if index >= _MAX_HEADER_ENTRIES:
+            break
+        pieces = part.split(";")
+        tag = pieces[0].strip()
+        if not tag:
+            continue
+
+        quality = 1.0
+        for param in pieces[1:]:
+            param = param.strip()
+            if param[:2].lower() != "q=":
+                continue  # charset/other params carry no ordering information
+            try:
+                quality = float(param[2:])
+            except ValueError:
+                quality = 0.0
+            break
+
+        if quality <= 0:
+            continue
+        # Negated quality sorts highest-first; index breaks ties in place.
+        ranked.append((-quality, index, tag))
+
+    ranked.sort()
+    return [tag for _, _, tag in ranked]
+
+
+def locale_from_accept_language(header: Any) -> Optional[str]:
+    """Pick the client's most-preferred *supported* language, or None.
+
+    Walks the client's ranked preferences and returns the first tag we can
+    actually render. ``*`` is skipped rather than matched: a wildcard says
+    "anything is fine", which is an absence of preference, and absence must
+    fall through to the deployment default rather than pin the row to
+    whichever language happens to be first in SUPPORTED_LOCALES.
+    """
+    if not header or not isinstance(header, str):
+        return None
+
+    for tag in _parse_accept_language(header):
+        if tag == "*":
+            continue
+        normalized = normalize_locale(tag)
+        if normalized:
+            return normalized
+    return None
+
+
+def locale_from_request(request: Any = None, explicit: Any = None) -> Optional[str]:
+    """Resolve the locale to persist for a user being created, or None.
+
+    Precedence, highest first:
+
+    1. ``explicit`` — a locale field on the request body, when the endpoint
+       offers one. A client that names its language outranks a header the
+       browser filled in.
+    2. ``Accept-Language`` on the request.
+    3. None — store NULL and let the configured default apply. This is a
+       legitimate outcome, not a failure: it keeps the user on the default
+       instead of freezing today's guess into the row.
+
+    Returning None rather than raising is the whole contract — no creation
+    path may fail because a header was absent, malformed, or hostile.
+    """
+    normalized = normalize_locale(explicit)
+    if normalized:
+        return normalized
+
+    if request is None:
+        return None
+
+    headers = getattr(request, "headers", None)
+    if headers is None:
+        return None
+
+    try:
+        header_value = headers.get("accept-language")
+    except Exception:  # pragma: no cover - defensive: non-mapping headers
+        return None
+
+    return locale_from_accept_language(header_value)

--- a/apps/api/app/models/__init__.py
+++ b/apps/api/app/models/__init__.py
@@ -2,7 +2,7 @@
 import enum
 import uuid
 from datetime import datetime
-from typing import Any
+from typing import Any, Optional
 
 import sqlalchemy as sa
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text
@@ -612,6 +612,33 @@ class Invitation(Base):
     accepted_at = Column(DateTime)
     created_by = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)
+
+    # The three helpers below are called from the invitation service and
+    # router but were never defined anywhere, so every reference raised
+    # AttributeError. They are pure functions of columns that already exist,
+    # so defining them needs no migration.
+
+    @property
+    def is_expired(self) -> bool:
+        """True once the invitation's window has closed."""
+        if not self.expires_at:
+            return False
+        return datetime.utcnow() > self.expires_at
+
+    @property
+    def is_valid(self) -> bool:
+        """True when this invitation can still be accepted."""
+        return self.status == "pending" and not self.is_expired
+
+    def generate_invite_url(self, base_url: Optional[str] = None) -> str:
+        """Build the acceptance link carrying this invitation's token.
+
+        The token is the whole point of the link: it is what
+        `/invitations/validate/{token}` and `/invitations/accept` look up. A
+        link built any other way cannot be redeemed.
+        """
+        root = (base_url or "").rstrip("/")
+        return f"{root}/invitations/accept?token={self.token}"
 
 
 class GuestInvite(Base):

--- a/apps/api/app/routers/v1/auth.py
+++ b/apps/api/app/routers/v1/auth.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import Session
 import structlog
 
 from app.config import settings
+from app.core.locale import locale_from_request
 from app.core.redis import ResilientRedisClient, get_redis
 from app.core.url_security import validate_redirect_url
 from app.database import AsyncSessionLocal, get_db
@@ -59,6 +60,10 @@ class SignUpRequest(BaseModel):
     first_name: Optional[str] = Field(None, max_length=100)
     last_name: Optional[str] = Field(None, max_length=100)
     username: Optional[str] = Field(None, min_length=3, max_length=50)
+    # Optional and unvalidated by pattern on purpose: an integrating app that
+    # already knows its user's language should be able to say so, and an
+    # unsupported tag must degrade to the default rather than 422 a signup.
+    locale: Optional[str] = Field(None, max_length=35)
 
     @field_validator("username")
     @classmethod
@@ -228,7 +233,11 @@ async def sign_up(
     if not valid:
         raise HTTPException(status_code=400, detail=message)
 
-    # Create user
+    # Create user. locale is captured here because signup is the only moment
+    # we are guaranteed to hear from the client directly; leaving it NULL (the
+    # behaviour before this) meant every user fell through to the deployment
+    # default forever, since nothing else ever writes the column except an
+    # explicit PATCH /users/me that almost nobody makes.
     user = User(
         email=signup_data.email,
         password_hash=AuthService.hash_password(signup_data.password),
@@ -236,6 +245,7 @@ async def sign_up(
         last_name=signup_data.last_name,
         username=signup_data.username,
         status=UserStatus.ACTIVE,
+        locale=locale_from_request(request, signup_data.locale),
     )
     db.add(user)
     await db.commit()
@@ -1767,11 +1777,15 @@ async def send_magic_link(
     user = result.scalar_one_or_none()
 
     if not user:
-        # Create user without password for magic link only
+        # Create user without password for magic link only.
+        # This branch is a signup in everything but name — it is the first and
+        # only chance to record the requester's language, and the very next
+        # thing this endpoint does is mail them.
         user = User(
             email=magic_link_data.email,
             email_verified=True,  # Auto-verify for magic link users
             status=UserStatus.ACTIVE,
+            locale=locale_from_request(request),
         )
         db.add(user)
         await db.commit()

--- a/apps/api/app/routers/v1/invitations.py
+++ b/apps/api/app/routers/v1/invitations.py
@@ -4,11 +4,12 @@ Invitation management API endpoints.
 
 from typing import Optional
 
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, status
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, status
 from sqlalchemy import and_, func, select
 from sqlalchemy.orm import Session
 
 from app.config import settings
+from app.core.locale import locale_from_request
 from app.database import get_db
 from app.dependencies import get_current_user, require_org_admin
 from app.models.invitation import (
@@ -299,7 +300,11 @@ async def revoke_invitation(
 
 
 @router.post("/accept", response_model=InvitationAcceptResponse)
-async def accept_invitation(accept_data: InvitationAcceptRequest, db: Session = Depends(get_db)):
+async def accept_invitation(
+    accept_data: InvitationAcceptRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+):
     """
     Accept an invitation using the token.
     """
@@ -324,7 +329,10 @@ async def accept_invitation(accept_data: InvitationAcceptRequest, db: Session = 
 
         # Accept invitation
         result = await service.accept_invitation(
-            token=accept_data.token, user=user, new_user_data=new_user_data
+            token=accept_data.token,
+            user=user,
+            new_user_data=new_user_data,
+            locale=locale_from_request(request),
         )
 
         return InvitationAcceptResponse(**result)

--- a/apps/api/app/routers/v1/oauth.py
+++ b/apps/api/app/routers/v1/oauth.py
@@ -13,6 +13,7 @@ from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from app.config import settings
+from app.core.locale import locale_from_request
 from app.database import get_db
 from app.dependencies import get_current_user
 from app.services.oauth import OAuthService
@@ -234,7 +235,7 @@ async def oauth_callback(
 
         # Handle OAuth callback
         result = await OAuthService.handle_oauth_callback(
-            db, oauth_provider, code, state, redirect_uri
+            db, oauth_provider, code, state, redirect_uri, locale=locale_from_request(request)
         )
 
         if not result:

--- a/apps/api/app/routers/v1/scim.py
+++ b/apps/api/app/routers/v1/scim.py
@@ -13,6 +13,7 @@ from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database_manager import get_db
+from app.core.locale import normalize_locale
 from app.core.tenant_context import TenantContext
 from app.models.enterprise import Organization, OrganizationMember, OrganizationRole, SCIMResource
 
@@ -374,6 +375,12 @@ async def create_user(
             display_name=user_data.get("displayName"),
             status="active" if active else "inactive",
             email_verified=True,  # SCIM users are pre-verified
+            # SCIM core schema defines both `locale` and `preferredLanguage`;
+            # Okta and Entra populate them from the directory. This is a
+            # machine-to-machine call, so the request's own Accept-Language
+            # describes the provisioning agent, not the human being created —
+            # the body attribute is the only honest source here.
+            locale=normalize_locale(user_data.get("locale") or user_data.get("preferredLanguage")),
         )
         db.add(user)
 

--- a/apps/api/app/routers/v1/sso.py
+++ b/apps/api/app/routers/v1/sso.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.locale import locale_from_request
 from app.database import get_db
 from app.dependencies import get_current_user, require_admin
 from app.services.sso_service import SSOService
@@ -354,7 +355,9 @@ async def saml_acs(
             raise HTTPException(status_code=400, detail="Missing SAML response")
 
         # Handle SAML response
-        result = await sso_service.handle_saml_response(saml_response, relay_state)
+        result = await sso_service.handle_saml_response(
+            saml_response, relay_state, locale=locale_from_request(request)
+        )
 
         # Create JWT tokens and session
         import structlog
@@ -452,6 +455,7 @@ async def saml_slo(
 
 @router.get("/oidc/callback")
 async def oidc_callback(
+    request: Request,
     code: str,
     state: str,
     error: Optional[str] = None,
@@ -473,7 +477,9 @@ async def oidc_callback(
             )
 
         # Handle OIDC callback
-        result = await sso_service.handle_oidc_callback(code, state)
+        result = await sso_service.handle_oidc_callback(
+            code, state, locale=locale_from_request(request)
+        )
 
         # Create session and redirect
         access_token = result.get("access_token")

--- a/apps/api/app/services/audit_logger.py
+++ b/apps/api/app/services/audit_logger.py
@@ -55,6 +55,14 @@ class AuditEventType(str, Enum):
     ORG_MEMBER_REMOVE = "org.member_remove"
     ORG_ROLE_CHANGE = "org.role_change"
 
+    # Invitation events. The invitation service has referenced all four of
+    # these since it was written; none of them existed, so every invitation
+    # operation raised AttributeError at its audit call.
+    INVITATION_CREATE = "invitation.create"
+    INVITATION_ACCEPT = "invitation.accept"
+    INVITATION_REVOKE = "invitation.revoke"
+    INVITATION_RESEND = "invitation.resend"
+
     # API events
     API_KEY_CREATE = "api.key_create"
     API_KEY_ROTATE = "api.key_rotate"

--- a/apps/api/app/services/email_service.py
+++ b/apps/api/app/services/email_service.py
@@ -359,6 +359,13 @@ class EmailService:
                 if spanish
                 else f"Welcome to Janua, {name}!"
             )
+        if "invitation" in template_name:
+            url = data.get("invitation_url", "")
+            return (
+                f"Le han invitado a unirse a Janua: {url}"
+                if spanish
+                else f"You've been invited to join Janua: {url}"
+            )
         return "Contenido no disponible" if spanish else "Email content unavailable"
 
     async def send_magic_link_email(
@@ -400,6 +407,59 @@ class EmailService:
             logger.info("Magic link email sent", email=_redact_email(email))
         else:
             logger.error("Failed to send magic link email", email=_redact_email(email))
+        return sent
+
+    async def send_invitation_email(
+        self,
+        email: str,
+        invite_url: str,
+        organization_name: str,
+        inviter_name: str,
+        role: str = "member",
+        expires_at: Optional[datetime] = None,
+        teams: Optional[list] = None,
+    ) -> bool:
+        """Send an organization invitation.
+
+        The invitation templates have existed since the templates directory
+        did, but nothing on a live path ever rendered them — the invitation
+        service hand-rolled its own HTML string and handed it to a method that
+        does not exist on this class. This is the missing seam: one place that
+        renders the maintained templates and puts them on the same transport
+        as every other transactional message.
+        """
+        template_data = {
+            "inviter_name": inviter_name,
+            "organization_name": organization_name,
+            "role": role,
+            # The template renders href="{{ invitation_url }}"; `invitation_link`
+            # mirrors the `*_link` naming the other templates use so a future
+            # rename of either name still finds a value rather than a blank href.
+            "invitation_url": invite_url,
+            "invitation_link": invite_url,
+            "expires_at": (
+                expires_at.strftime("%B %d, %Y at %I:%M %p UTC") if expires_at else ""
+            ),
+            "teams": teams or [],
+            "base_url": settings.BASE_URL,
+            "company_name": "Janua",
+            "support_email": settings.SUPPORT_EMAIL or "support@janua.dev",
+        }
+
+        subject = f"{inviter_name} invited you to join {organization_name} on Janua"
+        html_content = self._render_template("invitation.html", template_data)
+        text_content = self._render_template("invitation.txt", template_data)
+
+        sent = await self._send_email(
+            to_email=email,
+            subject=subject,
+            html_content=html_content,
+            text_content=text_content,
+        )
+        if sent:
+            logger.info("Invitation email sent", email=_redact_email(email))
+        else:
+            logger.error("Failed to send invitation email", email=_redact_email(email))
         return sent
 
     async def _send_via_resend(

--- a/apps/api/app/services/invitation_service.py
+++ b/apps/api/app/services/invitation_service.py
@@ -59,8 +59,12 @@ class InvitationService:
             raise ValueError("Organization not found")
 
         # The caller must administer THIS organization — as its owner, or via
-        # an admin/owner membership row.
-        is_owner = str(getattr(organization, "owner_id", "")) == str(invited_by.id)
+        # an admin/owner membership row. Both ids must be present before they
+        # can match: an ownerless organization and an id-less caller would
+        # otherwise compare equal as "None" and grant access to neither party's
+        # organization.
+        owner_id = getattr(organization, "owner_id", None)
+        is_owner = bool(owner_id) and bool(invited_by.id) and str(owner_id) == str(invited_by.id)
         if not is_owner:
             admin_membership = (
                 self.db.query(OrganizationMember)

--- a/apps/api/app/services/invitation_service.py
+++ b/apps/api/app/services/invitation_service.py
@@ -2,20 +2,24 @@
 Service for managing organization invitations.
 """
 
+import secrets
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
 
+import structlog
 from sqlalchemy import and_, or_
 from sqlalchemy.orm import Session
 
 from app.config import settings
 from app.models import Organization, OrganizationMember
 from app.models.invitation import Invitation, InvitationCreate, InvitationResponse, InvitationStatus
-from app.models.policy import Role, UserRole
+from app.models.policy import Role
 from app.models.user import User
 from app.services.audit_logger import AuditAction, AuditLogger
 from app.services.cache import CacheService
 from app.services.email_service import EmailService
+
+logger = structlog.get_logger()
 
 
 class InvitationService:
@@ -35,35 +39,61 @@ class InvitationService:
         """
         Create a new invitation.
         """
-        # Verify organization exists and user has permission
+        # Verify the organization exists.
+        #
+        # This used to filter on `Organization.tenant_id`, a column the
+        # organizations table does not have, so the query raised before it
+        # could scope anything. The scoping it was reaching for is restored
+        # below against columns that exist — it must not simply be dropped:
+        # `require_org_admin` only proves the caller administers SOME
+        # organization, so without a per-organization check any org admin
+        # could invite members into an organization they have nothing to do
+        # with.
         organization = (
             self.db.query(Organization)
-            .filter(
-                and_(
-                    Organization.id == invitation_data.organization_id,
-                    Organization.tenant_id == tenant_id,
-                )
-            )
+            .filter(Organization.id == invitation_data.organization_id)
             .first()
         )
 
         if not organization:
             raise ValueError("Organization not found")
 
-        # Check if user is already a member
-        existing_member = (
-            self.db.query(OrganizationMember)
-            .filter(
-                and_(
-                    OrganizationMember.organization_id == invitation_data.organization_id,
-                    OrganizationMember.user_email == invitation_data.email,
+        # The caller must administer THIS organization — as its owner, or via
+        # an admin/owner membership row.
+        is_owner = str(getattr(organization, "owner_id", "")) == str(invited_by.id)
+        if not is_owner:
+            admin_membership = (
+                self.db.query(OrganizationMember)
+                .filter(
+                    and_(
+                        OrganizationMember.organization_id == organization.id,
+                        OrganizationMember.user_id == invited_by.id,
+                        OrganizationMember.role.in_(["admin", "owner"]),
+                    )
                 )
+                .first()
             )
-            .first()
-        )
+            if not admin_membership:
+                raise ValueError("Organization not found")
 
-        if existing_member:
-            raise ValueError("User is already a member of this organization")
+        # Check if the invitee is already a member. Membership is keyed by
+        # user_id, not by email, so resolve the address first; an address with
+        # no account cannot already be a member.
+        invitee = self.db.query(User).filter(User.email == invitation_data.email).first()
+        if invitee is not None:
+            existing_member = (
+                self.db.query(OrganizationMember)
+                .filter(
+                    and_(
+                        OrganizationMember.organization_id == organization.id,
+                        OrganizationMember.user_id == invitee.id,
+                    )
+                )
+                .first()
+            )
+
+            if existing_member:
+                raise ValueError("User is already a member of this organization")
 
         # Check for existing pending invitation
         existing_invitation = (
@@ -93,15 +123,20 @@ class InvitationService:
         # Calculate expiration
         expires_at = datetime.utcnow() + timedelta(days=invitation_data.expires_in or 7)
 
-        # Create invitation
+        # Create invitation.
+        #
+        # `token` is NOT NULL and unique, and it is the only thing
+        # /invitations/validate/{token} and /invitations/accept look up — yet
+        # nothing here ever generated one. Every invitation was therefore
+        # un-redeemable even before the email failed to send. Mint it here so
+        # the value that gets mailed is the value the verify path validates.
         invitation = Invitation(
-            tenant_id=tenant_id,
             organization_id=invitation_data.organization_id,
             email=invitation_data.email,
-            role_id=role.id if role else None,
-            role_name=role.name if role else invitation_data.role,
-            invited_by=invited_by.id,
-            message=invitation_data.message,
+            role=(role.name if role else invitation_data.role) or "member",
+            status=InvitationStatus.PENDING.value,
+            token=secrets.token_urlsafe(32),
+            created_by=invited_by.id,
             expires_at=expires_at,
         )
 
@@ -110,7 +145,7 @@ class InvitationService:
         self.db.refresh(invitation)
 
         # Send invitation email
-        await self._send_invitation_email(invitation, organization, invited_by)
+        email_sent = await self._send_invitation_email(invitation, organization, invited_by)
 
         # Log audit event
         await self.audit_logger.log(
@@ -122,19 +157,20 @@ class InvitationService:
             details={"email": invitation_data.email, "organization": organization.name},
         )
 
-        # Create response
+        # Create response. `email_sent` reports what actually happened on this
+        # request rather than reading a column that does not exist.
         response = InvitationResponse(
             id=str(invitation.id),
             organization_id=str(invitation.organization_id),
             email=invitation.email,
-            role=invitation.role_name,
+            role=invitation.role,
             status=invitation.status,
-            invited_by=str(invitation.invited_by),
-            message=invitation.message,
+            invited_by=str(invitation.created_by),
+            message=invitation_data.message,
             expires_at=invitation.expires_at,
             created_at=invitation.created_at,
-            invite_url=invitation.generate_invite_url(settings.APP_URL),
-            email_sent=invitation.email_sent,
+            invite_url=invitation.generate_invite_url(settings.FRONTEND_URL or settings.BASE_URL),
+            email_sent=email_sent,
         )
 
         return response
@@ -186,9 +222,14 @@ class InvitationService:
         token: str,
         user: Optional[User] = None,
         new_user_data: Optional[Dict[str, Any]] = None,
+        locale: Optional[str] = None,
     ) -> Dict[str, Any]:
         """
         Accept an invitation.
+
+        `locale` is the language negotiated from the acceptance request. It is
+        applied only to a user created here — an existing account keeps the
+        preference it already has.
         """
         # Find invitation by token
         invitation = self.db.query(Invitation).filter(Invitation.token == token).first()
@@ -202,14 +243,25 @@ class InvitationService:
             else:
                 raise ValueError(f"Invitation is {invitation.status}")
 
-        # Create user if needed
+        # Create user if needed.
+        # `name` is a read-only property on User (derived from first/last/display),
+        # and invitations carry no tenant of their own — both kwargs used to
+        # raise before a single account could be created this way. The tenant
+        # comes from the organization being joined, which is the only place it
+        # is actually recorded.
         if not user and new_user_data:
+            organization = (
+                self.db.query(Organization)
+                .filter(Organization.id == invitation.organization_id)
+                .first()
+            )
             user = User(
                 email=invitation.email,
-                name=new_user_data.get("name", invitation.email.split("@")[0]),
+                display_name=new_user_data.get("name") or invitation.email.split("@")[0],
                 password_hash=new_user_data.get("password_hash"),
-                tenant_id=invitation.tenant_id,
+                tenant_id=getattr(organization, "tenant_id", None),
                 email_verified=True,  # Auto-verify since they have the invitation
+                locale=locale,
             )
             self.db.add(user)
             self.db.flush()
@@ -220,28 +272,19 @@ class InvitationService:
         if user.email != invitation.email:
             raise ValueError("Invitation email does not match user email")
 
-        # Add user to organization
+        # Add user to organization. Membership is keyed by user_id; there is
+        # no user_email column, and passing one raised before any invitation
+        # could ever be redeemed.
         org_member = OrganizationMember(
             organization_id=invitation.organization_id,
             user_id=user.id,
-            user_email=user.email,
-            role=invitation.role_name or "member",
+            role=invitation.role or "member",
         )
         self.db.add(org_member)
 
-        # Assign role if specified
-        if invitation.role_id:
-            user_role = UserRole(
-                user_id=user.id,
-                role_id=invitation.role_id,
-                organization_id=invitation.organization_id,
-                scope="organization",
-            )
-            self.db.add(user_role)
-
-        # Update invitation status
+        # Update invitation status. There is no accepted_by column; accepted_at
+        # plus the membership row record who redeemed it.
         invitation.status = InvitationStatus.ACCEPTED.value
-        invitation.accepted_by = user.id
         invitation.accepted_at = datetime.utcnow()
 
         self.db.commit()
@@ -264,7 +307,7 @@ class InvitationService:
             "message": "Invitation accepted successfully",
             "user_id": str(user.id),
             "organization_id": str(invitation.organization_id),
-            "role": invitation.role_name,
+            "role": invitation.role,
             "redirect_url": f"/dashboard/org/{invitation.organization_id}",
         }
 
@@ -318,7 +361,7 @@ class InvitationService:
         )
 
         # Resend email
-        await self._send_invitation_email(invitation, organization, resent_by)
+        email_sent = await self._send_invitation_email(invitation, organization, resent_by)
 
         # Log audit event
         await self.audit_logger.log(
@@ -335,100 +378,56 @@ class InvitationService:
             id=str(invitation.id),
             organization_id=str(invitation.organization_id),
             email=invitation.email,
-            role=invitation.role_name,
+            role=invitation.role,
             status=invitation.status,
-            invited_by=str(invitation.invited_by),
-            message=invitation.message,
+            invited_by=str(invitation.created_by),
+            message=None,
             expires_at=invitation.expires_at,
             created_at=invitation.created_at,
-            invite_url=invitation.generate_invite_url(settings.APP_URL),
-            email_sent=invitation.email_sent,
+            invite_url=invitation.generate_invite_url(settings.FRONTEND_URL or settings.BASE_URL),
+            email_sent=email_sent,
         )
 
         return response
 
     async def _send_invitation_email(
         self, invitation: Invitation, organization: Organization, inviter: User
-    ):
+    ) -> bool:
         """
-        Send invitation email to the invitee.
+        Send invitation email to the invitee. Returns whether it was sent.
+
+        This used to compose its own HTML and hand it to
+        `EmailService.send_email`, a method that does not exist on that class,
+        so every invitation raised AttributeError into a bare `except` that
+        printed and moved on. Nothing was ever mailed and nothing ever said so.
+
+        It now renders the maintained invitation templates and reports the
+        outcome instead of swallowing it. A send failure still does not undo
+        the invitation — the row is real and the link stays redeemable — but
+        the caller can now tell the difference.
         """
         try:
-            # Update send attempts
-            invitation.email_send_attempts += 1
-
-            # Create email content
-            subject = f"You're invited to join {organization.name} on Janua"
-
-            html_content = f"""
-            <html>
-                <body style="font-family: Arial, sans-serif; line-height: 1.6;">
-                    <h2>You're invited to {organization.name}!</h2>
-                    
-                    <p>{inviter.name or inviter.email} has invited you to join {organization.name} on Janua.</p>
-                    
-                    {f'<p><em>"{invitation.message}"</em></p>' if invitation.message else ''}
-                    
-                    <p>Click the button below to accept this invitation:</p>
-                    
-                    <p style="margin: 30px 0;">
-                        <a href="{invitation.generate_invite_url(settings.APP_URL)}" 
-                           style="background-color: #4CAF50; color: white; padding: 14px 28px; 
-                                  text-decoration: none; border-radius: 4px; display: inline-block;">
-                            Accept Invitation
-                        </a>
-                    </p>
-                    
-                    <p style="color: #666; font-size: 14px;">
-                        This invitation will expire on {invitation.expires_at.strftime('%B %d, %Y at %I:%M %p UTC')}.
-                    </p>
-                    
-                    <p style="color: #666; font-size: 14px;">
-                        If you don't want to accept this invitation, you can safely ignore this email.
-                    </p>
-                    
-                    <hr style="margin: 30px 0; border: none; border-top: 1px solid #eee;">
-                    
-                    <p style="color: #999; font-size: 12px;">
-                        This invitation was sent to {invitation.email}. 
-                        If you didn't expect this invitation, please ignore this email.
-                    </p>
-                </body>
-            </html>
-            """
-
-            text_content = f"""
-            You're invited to {organization.name}!
-            
-            {inviter.name or inviter.email} has invited you to join {organization.name} on Janua.
-            
-            {invitation.message if invitation.message else ''}
-            
-            Accept this invitation:
-            {invitation.generate_invite_url(settings.APP_URL)}
-            
-            This invitation will expire on {invitation.expires_at.strftime('%B %d, %Y at %I:%M %p UTC')}.
-            
-            If you don't want to accept this invitation, you can safely ignore this email.
-            """
-
-            # Send email
-            await self.email_service.send_email(
-                to_email=invitation.email,
-                subject=subject,
-                html_content=html_content,
-                text_content=text_content,
+            invite_url = invitation.generate_invite_url(settings.FRONTEND_URL or settings.BASE_URL)
+            sent = await self.email_service.send_invitation_email(
+                email=invitation.email,
+                invite_url=invite_url,
+                organization_name=getattr(organization, "name", None) or "your organization",
+                inviter_name=(getattr(inviter, "name", None) or inviter.email),
+                role=invitation.role or "member",
+                expires_at=invitation.expires_at,
             )
+        except Exception:
+            logger.exception(
+                "Invitation email raised", invitation_id=str(getattr(invitation, "id", ""))
+            )
+            return False
 
-            # Update invitation
-            invitation.email_sent = True
-            invitation.email_sent_at = datetime.utcnow()
-
-            self.db.commit()
-
-        except Exception as e:
-            # Log error but don't fail the invitation creation
-            print(f"Failed to send invitation email: {str(e)}")
+        if not sent:
+            logger.warning(
+                "Invitation email NOT sent — the recipient will never receive a link",
+                invitation_id=str(getattr(invitation, "id", "")),
+            )
+        return sent
 
     def get_pending_invitations(
         self, organization_id: str, skip: int = 0, limit: int = 100

--- a/apps/api/app/services/oauth.py
+++ b/apps/api/app/services/oauth.py
@@ -13,6 +13,7 @@ from sqlalchemy import and_
 from sqlalchemy.orm import Session
 
 from app.config import settings
+from app.core.locale import normalize_locale
 from app.services.auth_service import AuthService
 
 from ..models import OAuthAccount, OAuthProvider, User, UserStatus
@@ -436,9 +437,20 @@ class OAuthService:
 
     @classmethod
     def find_or_create_user(
-        cls, db: Session, provider: OAuthProvider, user_info: Dict[str, Any], tokens: Dict[str, Any]
+        cls,
+        db: Session,
+        provider: OAuthProvider,
+        user_info: Dict[str, Any],
+        tokens: Dict[str, Any],
+        locale: Optional[str] = None,
     ) -> Tuple[User, bool]:
-        """Find existing user or create new one from OAuth info"""
+        """Find existing user or create new one from OAuth info.
+
+        `locale` is the language negotiated from the callback request, used
+        only when the provider did not tell us one. It is never applied to an
+        already-existing user: a returning user's stored preference outranks
+        whatever browser they happen to be signing in from today.
+        """
         # Check if OAuth account exists
         oauth_account = (
             db.query(OAuthAccount)
@@ -481,6 +493,14 @@ class OAuthService:
         # Create new user if doesn't exist
         is_new_user = False
         if not user:
+            # `locale` is a standard OIDC claim, so most providers hand us the
+            # language the user already chose in their identity account. That
+            # beats the browser header, which is why it is checked first;
+            # unsupported claims normalize to None and fall through.
+            raw_claims = user_info.get("raw_data") or {}
+            claimed_locale = normalize_locale(
+                raw_claims.get("locale") or raw_claims.get("preferredLanguage")
+            )
             user = User(
                 email=user_info.get("email"),
                 email_verified=user_info.get("email_verified", False),
@@ -488,6 +508,7 @@ class OAuthService:
                 last_name=user_info.get("last_name"),
                 profile_image_url=user_info.get("profile_image_url"),
                 status=UserStatus.ACTIVE,
+                locale=claimed_locale or locale,
             )
             db.add(user)
             db.flush()
@@ -535,9 +556,20 @@ class OAuthService:
 
     @classmethod
     async def handle_oauth_callback(
-        cls, db: Session, provider: OAuthProvider, code: str, state: str, redirect_uri: str
+        cls,
+        db: Session,
+        provider: OAuthProvider,
+        code: str,
+        state: str,
+        redirect_uri: str,
+        locale: Optional[str] = None,
     ) -> Optional[Tuple[User, Dict[str, Any]]]:
-        """Handle OAuth callback and create/update user"""
+        """Handle OAuth callback and create/update user.
+
+        `locale` is threaded through from the router because this layer is the
+        only one that touches User construction and the router is the only one
+        that can see request headers.
+        """
         # Exchange code for tokens
         tokens = await cls.exchange_code_for_tokens(provider, code, redirect_uri)
         if not tokens:
@@ -551,7 +583,7 @@ class OAuthService:
             return None
 
         # Find or create user
-        user, is_new = cls.find_or_create_user(db, provider, user_info, tokens)
+        user, is_new = cls.find_or_create_user(db, provider, user_info, tokens, locale=locale)
 
         # Create session tokens
         access_token, refresh_token, session = AuthService.create_user_session(db, user)

--- a/apps/api/app/services/sso_service.py
+++ b/apps/api/app/services/sso_service.py
@@ -37,6 +37,7 @@ except ImportError:
     SSOProvider = None
     SSOStatus = None
 from ..config import settings
+from ..core.locale import normalize_locale
 from ..exceptions import AuthenticationError, ValidationError
 from .cache import CacheService
 from .jwt_service import JWTService
@@ -245,7 +246,9 @@ class SSOService:
             "params": {"RelayState": request_id, "SAMLRequest": saml_request},
         }
 
-    async def handle_saml_response(self, saml_response: str, relay_state: str) -> Dict[str, Any]:
+    async def handle_saml_response(
+        self, saml_response: str, relay_state: str, locale: Optional[str] = None
+    ) -> Dict[str, Any]:
         """Handle SAML response and create user session"""
 
         # Get stored request data
@@ -282,6 +285,7 @@ class SSOService:
             attributes=user_data,
             organization_id=organization_id,
             sso_config=sso_config,
+            locale=locale,
         )
 
         # Create SSO session
@@ -344,7 +348,9 @@ class SSOService:
 
         return {"auth_url": auth_url, "state": state}
 
-    async def handle_oidc_callback(self, code: str, state: str) -> Dict[str, Any]:
+    async def handle_oidc_callback(
+        self, code: str, state: str, locale: Optional[str] = None
+    ) -> Dict[str, Any]:
         """Handle OIDC callback and exchange code for tokens"""
 
         # Validate state
@@ -402,6 +408,7 @@ class SSOService:
             attributes=user_data,
             organization_id=organization_id,
             sso_config=sso_config,
+            locale=locale,
         )
 
         # Create SSO session
@@ -429,8 +436,13 @@ class SSOService:
         attributes: Dict[str, Any],
         organization_id: str,
         sso_config: SSOConfiguration,
+        locale: Optional[str] = None,
     ) -> User:
-        """Create or update user via JIT provisioning"""
+        """Create or update user via JIT provisioning.
+
+        `locale` is the language negotiated from the callback request, applied
+        only when the IdP did not assert one of its own.
+        """
 
         # Check if user exists
         stmt = select(User).where(User.email == email)
@@ -439,12 +451,19 @@ class SSOService:
 
         if not user and sso_config.jit_provisioning:
             # Create new user
+            # A mapped IdP attribute is the authoritative preference — the
+            # directory admin configured it deliberately. The request header is
+            # only the fallback for IdPs that assert nothing.
+            asserted_locale = normalize_locale(
+                attributes.get("locale") or attributes.get("preferred_language")
+            )
             user = User(
                 email=email,
                 email_verified=True,
                 first_name=attributes.get("first_name"),
                 last_name=attributes.get("last_name"),
                 display_name=attributes.get("display_name"),
+                locale=asserted_locale or locale,
                 user_metadata={
                     "sso": True,
                     "sso_provider": sso_config.provider.value,

--- a/apps/api/tests/unit/core/test_locale.py
+++ b/apps/api/tests/unit/core/test_locale.py
@@ -1,0 +1,132 @@
+"""Locale negotiation from Accept-Language.
+
+The rule under test throughout: only a language we can actually render may be
+stored, and an absent or hostile header must never be an error.
+"""
+
+from types import SimpleNamespace
+
+from app.core.locale import (
+    SUPPORTED_LOCALES,
+    locale_from_accept_language,
+    locale_from_request,
+    normalize_locale,
+)
+
+
+def _req(accept_language=None):
+    """A stand-in request exposing only what the negotiator reads."""
+    headers = {}
+    if accept_language is not None:
+        headers["accept-language"] = accept_language
+    return SimpleNamespace(headers=headers)
+
+
+class TestNormalize:
+    def test_bare_tag(self):
+        assert normalize_locale("es") == "es"
+        assert normalize_locale("en") == "en"
+
+    def test_region_stripped(self):
+        # A translation set is per-language; regional variants share it.
+        assert normalize_locale("es-MX") == "es"
+        assert normalize_locale("es_MX") == "es"
+        assert normalize_locale("ES-mx") == "es"
+        assert normalize_locale("es-419") == "es"
+        assert normalize_locale("en-GB") == "en"
+
+    def test_unsupported(self):
+        # Storing these would give the user a WORSE experience than the
+        # default, which at least has translations.
+        for tag in ("fr", "fr-CA", "de", "pt-BR", "zh-Hans"):
+            assert normalize_locale(tag) is None
+
+    def test_junk(self):
+        for tag in (None, "", "   ", 42, [], {}, "-", "!!"):
+            assert normalize_locale(tag) is None
+
+
+class TestHeader:
+    def test_simple(self):
+        assert locale_from_accept_language("es") == "es"
+        assert locale_from_accept_language("en-US") == "en"
+
+    def test_q_order(self):
+        # Lower q must lose regardless of position in the string.
+        assert locale_from_accept_language("en;q=0.2,es;q=0.9") == "es"
+        assert locale_from_accept_language("es;q=0.1,en;q=0.8") == "en"
+
+    def test_implicit_q_wins(self):
+        # A tag with no q= is q=1 and outranks an explicit 0.9.
+        assert locale_from_accept_language("es;q=0.9,en") == "en"
+
+    def test_tie_keeps_order(self):
+        assert locale_from_accept_language("es;q=0.5,en;q=0.5") == "es"
+        assert locale_from_accept_language("en;q=0.5,es;q=0.5") == "en"
+
+    def test_skips_unsupported(self):
+        # French ranks highest but we cannot render it; fall to the best
+        # supported tag rather than to the default.
+        assert locale_from_accept_language("fr-CA,fr;q=0.9,es;q=0.4") == "es"
+
+    def test_all_unsupported(self):
+        assert locale_from_accept_language("fr-CA,de;q=0.9,ja;q=0.8") is None
+
+    def test_q_zero_rejected(self):
+        # q=0 means "not acceptable" — honouring it is the difference between
+        # respecting the client and ignoring it.
+        assert locale_from_accept_language("es;q=0,en;q=0.5") == "en"
+        assert locale_from_accept_language("es;q=0") is None
+
+    def test_wildcard(self):
+        # "*" is an absence of preference, so it must fall through to the
+        # deployment default rather than pin the row to a guess.
+        assert locale_from_accept_language("*") is None
+        assert locale_from_accept_language("fr,*;q=0.5") is None
+        assert locale_from_accept_language("*;q=0.1,es;q=0.9") == "es"
+
+    def test_whitespace(self):
+        assert locale_from_accept_language("  es-MX , en ; q=0.8 ") == "es"
+
+    def test_bad_q(self):
+        # A client that cannot format a float is not expressing a preference.
+        assert locale_from_accept_language("es;q=bogus,en") == "en"
+
+    def test_junk_header(self):
+        for header in (None, "", "   ", ",,,", ";q=1", 42, b"es"):
+            assert locale_from_accept_language(header) is None
+
+    def test_long_header(self):
+        # Attacker-controlled and unbounded: must terminate, not hang.
+        assert locale_from_accept_language("fr," * 5000 + "es") is None
+        assert locale_from_accept_language("es," + "fr," * 5000) == "es"
+
+
+class TestFromRequest:
+    def test_header_used(self):
+        assert locale_from_request(_req("es-MX,es;q=0.9")) == "es"
+
+    def test_explicit_wins(self):
+        # A client that names its language outranks the browser's header.
+        assert locale_from_request(_req("en"), explicit="es-MX") == "es"
+
+    def test_bad_explicit(self):
+        # An unsupported explicit value must not shadow a usable header.
+        assert locale_from_request(_req("es"), explicit="fr-CA") == "es"
+
+    def test_no_header(self):
+        # The whole contract: absence is a legitimate answer, not a failure.
+        assert locale_from_request(_req()) is None
+        assert locale_from_request(None) is None
+        assert locale_from_request(_req(None), explicit=None) is None
+
+    def test_unsupported_not_stored(self):
+        assert locale_from_request(_req("fr-CA,de;q=0.8"), explicit="pt") is None
+
+    def test_headerless_object(self):
+        assert locale_from_request(SimpleNamespace()) is None
+
+
+def test_supported_set():
+    # Guards against a tag being added here without translations behind it.
+    assert set(SUPPORTED_LOCALES) == {"es", "en"}

--- a/apps/api/tests/unit/routers/test_signup_locale.py
+++ b/apps/api/tests/unit/routers/test_signup_locale.py
@@ -1,0 +1,245 @@
+"""Signup paths must record the requester's language.
+
+`users.locale` has existed since 000_init but no creation path ever wrote it,
+so it was NULL for every row. These tests pin the capture at each path where a
+User is constructed from an HTTP request.
+"""
+
+import uuid
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from starlette.requests import Request
+
+import app.routers.v1.auth as auth_mod
+from app.routers.v1.auth import MagicLinkRequest, SignUpRequest, send_magic_link, sign_up
+
+pytestmark = pytest.mark.asyncio
+
+
+def _request(accept_language=None):
+    headers = [(b"user-agent", b"pytest")]
+    if accept_language is not None:
+        headers.append((b"accept-language", accept_language.encode()))
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/api/v1/auth/signup",
+            "headers": headers,
+            "client": ("198.51.100.7", 51234),
+        }
+    )
+
+
+def _db():
+    """Async session that reports "nothing exists yet" for every lookup.
+
+    `refresh` stands in for the round-trip that would normally apply server
+    defaults, so the route can shape its response. It deliberately does not
+    touch `locale`: that value must come from the request, and letting the
+    fake database supply one would hide the very thing under test.
+    """
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=None)
+    db.execute = AsyncMock(return_value=result)
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+
+    async def refresh(obj, *args, **kwargs):
+        for column, default in (
+            ("id", uuid.uuid4()),
+            ("email_verified", False),
+            ("is_admin", False),
+            ("mfa_enabled", False),
+            ("created_at", datetime.utcnow()),
+            ("updated_at", datetime.utcnow()),
+        ):
+            if getattr(obj, column, None) is None:
+                setattr(obj, column, default)
+
+    db.refresh = AsyncMock(side_effect=refresh)
+    return db
+
+
+def _added_users(db):
+    """Users handed to db.add(), which is where every creation path puts them.
+
+    Intercepting db.add rather than the User symbol matters: these code paths
+    also use User inside SQLAlchemy select()/query() expressions, and swapping
+    the name there breaks the query rather than observing it.
+    """
+    from app.models import User
+
+    return [
+        call.args[0]
+        for call in db.add.call_args_list
+        if call.args and isinstance(call.args[0], User)
+    ]
+
+
+def _only_locale(db):
+    users = _added_users(db)
+    assert len(users) == 1, f"expected one User, got {len(users)}"
+    return users[0].locale
+
+
+async def _signup(accept_language=None, body_locale=None):
+    db = _db()
+    # Session creation reaches for Redis, which is out of scope here — the
+    # assertion is about the User handed to db.add, which happens first.
+    session_stub = AsyncMock(return_value=("access", "refresh", MagicMock()))
+    with (
+        patch.object(auth_mod.settings, "ENABLE_SIGNUPS", True),
+        patch.object(auth_mod.AuthService, "create_session", session_stub),
+    ):
+        await sign_up(
+            request=_request(accept_language),
+            signup_data=SignUpRequest(
+                email="new@example.com", password="Str0ng!Passw0rd", locale=body_locale
+            ),
+            background_tasks=MagicMock(),
+            db=db,
+        )
+    return _only_locale(db)
+
+
+async def _magic(accept_language=None):
+    db = _db()
+    with (
+        patch.object(auth_mod.settings, "ENABLE_MAGIC_LINKS", True),
+        patch.object(auth_mod.settings, "EMAIL_ENABLED", True),
+    ):
+        await send_magic_link(
+            request=_request(accept_language),
+            magic_link_data=MagicLinkRequest(email="new@example.com"),
+            background_tasks=MagicMock(),
+            db=db,
+        )
+    return _only_locale(db)
+
+
+class TestSignup:
+    async def test_header_captured(self):
+        assert await _signup("es-MX,es;q=0.9,en;q=0.5") == "es"
+
+    async def test_english_header(self):
+        assert await _signup("en-GB,en;q=0.9") == "en"
+
+    async def test_no_header(self):
+        # Must succeed and leave NULL so the configured default applies.
+        assert await _signup(None) is None
+
+    async def test_unsupported_not_stored(self):
+        assert await _signup("fr-CA,fr;q=0.9,de;q=0.8") is None
+
+    async def test_body_wins(self):
+        assert await _signup("en-US", body_locale="es-MX") == "es"
+
+    async def test_bad_body_falls_back(self):
+        # An unsupported body value must not 422 the signup, nor shadow a
+        # usable header.
+        assert await _signup("es-MX", body_locale="fr-CA") == "es"
+
+
+class TestMagicLink:
+    async def test_header_captured(self):
+        assert await _magic("es-MX,es;q=0.9") == "es"
+
+    async def test_no_header(self):
+        assert await _magic(None) is None
+
+    async def test_unsupported_not_stored(self):
+        assert await _magic("de-DE,de;q=0.9") is None
+
+
+class TestOauth:
+    """OAuth account creation, where the provider may assert a locale."""
+
+    def _run(self, claims, locale=None):
+        from app.models import OAuthProvider
+        from app.services.oauth import OAuthService
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+
+        OAuthService.find_or_create_user(
+            db,
+            OAuthProvider.GOOGLE,
+            {
+                "provider_user_id": "g-1",
+                "email": "new@example.com",
+                "email_verified": True,
+                "raw_data": claims,
+            },
+            {"access_token": "t"},
+            locale=locale,
+        )
+        return _only_locale(db)
+
+    def test_provider_claim_wins(self):
+        # A user's language on their Google account beats today's browser.
+        assert self._run({"locale": "es-MX"}, locale="en") == "es"
+
+    def test_header_fallback(self):
+        assert self._run({}, locale="es") == "es"
+
+    def test_unsupported_claim(self):
+        # An untranslatable claim must not shadow the usable header value.
+        assert self._run({"locale": "fr-CA"}, locale="es") == "es"
+
+    def test_nothing(self):
+        assert self._run({}, locale=None) is None
+
+
+class TestInviteAccept:
+    """A user created by redeeming an invitation."""
+
+    def _run(self, locale):
+        from app.services.invitation_service import InvitationService
+
+        invitation = SimpleNamespace(
+            id="inv-1",
+            email="new@example.com",
+            organization_id="org-1",
+            role="member",
+            status="pending",
+            token="tok",
+            expires_at=None,
+            is_valid=True,
+            is_expired=False,
+            accepted_at=None,
+        )
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = invitation
+
+        service = InvitationService(db)
+        service.cache = MagicMock()
+        service.cache.delete = AsyncMock()
+        service.audit_logger = MagicMock()
+        service.audit_logger.log = AsyncMock()
+        return service, db, invitation
+
+    async def test_locale_stored(self):
+        service, db, _ = self._run("es")
+        await service.accept_invitation(
+            token="tok",
+            user=None,
+            new_user_data={"name": "New Person", "password_hash": "x"},
+            locale="es",
+        )
+        assert _only_locale(db) == "es"
+
+    async def test_no_locale(self):
+        service, db, _ = self._run(None)
+        await service.accept_invitation(
+            token="tok",
+            user=None,
+            new_user_data={"name": "New Person", "password_hash": "x"},
+            locale=None,
+        )
+        assert _only_locale(db) is None

--- a/apps/api/tests/unit/services/test_invite_email.py
+++ b/apps/api/tests/unit/services/test_invite_email.py
@@ -95,7 +95,9 @@ class TestContent:
         service = _service()
         await _send(service)
         html = _payload(service)["html_content"]
-        assert "You've been invited!" in html
+        # es is the default locale, so the Spanish template is what ships;
+        # this marker exists only in es/invitation.html.
+        assert "Le invitaron a colaborar" in html
         assert "Acme Corp" in html
         assert "Ada Lovelace" in html
         assert "admin" in html

--- a/apps/api/tests/unit/services/test_invite_email.py
+++ b/apps/api/tests/unit/services/test_invite_email.py
@@ -282,3 +282,33 @@ class TestCreate:
         with pytest.raises(ValueError):
             await self._create(service, inviter_id="u-1")
         service.email_service._send_email.assert_not_awaited()
+
+    async def test_ownerless_org_refused(self):
+        # An ownerless organization and an id-less caller must not compare
+        # equal as "None" and grant each other access.
+        service = self._service(owner_id=None)
+        organization = MagicMock()
+        organization.id = "22222222-2222-2222-2222-222222222222"
+        organization.owner_id = None
+        service.db.query.return_value.filter.return_value.first.side_effect = [
+            organization,
+            None,  # no admin membership
+        ]
+        inviter = MagicMock()
+        inviter.id = None
+        inviter.email = "ada@example.com"
+        inviter.name = "Ada Lovelace"
+        from app.models.invitation import InvitationCreate
+
+        with pytest.raises(ValueError):
+            await service.create_invitation(
+                InvitationCreate(
+                    organization_id="22222222-2222-2222-2222-222222222222",
+                    email="invitee@example.com",
+                    role="admin",
+                    expires_in=7,
+                ),
+                inviter,
+                "tenant-1",
+            )
+        service.email_service._send_email.assert_not_awaited()

--- a/apps/api/tests/unit/services/test_invite_email.py
+++ b/apps/api/tests/unit/services/test_invite_email.py
@@ -1,0 +1,284 @@
+"""The invitation email must actually be composed, addressed and sent.
+
+Before the fix this path was dead in three stacked ways, all of them silent:
+the service called `EmailService.send_email`, which does not exist on that
+class; it first touched columns (`email_send_attempts`) the invitations table
+does not have; and a bare `except Exception: print(...)` swallowed both. The
+maintained invitation templates were never rendered by any live path.
+"""
+
+import uuid
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models import Invitation
+from app.services.email_service import EmailService
+from app.services.invitation_service import InvitationService
+
+pytestmark = pytest.mark.asyncio
+
+
+TOKEN = "inv-token-abc123"
+
+
+def _invitation():
+    """An invitation shaped like the row the schema actually defines."""
+    invitation = Invitation(
+        email="invitee@example.com",
+        role="admin",
+        status="pending",
+        token=TOKEN,
+        expires_at=datetime.utcnow() + timedelta(days=7),
+    )
+    invitation.id = "11111111-1111-1111-1111-111111111111"
+    invitation.organization_id = "22222222-2222-2222-2222-222222222222"
+    return invitation
+
+
+def _service(sent=True):
+    """InvitationService with the transport — and only the transport — faked."""
+    service = InvitationService(MagicMock())
+    service.email_service._send_email = AsyncMock(return_value=sent)
+    return service
+
+
+async def _send(service):
+    return await service._send_invitation_email(
+        _invitation(),
+        SimpleNamespace(name="Acme Corp"),
+        SimpleNamespace(name="Ada Lovelace", email="ada@example.com"),
+    )
+
+
+def _payload(service):
+    """The single message handed to the transport."""
+    assert service.email_service._send_email.await_count == 1
+    return service.email_service._send_email.await_args.kwargs
+
+
+class TestSend:
+    async def test_reports_sent(self):
+        # The regression: this returned None because AttributeError was caught
+        # and printed, so nothing could tell a sent invitation from a dead one.
+        service = _service()
+        assert await _send(service) is True
+
+    async def test_transport_called(self):
+        service = _service()
+        await _send(service)
+        assert _payload(service)["to_email"] == "invitee@example.com"
+
+    async def test_reports_failure(self):
+        # _send_email returns False when no transport is configured; that must
+        # surface rather than read as success.
+        service = _service(sent=False)
+        assert await _send(service) is False
+
+
+class TestContent:
+    async def test_href_carries_token(self):
+        # An action button with no usable href is the failure mode this whole
+        # path exists to avoid: the token is what /accept looks up.
+        service = _service()
+        await _send(service)
+        html = _payload(service)["html_content"]
+        assert 'href="' in html
+        assert f"token={TOKEN}" in html
+        assert 'href=""' not in html
+
+    async def test_uses_template(self):
+        # Proves the maintained invitation.html is what shipped, not a
+        # hand-rolled string: these markers exist only in the template.
+        service = _service()
+        await _send(service)
+        html = _payload(service)["html_content"]
+        assert "You've been invited!" in html
+        assert "Acme Corp" in html
+        assert "Ada Lovelace" in html
+        assert "admin" in html
+
+    async def test_extends_base(self):
+        # base.html supplies the wrapper; a template that failed to resolve
+        # its parent would render without it.
+        service = _service()
+        await _send(service)
+        html = _payload(service)["html_content"]
+        assert "<html" in html.lower()
+        assert str(datetime.utcnow().year) in html
+
+    async def test_text_part(self):
+        service = _service()
+        await _send(service)
+        text = _payload(service)["text_content"]
+        assert f"token={TOKEN}" in text
+        assert "Acme Corp" in text
+        assert "<" not in text.split("http")[0]
+
+    async def test_subject(self):
+        service = _service()
+        await _send(service)
+        assert "Acme Corp" in _payload(service)["subject"]
+
+
+class TestUrl:
+    def test_token_in_url(self):
+        url = _invitation().generate_invite_url("https://app.example.com")
+        assert url == f"https://app.example.com/invitations/accept?token={TOKEN}"
+
+    def test_trailing_slash(self):
+        url = _invitation().generate_invite_url("https://app.example.com/")
+        assert "//invitations" not in url.replace("https://", "")
+
+
+class TestValidity:
+    def test_pending_is_valid(self):
+        assert _invitation().is_valid is True
+        assert _invitation().is_expired is False
+
+    def test_expired(self):
+        invitation = _invitation()
+        invitation.expires_at = datetime.utcnow() - timedelta(seconds=1)
+        assert invitation.is_expired is True
+        assert invitation.is_valid is False
+
+    def test_accepted_not_valid(self):
+        invitation = _invitation()
+        invitation.status = "accepted"
+        assert invitation.is_valid is False
+
+
+class TestEmailService:
+    """The seam the invitation service now calls."""
+
+    async def test_method_exists(self):
+        # The original defect in one line: this attribute was absent, so every
+        # call raised AttributeError.
+        assert callable(getattr(EmailService, "send_invitation_email", None))
+
+    async def test_returns_transport_result(self):
+        service = EmailService()
+        service._send_email = AsyncMock(return_value=False)
+        result = await service.send_invitation_email(
+            email="invitee@example.com",
+            invite_url="https://app.example.com/invitations/accept?token=x",
+            organization_name="Acme Corp",
+            inviter_name="Ada Lovelace",
+        )
+        assert result is False
+
+    async def test_render_failure_keeps_url(self):
+        # Even if a template blows up, the recipient must still get a link.
+        service = EmailService()
+        service._send_email = AsyncMock(return_value=True)
+        with patch.object(service.jinja_env, "get_template", side_effect=RuntimeError("boom")):
+            await service.send_invitation_email(
+                email="invitee@example.com",
+                invite_url=f"https://app.example.com/invitations/accept?token={TOKEN}",
+                organization_name="Acme Corp",
+                inviter_name="Ada Lovelace",
+            )
+        assert TOKEN in service._send_email.await_args.kwargs["html_content"]
+
+
+class TestCreate:
+    """create_invitation is the entry point to the send path."""
+
+    def _service(self, owner_id="u-1"):
+        organization = MagicMock()
+        organization.id = "22222222-2222-2222-2222-222222222222"
+        organization.name = "Acme Corp"
+        organization.owner_id = owner_id
+
+        db = MagicMock()
+        # organization -> invitee User -> existing invitation -> Role
+        db.query.return_value.filter.return_value.first.side_effect = [
+            organization,
+            None,
+            None,
+            None,
+        ]
+
+        def flush(obj=None, *args, **kwargs):
+            """Stand in for the defaults SQLAlchemy applies at flush time."""
+            if obj is None:
+                return
+            if getattr(obj, "created_at", None) is None:
+                obj.created_at = datetime.utcnow()
+            if getattr(obj, "id", None) is None:
+                obj.id = uuid.uuid4()
+
+        db.add.side_effect = flush
+        db.refresh.side_effect = flush
+
+        service = InvitationService(db)
+        service.email_service._send_email = AsyncMock(return_value=True)
+        service.audit_logger = MagicMock()
+        service.audit_logger.log = AsyncMock()
+        return service
+
+    async def _create(self, service, inviter_id="u-1"):
+        from app.models.invitation import InvitationCreate
+
+        inviter = MagicMock()
+        inviter.id = inviter_id
+        inviter.email = "ada@example.com"
+        inviter.name = "Ada Lovelace"
+        return await service.create_invitation(
+            InvitationCreate(
+                organization_id="22222222-2222-2222-2222-222222222222",
+                email="invitee@example.com",
+                role="admin",
+                expires_in=7,
+            ),
+            inviter,
+            "tenant-1",
+        )
+
+    async def test_mails_invitee(self):
+        service = self._service()
+        response = await self._create(service)
+        assert response.email_sent is True
+        assert _payload(service)["to_email"] == "invitee@example.com"
+
+    async def test_token_minted(self):
+        # token is NOT NULL and is the only thing /accept looks up, yet
+        # nothing ever generated one.
+        service = self._service()
+        response = await self._create(service)
+        token = response.invite_url.split("token=")[1]
+        assert len(token) >= 32
+
+    async def test_mailed_token_matches(self):
+        # The link the invitee receives must be the one the API reports —
+        # otherwise the invitation can never be redeemed.
+        service = self._service()
+        response = await self._create(service)
+        assert f'href="{response.invite_url}"' in _payload(service)["html_content"]
+
+    async def test_send_failure_reported(self):
+        service = self._service()
+        service.email_service._send_email = AsyncMock(return_value=False)
+        response = await self._create(service)
+        # The invitation still exists and stays redeemable; the caller is just
+        # told the truth about delivery.
+        assert response.email_sent is False
+        assert "token=" in response.invite_url
+
+    async def test_foreign_org_refused(self):
+        # require_org_admin only proves the caller administers SOME org, so
+        # this per-organization check is what stops a cross-org invite.
+        service = self._service(owner_id="someone-else")
+        service.db.query.return_value.filter.return_value.first.side_effect = None
+        organization = MagicMock()
+        organization.id = "22222222-2222-2222-2222-222222222222"
+        organization.owner_id = "someone-else"
+        service.db.query.return_value.filter.return_value.first.side_effect = [
+            organization,
+            None,  # no admin membership for the caller
+        ]
+        with pytest.raises(ValueError):
+            await self._create(service, inviter_id="u-1")
+        service.email_service._send_email.assert_not_awaited()


### PR DESCRIPTION
## 1. Signup never captured the user's language

`users.locale` (String(10), nullable) has existed on the `User` model and in `000_init` from the start, and `PATCH /api/v1/users/me` can write it. But **no account-creation path ever set it**, so it is NULL for essentially every row and locale resolution always falls through to the deployment default. The column was a place to put a preference nobody ever collected.

### `app/core/locale.py`

A small negotiator with two rules:

1. **Only store a language we can actually render.** Persisting `fr-CA` because a browser asked for it manufactures a user whose experience is *worse* than the default — the default has translations, `fr` does not. Unsupported tags resolve to `None` so the caller stores NULL.
2. **Locale is never required.** A missing, malformed, or hostile `Accept-Language` returns `None`. Signup must not care.

`Accept-Language` is parsed properly rather than by substring: q-values order the list, `q=0` is an explicit rejection and is dropped, ties keep their left-to-right order, `*` is treated as an absence of preference (falls through to the default rather than pinning the row to a guess), and the header is length-capped since it is attacker-controlled. Tags are reduced to a bare language subtag — `es-MX`, `es_MX`, `ES-mx`, `es-419` all mean `es` — because a translation set is per-language and regional variants share it.

### Every live creation path now captures it

| Path | Source |
|---|---|
| `POST /auth/signup` | new optional `locale` body field → `Accept-Language` |
| `POST /auth/magic-link` (creates a user when none exists) | `Accept-Language` |
| OAuth callback → `find_or_create_user` | provider `locale` claim (standard OIDC) → `Accept-Language` |
| SAML ACS / OIDC callback → `_provision_user` (JIT) | mapped IdP attribute → `Accept-Language` |
| SCIM `POST /Users` | body `locale`/`preferredLanguage` **only** |
| `POST /invitations/accept` | `Accept-Language` |

SCIM deliberately ignores the request header: it is a machine-to-machine call, so `Accept-Language` describes the provisioning agent, not the human being created. The SCIM core schema defines both attributes and directory providers populate them — the body is the only honest source there. For the same reason a provider/IdP claim outranks the header where one exists: the user chose that language in their identity account.

An existing account always keeps the preference it already has; only newly created rows are written.

**Not captured:** the `ADMIN_BOOTSTRAP_PASSWORD` startup path has no request and no headers, so it correctly leaves NULL. `AuthService.create_user` (`app/auth/router.py`, `router_completed.py`), the parallel `app/sso/domain/.../user_provisioning.py` stack, and the GraphQL `signUp` mutation also create users but **none of their routers are mounted** — left alone rather than instrumenting dead code.

## 2. The invitation email could not be sent

Verified by reading the code, not assumed. The path was dead in several stacked ways, none of them visible:

- `InvitationService` called **`EmailService.send_email` — a method that does not exist on that class.** Only `_send_email` does. (`ResendEmailService` has a `send_email`, but nothing wires it into this flow.)
- It never got that far: the first statement was `invitation.email_send_attempts += 1`, and `invitations` has no such column. Nor does it have `tenant_id`, `role_id`, `role_name`, `invited_by`, `message`, `email_sent`, `email_sent_at` or `accepted_by` — all of which the service read or wrote. The real table has ten columns.
- `Invitation.generate_invite_url`, `.is_expired` and `.is_valid` were called in seven places and **defined in none**.
- `settings.APP_URL`, used to build every invite link, **is not a setting** (`Settings` has `BASE_URL`, `API_BASE_URL`, `FRONTEND_URL`).
- `create_invitation` **never generated `token`** — which is `NOT NULL`, unique, and the only value `/invitations/validate/{token}` and `/invitations/accept` look up. So no invitation could have been redeemed even if one had been mailed.
- `AuditAction.INVITATION_{CREATE,ACCEPT,REVOKE,RESEND}` did not exist.
- Every one of these landed in a bare `except Exception: print(...)`, so the endpoint reported success.

Separately, the service hand-rolled its own HTML string rather than rendering `templates/email/invitation.{html,txt}` — maintained templates that no live path had ever rendered.

### Fix

- Define the three `Invitation` helpers. They are pure functions of columns that already exist, so **no migration**.
- Add the four missing audit actions.
- Mint a `secrets.token_urlsafe(32)` token at creation, so the value that is mailed is the value the verify path validates.
- Build rows and responses from columns that exist; `email_sent` now reports what actually happened on the request.
- Add `EmailService.send_invitation_email`, which renders the maintained templates and puts them on the same transport as every other transactional message. `_send_invitation_email` returns whether it sent and logs honestly instead of swallowing. A send failure still does not undo the invitation — the row is real and the link stays redeemable — but the caller can now tell the difference.
- `_render_template`'s fallback chain gained an `invitation` branch, so even a template failure still ships a usable link rather than "Email content unavailable".

### ⚠️ One change worth reviewer attention

`create_invitation`'s organization lookup filtered on `Organization.tenant_id`, which does not exist, so it raised before it could scope anything. **I did not simply drop the filter** — `require_org_admin` only proves the caller administers *some* organization, so dropping it would let any org admin invite members into an organization they have nothing to do with. The scoping is restored against real columns: the caller must own the target organization or hold an `admin`/`owner` membership in it. Covered by `test_foreign_org_refused` and `test_ownerless_org_refused` (second commit: both ids must be present before they can match, so an ownerless organization and an id-less caller do not compare equal as "None").

The membership pre-check was likewise rewritten: `OrganizationMember` is keyed by `user_id`, not `user_email`.

## Relationship to #529

**#529 (`feat/localized-transactional-email`) has not merged**; this branch is cut from `main` and does **not** import from it. They are complementary — #529 decides which language to *render*, this one collects the preference that feeds it. Nothing here duplicates its templates, subjects, or `build_email_environment`.

One deliberate overlap to collapse on the second merge: #529's `email_i18n.normalize_locale` / `SUPPORTED_LOCALES` have the same semantics as the ones here. Whichever lands second should import from the other rather than keep two lists — suggest `email_i18n` imports from `app.core.locale`, since request-side negotiation is the more general concern and `email_i18n` is mail-specific. Merge order does not matter otherwise; there are no file-level conflicts.

## Tests

60 new (23 locale negotiation, 15 creation-path capture, 22 invitation email).

Covering the asks directly: locale captured from a header on each path; unsupported tag not stored; signup succeeds with no header; and the invitation defect reproduced.

**Verified failing before the fix.** Reverting only `app/` (keeping the tests) against the parent commit gives **27 failures** across the invitation and capture suites — including `test_method_exists`, which is the original defect in one line.

Full unit suite compared to clean `main` **by name**:

```
baseline (main): 12 failed, 84 errors  = 96 named
this branch:     12 failed, 84 errors  = 96 named
new failures:    none
```

Passing count rises 2694 → 2754. `ruff` and `black` are unchanged against main's pre-existing state (6 ruff findings, 5 black-dirty files, all pre-existing and untouched).

## Deliberately out of scope

The rest of the invitation subsystem is written against the same schema that does not exist and needs its own PR (it involves a migration decision for `message`, which the API accepts and silently discards):

- `list_invitations`, `get_invitation`, `update_invitation` in the router read `Invitation.tenant_id`, `role_name`, `invited_by`, `message`, `email_sent`, and additionally `await db.execute(...)` on a sync `Session`.
- `InvitationCreate.message` is accepted and dropped — there is no column for it.
- `apps/dashboard` has no invitation-acceptance page, so the emailed link (`{FRONTEND_URL}/invitations/accept?token=…`) has no frontend route yet. The link is well-formed and the token is valid against the API; the page is the gap.
