### PR TITLE
fix(api): make the invitations router work against the real schema

### DIFF
--- a/apps/api/alembic/versions/011_invitation_columns.py
+++ b/apps/api/alembic/versions/011_invitation_columns.py
@@ -1,0 +1,63 @@
+"""Add the two invitation columns the router has always read and written.
+
+`app/routers/v1/invitations.py` returns `message` and `email_sent` from every
+read endpoint, and `PATCH /invitations/{id}` writes `message`. Neither column
+existed: alembic `000_init` created `invitations` with only (id,
+organization_id, email, role, status, token, expires_at, accepted_at,
+created_by, created_at) and the SQLAlchemy model matched that exactly. So the
+reads raised AttributeError before reaching the database, and PATCH's write
+landed on a plain Python attribute that no commit could ever persist -- the
+endpoint reported the new message back to the caller and stored nothing.
+
+`message` is offered by `InvitationCreate`, returned by `InvitationResponse`
+and updatable through `InvitationUpdate`. Persisting it is what lets those
+three schemas describe the same field; the alternative -- deleting it from the
+request and response models -- would remove a documented field from the public
+API and every generated SDK to work around a missing column on an empty table.
+
+`email_sent` is reported by the list/get/update responses, which read a row
+back from the database and therefore have no request-scoped send outcome to
+borrow. It defaults to false and is set by the delivery path.
+
+The table is empty everywhere (verified 0 rows in production on 2026-08-13
+before this migration was written), so the new NOT NULL column can take a
+server default without a backfill step.
+
+`IF NOT EXISTS` keeps this idempotent against environments that ran
+`Base.metadata.create_all` instead of migrations (the test suite does).
+
+Revision ID: 011_invitation_columns
+Revises: 010_policy_authz_columns
+"""
+
+from alembic import op
+
+revision = "011_invitation_columns"
+down_revision = "010_policy_authz_columns"
+branch_labels = None
+depends_on = None
+
+
+# (column, DDL type + constraints)
+_COLUMNS = [
+    ("message", "text"),
+    ("email_sent", "boolean NOT NULL DEFAULT false"),
+]
+
+
+def upgrade() -> None:
+    for name, ddl in _COLUMNS:
+        op.execute(f"ALTER TABLE invitations ADD COLUMN IF NOT EXISTS {name} {ddl}")
+
+    # Every list/count query scopes to a set of organizations and then filters
+    # or groups by status.
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_invitations_organization_id_status "
+        "ON invitations (organization_id, status)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_invitations_organization_id_status")
+    for name, _ in reversed(_COLUMNS):
+        op.execute(f"ALTER TABLE invitations DROP COLUMN IF EXISTS {name}")

--- a/apps/api/app/models/__init__.py
+++ b/apps/api/app/models/__init__.py
@@ -613,6 +613,15 @@ class Invitation(Base):
     created_by = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     created_at = Column(DateTime, default=datetime.utcnow)
 
+    # `message` is offered by InvitationCreate, returned by InvitationResponse
+    # and updatable through InvitationUpdate, but was never a column. Reads
+    # raised AttributeError and PATCH's write landed on a plain Python
+    # attribute that no commit could persist. `email_sent` is the same story
+    # for the delivery flag the list/get responses report: a row read back
+    # from the database has no request-scoped send outcome to borrow, so the
+    # outcome has to live on the row.
+    message = Column(Text)
+    email_sent = Column(Boolean, nullable=False, default=False, server_default="false")
     # The three helpers below are called from the invitation service and
     # router but were never defined anywhere, so every reference raised
     # AttributeError. They are pure functions of columns that already exist,
@@ -1024,8 +1033,8 @@ class Translation(Base):
 
 
 # Import enterprise models
-from app.models.enterprise import SSOConfiguration, SSOProvider, SSOStatus  # noqa: E402
 from app.models.connected_account import ConnectedAccount, ProviderType  # noqa: E402,F401
+from app.models.enterprise import SSOConfiguration, SSOProvider, SSOStatus  # noqa: E402
 
 # Import compliance models
 

--- a/apps/api/app/routers/v1/invitations.py
+++ b/apps/api/app/routers/v1/invitations.py
@@ -2,16 +2,19 @@
 Invitation management API endpoints.
 """
 
+import uuid
+from datetime import datetime
 from typing import Optional
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, status
-from sqlalchemy import and_, func, select
-from sqlalchemy.orm import Session
+from sqlalchemy import func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.core.locale import locale_from_request
 from app.database import get_db
 from app.dependencies import get_current_user, require_org_admin
+from app.models import Organization, OrganizationMember
 from app.models.invitation import (
     BulkInvitationCreate,
     BulkInvitationResponse,
@@ -31,12 +34,108 @@ from app.services.invitation_service import InvitationService
 router = APIRouter(prefix="/v1/invitations", tags=["invitations"])
 
 
+def _invite_base_url() -> str:
+    """Root for acceptance links.
+
+    The handlers below used to pass `settings.APP_URL`, which is not a setting
+    on this application at all -- reading it raised AttributeError before the
+    URL could be built.
+    """
+    return settings.FRONTEND_URL or settings.BASE_URL
+
+
+def _as_uuid(value: str) -> Optional[uuid.UUID]:
+    """Parse an id from the path, or None when it is not a UUID at all.
+
+    The columns being compared are `uuid`, so handing Postgres an arbitrary
+    string is a 500 rather than the 404 the caller should see.
+    """
+    try:
+        return uuid.UUID(str(value))
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
+async def _accessible_org_ids(db: AsyncSession, user: User) -> set:
+    """Organizations whose invitations this user may see.
+
+    Scoping is by `organization_id`, the only tenancy this table records.
+    The previous filter -- `Invitation.tenant_id == current_user.tenant_id` --
+    named a column that does not exist on `invitations`, and the fallback
+    branch called `current_user.get_organizations()`, a method `User` does not
+    define. Either one raised before a single row could be scoped.
+    """
+    member_rows = await db.execute(
+        select(OrganizationMember.organization_id).where(OrganizationMember.user_id == user.id)
+    )
+    org_ids = set(member_rows.scalars().all())
+
+    owned_rows = await db.execute(select(Organization.id).where(Organization.owner_id == user.id))
+    org_ids.update(owned_rows.scalars().all())
+
+    return org_ids
+
+
+async def _require_org_admin_for(db: AsyncSession, user: User, organization_id) -> None:
+    """Assert the caller administers *this* organization.
+
+    `require_org_admin` only proves the caller is an admin or owner of SOME
+    organization. Without a per-organization check, an admin of org A could
+    mutate org B's invitations. Raises 404 rather than 403 so the endpoint
+    does not confirm that an invitation the caller cannot reach exists.
+    """
+    org = (
+        await db.execute(select(Organization).where(Organization.id == organization_id))
+    ).scalar_one_or_none()
+
+    owner_id = getattr(org, "owner_id", None)
+    # Both ids must be present before they can match, so that an ownerless
+    # organization and an id-less caller do not compare equal as "None".
+    if owner_id and user.id and str(owner_id) == str(user.id):
+        return
+
+    membership = (
+        await db.execute(
+            select(OrganizationMember).where(
+                OrganizationMember.organization_id == organization_id,
+                OrganizationMember.user_id == user.id,
+                OrganizationMember.role.in_(["admin", "owner"]),
+            )
+        )
+    ).scalar_one_or_none()
+
+    if membership is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invitation not found")
+
+
+def _to_response(invitation: Invitation) -> InvitationResponse:
+    """Build the API response from columns that exist.
+
+    `role_name`, `invited_by`, `message` and `email_sent` were read here; the
+    first two are spelled `role` and `created_by` on the table and the last
+    two were not columns at all until this change.
+    """
+    return InvitationResponse(
+        id=str(invitation.id),
+        organization_id=str(invitation.organization_id),
+        email=invitation.email,
+        role=invitation.role or "member",
+        status=invitation.status,
+        invited_by=str(invitation.created_by),
+        message=invitation.message,
+        expires_at=invitation.expires_at,
+        created_at=invitation.created_at,
+        invite_url=invitation.generate_invite_url(_invite_base_url()),
+        email_sent=bool(invitation.email_sent),
+    )
+
+
 @router.post("/", response_model=InvitationResponse, status_code=status.HTTP_201_CREATED)
 async def create_invitation(
     invitation_data: InvitationCreate,
     background_tasks: BackgroundTasks,
     current_user=Depends(require_org_admin),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db),
 ):
     """
     Create a new invitation for an organization (org admin only).
@@ -61,7 +160,7 @@ async def create_bulk_invitations(
     bulk_data: BulkInvitationCreate,
     background_tasks: BackgroundTasks,
     current_user=Depends(require_org_admin),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db),
 ):
     """
     Create multiple invitations at once (org admin only).
@@ -89,82 +188,51 @@ async def list_invitations(
     skip: int = Query(0, ge=0),
     limit: int = Query(100, ge=1, le=1000),
     current_user=Depends(get_current_user),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db),
 ):
     """
     List invitations for organizations the user has access to.
     """
-    stmt = select(Invitation).where(Invitation.tenant_id == current_user.tenant_id)
+    org_ids = await _accessible_org_ids(db, current_user)
 
-    # Filter by organization if specified
+    # An explicit organization narrows the scope; it never widens it.
     if organization_id:
-        stmt = stmt.where(Invitation.organization_id == organization_id)
-    else:
-        # Get user's organizations
-        user_orgs = current_user.get_organizations()
-        org_ids = [org.id for org in user_orgs]
-        if org_ids:
-            stmt = stmt.where(Invitation.organization_id.in_(org_ids))
+        requested = _as_uuid(organization_id)
+        org_ids = {requested} & org_ids if requested else set()
 
-    # Filter by status
-    if status:
-        stmt = stmt.where(Invitation.status == status.value)
+    if not org_ids:
+        return InvitationListResponse(invitations=[], total=0)
 
-    # Filter by email
+    scoped = select(Invitation).where(Invitation.organization_id.in_(org_ids))
+
     if email:
-        stmt = stmt.where(Invitation.email.ilike(f"%{email}%"))
+        scoped = scoped.where(Invitation.email.ilike(f"%{email}%"))
 
-    # Get total count
-    count_result = await db.execute(select(func.count()).select_from(stmt.subquery()))
-    total = count_result.scalar()
+    # The status breakdown describes the whole scoped set, so it is counted
+    # before the status filter narrows the listing itself.
+    async def _count(stmt) -> int:
+        result = await db.execute(select(func.count()).select_from(stmt.subquery()))
+        return result.scalar() or 0
 
-    # Get status counts
-    pending_result = await db.execute(
-        select(func.count()).select_from(
-            stmt.where(Invitation.status == InvitationStatus.PENDING.value).subquery()
-        )
+    pending_count = await _count(scoped.where(Invitation.status == InvitationStatus.PENDING.value))
+    accepted_count = await _count(
+        scoped.where(Invitation.status == InvitationStatus.ACCEPTED.value)
     )
-    pending_count = pending_result.scalar()
+    expired_count = await _count(scoped.where(Invitation.status == InvitationStatus.EXPIRED.value))
 
-    accepted_result = await db.execute(
-        select(func.count()).select_from(
-            stmt.where(Invitation.status == InvitationStatus.ACCEPTED.value).subquery()
-        )
+    listing = scoped
+    if status:
+        listing = listing.where(Invitation.status == status.value)
+
+    total = await _count(listing)
+
+    result = await db.execute(
+        listing.order_by(Invitation.created_at.desc()).offset(skip).limit(limit)
     )
-    accepted_count = accepted_result.scalar()
-
-    expired_result = await db.execute(
-        select(func.count()).select_from(
-            stmt.where(Invitation.status == InvitationStatus.EXPIRED.value).subquery()
-        )
-    )
-    expired_count = expired_result.scalar()
-
-    # Get paginated results
-    result = await db.execute(stmt.order_by(Invitation.created_at.desc()).offset(skip).limit(limit))
     invitations = result.scalars().all()
 
-    # Convert to response models
-    invitation_responses = []
-    for inv in invitations:
-        invitation_responses.append(
-            InvitationResponse(
-                id=str(inv.id),
-                organization_id=str(inv.organization_id),
-                email=inv.email,
-                role=inv.role_name,
-                status=inv.status,
-                invited_by=str(inv.invited_by),
-                message=inv.message,
-                expires_at=inv.expires_at,
-                created_at=inv.created_at,
-                invite_url=inv.generate_invite_url(settings.APP_URL),
-                email_sent=inv.email_sent,
-            )
-        )
-
     return InvitationListResponse(
-        invitations=invitation_responses,
+        invitations=[_to_response(inv) for inv in invitations],
         total=total,
         pending_count=pending_count,
         accepted_count=accepted_count,
@@ -172,36 +240,31 @@ async def list_invitations(
     )
 
 
+async def _load_scoped(db: AsyncSession, invitation_id: str, user: User) -> Invitation:
+    """Fetch an invitation the caller is allowed to see, or 404."""
+    parsed = _as_uuid(invitation_id)
+    if parsed is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invitation not found")
+
+    invitation = (
+        await db.execute(select(Invitation).where(Invitation.id == parsed))
+    ).scalar_one_or_none()
+
+    if invitation is None or invitation.organization_id not in await _accessible_org_ids(db, user):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invitation not found")
+
+    return invitation
+
+
 @router.get("/{invitation_id}", response_model=InvitationResponse)
 async def get_invitation(
-    invitation_id: str, current_user=Depends(get_current_user), db: Session = Depends(get_db)
+    invitation_id: str, current_user=Depends(get_current_user), db: AsyncSession = Depends(get_db)
 ):
     """
     Get a specific invitation by ID.
     """
-    result = await db.execute(
-        select(Invitation).where(
-            and_(Invitation.id == invitation_id, Invitation.tenant_id == current_user.tenant_id)
-        )
-    )
-    invitation = result.scalar_one_or_none()
-
-    if not invitation:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invitation not found")
-
-    return InvitationResponse(
-        id=str(invitation.id),
-        organization_id=str(invitation.organization_id),
-        email=invitation.email,
-        role=invitation.role_name,
-        status=invitation.status,
-        invited_by=str(invitation.invited_by),
-        message=invitation.message,
-        expires_at=invitation.expires_at,
-        created_at=invitation.created_at,
-        invite_url=invitation.generate_invite_url(settings.APP_URL),
-        email_sent=invitation.email_sent,
-    )
+    invitation = await _load_scoped(db, invitation_id, current_user)
+    return _to_response(invitation)
 
 
 @router.patch("/{invitation_id}", response_model=InvitationResponse)
@@ -209,20 +272,13 @@ async def update_invitation(
     invitation_id: str,
     update_data: InvitationUpdate,
     current_user=Depends(require_org_admin),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db),
 ):
     """
     Update a pending invitation (org admin only).
     """
-    result = await db.execute(
-        select(Invitation).where(
-            and_(Invitation.id == invitation_id, Invitation.tenant_id == current_user.tenant_id)
-        )
-    )
-    invitation = result.scalar_one_or_none()
-
-    if not invitation:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Invitation not found")
+    invitation = await _load_scoped(db, invitation_id, current_user)
+    await _require_org_admin_for(db, current_user, invitation.organization_id)
 
     if invitation.status != InvitationStatus.PENDING.value:
         raise HTTPException(
@@ -230,9 +286,11 @@ async def update_invitation(
             detail=f"Cannot update invitation with status: {invitation.status}",
         )
 
-    # Update fields
+    # Update fields. `role` was written as `role_name` and `message` was not a
+    # column, so both assignments used to land on plain Python attributes: the
+    # response echoed the new values back and the database kept the old ones.
     if update_data.role is not None:
-        invitation.role_name = update_data.role
+        invitation.role = update_data.role
 
     if update_data.message is not None:
         invitation.message = update_data.message
@@ -243,19 +301,7 @@ async def update_invitation(
     await db.commit()
     await db.refresh(invitation)
 
-    return InvitationResponse(
-        id=str(invitation.id),
-        organization_id=str(invitation.organization_id),
-        email=invitation.email,
-        role=invitation.role_name,
-        status=invitation.status,
-        invited_by=str(invitation.invited_by),
-        message=invitation.message,
-        expires_at=invitation.expires_at,
-        created_at=invitation.created_at,
-        invite_url=invitation.generate_invite_url(settings.APP_URL),
-        email_sent=invitation.email_sent,
-    )
+    return _to_response(invitation)
 
 
 @router.post("/{invitation_id}/resend", response_model=InvitationResponse)
@@ -263,11 +309,17 @@ async def resend_invitation(
     invitation_id: str,
     background_tasks: BackgroundTasks,
     current_user=Depends(require_org_admin),
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db),
 ):
     """
     Resend an invitation email (org admin only).
     """
+    # Neither this endpoint nor the service it delegates to checked which
+    # organization the invitation belongs to, so any organization admin could
+    # act on any organization's invitations by id.
+    invitation = await _load_scoped(db, invitation_id, current_user)
+    await _require_org_admin_for(db, current_user, invitation.organization_id)
+
     service = InvitationService(db)
 
     try:
@@ -283,11 +335,16 @@ async def resend_invitation(
 
 @router.delete("/{invitation_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def revoke_invitation(
-    invitation_id: str, current_user=Depends(require_org_admin), db: Session = Depends(get_db)
+    invitation_id: str,
+    current_user=Depends(require_org_admin),
+    db: AsyncSession = Depends(get_db),
 ):
     """
     Revoke a pending invitation (org admin only).
     """
+    invitation = await _load_scoped(db, invitation_id, current_user)
+    await _require_org_admin_for(db, current_user, invitation.organization_id)
+
     service = InvitationService(db)
 
     try:
@@ -303,7 +360,7 @@ async def revoke_invitation(
 async def accept_invitation(
     accept_data: InvitationAcceptRequest,
     request: Request,
-    db: Session = Depends(get_db),
+    db: AsyncSession = Depends(get_db),
 ):
     """
     Accept an invitation using the token.
@@ -342,7 +399,7 @@ async def accept_invitation(
 
 
 @router.get("/validate/{token}")
-async def validate_invitation_token(token: str, db: Session = Depends(get_db)):
+async def validate_invitation_token(token: str, db: AsyncSession = Depends(get_db)):
     """
     Validate an invitation token and get details.
     """
@@ -382,8 +439,6 @@ async def validate_invitation_token(token: str, db: Session = Depends(get_db)):
         }
 
     # Get organization details
-    from app.models.organization import Organization
-
     org_result = await db.execute(
         select(Organization).where(Organization.id == invitation.organization_id)
     )
@@ -394,7 +449,7 @@ async def validate_invitation_token(token: str, db: Session = Depends(get_db)):
         "email": invitation.email,
         "organization_id": str(invitation.organization_id),
         "organization_name": org.name if org else None,
-        "role": invitation.role_name,
+        "role": invitation.role,
         "expires_at": invitation.expires_at.isoformat(),
         "message": invitation.message,
     }
@@ -402,13 +457,32 @@ async def validate_invitation_token(token: str, db: Session = Depends(get_db)):
 
 @router.post("/cleanup")
 async def cleanup_expired_invitations(
-    current_user=Depends(require_org_admin), db: Session = Depends(get_db)
+    current_user=Depends(require_org_admin), db: AsyncSession = Depends(get_db)
 ):
     """
     Clean up expired invitations (org admin only).
     """
-    service = InvitationService(db)
+    # This used to call `InvitationService.cleanup_expired_invitations`, a
+    # synchronous method built on `Session.query`. The session injected here
+    # is an AsyncSession, which has no `.query`, so the call raised before it
+    # could mark anything -- and it swept every organization's invitations,
+    # not just those of the admin making the request. Both are fixed by
+    # expiring within the caller's own organizations, in one statement.
+    org_ids = await _accessible_org_ids(db, current_user)
+    if not org_ids:
+        return {"message": "Marked 0 invitations as expired", "count": 0}
 
-    count = service.cleanup_expired_invitations()
+    result = await db.execute(
+        update(Invitation)
+        .where(
+            Invitation.organization_id.in_(org_ids),
+            Invitation.status == InvitationStatus.PENDING.value,
+            Invitation.expires_at < datetime.utcnow(),
+        )
+        .values(status=InvitationStatus.EXPIRED.value)
+    )
+    await db.commit()
+
+    count = result.rowcount or 0
 
     return {"message": f"Marked {count} invitations as expired", "count": count}

--- a/apps/api/tests/unit/routers/test_invitations_schema_drift.py
+++ b/apps/api/tests/unit/routers/test_invitations_schema_drift.py
@@ -1,0 +1,408 @@
+"""The invitations router read and wrote columns the `invitations` table lacks.
+
+`app/routers/v1/invitations.py` scoped every read on `Invitation.tenant_id` and
+built its responses from `role_name`, `invited_by`, `message` and `email_sent`.
+The table has ten columns -- (id, organization_id, email, role, status, token,
+expires_at, accepted_at, created_by, created_at) -- and the SQLAlchemy model
+matched it exactly, so model and migration agreed and the *router* was the
+drift. `role_name` and `invited_by` are `role` and `created_by` under different
+names; `message` and `email_sent` were not columns at all.
+
+Three more references had nothing behind them either: `generate_invite_url`,
+`is_expired` (defined on no class), `current_user.get_organizations()` (defined
+on no class) and `settings.APP_URL` (not a setting). Every handler therefore
+raised before reaching the database, which is why the production table held 0
+rows.
+
+`PATCH /invitations/{id}` was the quiet one: `invitation.role_name = ...` and
+`invitation.message = ...` land on plain Python attributes, so the endpoint
+returned the caller's new values with a 200 and committed none of them.
+
+These tests use real model instances and a real session because that is the
+only way to tell a real column from a missing one -- a mocked manager answers
+to any attribute name, which is exactly how this survived.
+
+Style follows `test_policies_schema_drift.py` (janua#527).
+"""
+
+import ast
+import inspect
+import uuid
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.models import Base, Invitation, Organization, OrganizationMember, User
+from app.models.invitation import InvitationResponse, InvitationStatus, InvitationUpdate
+from app.routers.v1 import invitations as invitations_router
+
+pytestmark = pytest.mark.asyncio
+
+# Tables this module touches. Creating only these keeps the fixture independent
+# of unrelated models that fail to map under SQLite.
+_TABLES = ["users", "organizations", "organization_members", "invitations"]
+
+
+@pytest_asyncio.fixture
+async def db():
+    """An isolated in-memory database per test.
+
+    These tests assert on row visibility, so they must not see another test's
+    rows.
+    """
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    tables = [Base.metadata.tables[name] for name in _TABLES]
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all, tables=tables)
+
+    session_factory = async_sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+
+    await engine.dispose()
+
+
+async def _org_with_admin(db, name):
+    """Create an organization plus an admin/owner member of it."""
+    org = Organization(id=uuid.uuid4(), name=name, slug=name)
+    user = User(id=uuid.uuid4(), email=f"admin@{name}.test")
+    db.add_all([org, user])
+    await db.flush()
+    db.add(
+        OrganizationMember(id=uuid.uuid4(), organization_id=org.id, user_id=user.id, role="admin")
+    )
+    await db.commit()
+    # The routers receive the authenticated principal, not an ORM instance.
+    return org, SimpleNamespace(id=user.id, tenant_id=None)
+
+
+async def _invite(db, org, creator, **overrides):
+    """Persist one invitation, exercising every column the router reports."""
+    fields = {
+        "id": uuid.uuid4(),
+        "organization_id": org.id,
+        "email": "invitee@example.test",
+        "role": "member",
+        "status": InvitationStatus.PENDING.value,
+        "token": f"tok-{uuid.uuid4().hex}",
+        "expires_at": datetime.utcnow() + timedelta(days=7),
+        "created_by": creator.id,
+        "created_at": datetime.utcnow(),
+        "message": "join us",
+        "email_sent": True,
+    }
+    fields.update(overrides)
+    invitation = Invitation(**fields)
+    db.add(invitation)
+    await db.commit()
+    return invitation
+
+
+def _executable_source(obj) -> str:
+    """Source of `obj` with docstrings stripped, so prose can't satisfy a scan."""
+    tree = ast.parse(inspect.getsource(obj))
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Module)):
+            if ast.get_docstring(node):
+                node.body = node.body[1:]
+    return ast.unparse(tree)
+
+
+def _attributes_accessed_on(module, names) -> set:
+    """Every `<name>.<attr>` referenced in `module`'s executable source."""
+    tree = ast.parse(_executable_source(module))
+    return {
+        node.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute)
+        and isinstance(node.value, ast.Name)
+        and node.value.id in names
+    }
+
+
+# ---------------------------------------------------------------------------
+# Structural guards: no caller may reference something that isn't there
+# ---------------------------------------------------------------------------
+
+
+def test_router_uses_one_model():
+    """`app.models.invitation.Invitation` is a re-export, not a second model."""
+    from app.models import Invitation as FromPackage
+    from app.models.invitation import Invitation as FromModule
+
+    assert FromModule is FromPackage
+    assert invitations_router.Invitation is FromPackage
+    assert FromPackage.__table__.name == "invitations"
+
+
+def test_scoped_by_column_that_exists():
+    """The `Invitation.tenant_id` half of the drift, mirroring #525/#527."""
+    assert hasattr(Invitation, "organization_id")
+    assert "tenant_id" not in Invitation.__table__.columns, (
+        "invitations has no tenant_id column; organization_id is the tenancy "
+        "key, consistent with Policy, Role and OrganizationMember."
+    )
+    assert "Invitation.tenant_id" not in _executable_source(invitations_router), (
+        "the router filters on Invitation.tenant_id, which does not exist."
+    )
+
+
+def test_attrs_are_real_columns():
+    """The structural guard a mock-driven suite cannot provide.
+
+    Every attribute the router reads off an invitation must resolve on the
+    mapped class -- as a column, a property or a method.
+    """
+    touched = _attributes_accessed_on(invitations_router, {"invitation", "inv"})
+    missing = sorted(a for a in touched if not hasattr(Invitation, a))
+    assert not missing, f"router touches non-existent Invitation attributes: {missing}"
+
+
+def test_no_get_organizations_call():
+    """`User.get_organizations()` is defined on no class; scoping must not call it."""
+    assert not hasattr(User, "get_organizations")
+    assert "get_organizations" not in _executable_source(invitations_router)
+
+
+def test_invite_base_url_resolves():
+    """`settings.APP_URL` does not exist; the link root must come from one that does."""
+    assert "APP_URL" not in _executable_source(invitations_router)
+    assert invitations_router._invite_base_url().startswith("http")
+
+
+def test_response_fields_have_columns():
+    """Every persisted field `InvitationResponse` declares can be stored.
+
+    `message` and `email_sent` are the two that had nowhere to land, which is
+    what made `InvitationCreate.message` a field the API accepted and dropped.
+    """
+    for field in ("message", "email_sent", "role", "created_by", "expires_at", "status"):
+        assert field in Invitation.__table__.columns, f"invitations lacks {field}"
+    assert {"message", "email_sent"} <= set(InvitationResponse.model_fields)
+
+
+# ---------------------------------------------------------------------------
+# Behavioural round-trips against a real session
+# ---------------------------------------------------------------------------
+
+
+async def test_get_returns_all_fields(db):
+    """Every field the response claims to support survives a database round-trip."""
+    org, admin = await _org_with_admin(db, "acme")
+    invitation = await _invite(db, org, admin)
+
+    response = await invitations_router.get_invitation(
+        invitation_id=str(invitation.id), current_user=admin, db=db
+    )
+
+    assert response.id == str(invitation.id)
+    assert response.organization_id == str(org.id)
+    assert response.email == "invitee@example.test"
+    assert response.role == "member"
+    assert response.status == InvitationStatus.PENDING.value
+    assert response.invited_by == str(admin.id)
+    assert response.message == "join us"
+    assert response.email_sent is True
+    assert response.expires_at == invitation.expires_at
+    assert invitation.token in response.invite_url
+
+
+async def test_patch_persists_fields(db):
+    """PATCH must commit, not just echo.
+
+    `role` was written as `role_name` and `message` was not a column, so both
+    assignments used to land on plain Python attributes and vanish on commit.
+    """
+    org, admin = await _org_with_admin(db, "acme")
+    invitation = await _invite(db, org, admin, role="member", message="before")
+    invitation_id = invitation.id
+    new_expiry = datetime.utcnow() + timedelta(days=21)
+
+    response = await invitations_router.update_invitation(
+        invitation_id=str(invitation.id),
+        update_data=InvitationUpdate(role="admin", message="after", expires_at=new_expiry),
+        current_user=admin,
+        db=db,
+    )
+
+    assert response.role == "admin"
+    assert response.message == "after"
+
+    # Re-read from the database: the echo above must be backed by stored rows.
+    db.expire_all()
+    stored = (
+        await db.execute(select(Invitation).where(Invitation.id == invitation_id))
+    ).scalar_one()
+    assert stored.role == "admin"
+    assert stored.message == "after"
+    assert stored.expires_at == new_expiry
+
+
+async def test_list_scoped_to_member_orgs(db):
+    """Listing is scoped by organization membership."""
+    org, admin = await _org_with_admin(db, "acme")
+    await _invite(db, org, admin, email="a@example.test")
+    await _invite(db, org, admin, email="b@example.test")
+
+    result = await invitations_router.list_invitations(current_user=admin, db=db, skip=0, limit=100)
+
+    assert result.total == 2
+    assert {i.email for i in result.invitations} == {"a@example.test", "b@example.test"}
+    assert result.pending_count == 2
+
+
+async def test_list_excludes_other_org(db):
+    """An admin of org A never sees org B's invitations."""
+    org_a, admin_a = await _org_with_admin(db, "acme")
+    org_b, admin_b = await _org_with_admin(db, "globex")
+    await _invite(db, org_b, admin_b, email="secret@globex.test")
+
+    result = await invitations_router.list_invitations(current_user=admin_a, db=db, skip=0, limit=100)
+    assert result.total == 0
+    assert result.invitations == []
+
+    # Naming org B explicitly must not widen the scope either.
+    targeted = await invitations_router.list_invitations(
+        organization_id=str(org_b.id), current_user=admin_a, db=db, skip=0, limit=100
+    )
+    assert targeted.total == 0
+
+
+async def test_get_other_org_404(db):
+    """Reading another organization's invitation by id is a 404, not a leak."""
+    org_a, admin_a = await _org_with_admin(db, "acme")
+    org_b, admin_b = await _org_with_admin(db, "globex")
+    invitation = await _invite(db, org_b, admin_b)
+
+    with pytest.raises(Exception) as exc:
+        await invitations_router.get_invitation(
+            invitation_id=str(invitation.id), current_user=admin_a, db=db
+        )
+    assert getattr(exc.value, "status_code", None) == 404
+
+
+async def test_patch_other_org_404(db):
+    """An admin of org A cannot mutate org B's invitation.
+
+    `require_org_admin` only proves the caller administers *some*
+    organization, so the handler must check the invitation's own organization.
+    """
+    org_a, admin_a = await _org_with_admin(db, "acme")
+    org_b, admin_b = await _org_with_admin(db, "globex")
+    invitation = await _invite(db, org_b, admin_b, role="member")
+    invitation_id = invitation.id
+
+    with pytest.raises(Exception) as exc:
+        await invitations_router.update_invitation(
+            invitation_id=str(invitation.id),
+            update_data=InvitationUpdate(role="owner"),
+            current_user=admin_a,
+            db=db,
+        )
+    assert getattr(exc.value, "status_code", None) == 404
+
+    db.expire_all()
+    stored = (
+        await db.execute(select(Invitation).where(Invitation.id == invitation_id))
+    ).scalar_one()
+    assert stored.role == "member"
+
+
+async def test_expire_marks_pending(db):
+    """The expire sweep marks lapsed pending invitations and leaves the rest."""
+    org, admin = await _org_with_admin(db, "acme")
+    lapsed = await _invite(
+        db, org, admin, email="old@example.test", expires_at=datetime.utcnow() - timedelta(days=1)
+    )
+    live = await _invite(db, org, admin, email="new@example.test")
+
+    result = await invitations_router.cleanup_expired_invitations(current_user=admin, db=db)
+    assert result["count"] == 1
+
+    db.expire_all()
+    rows = {r.email: r.status for r in (await db.execute(select(Invitation))).scalars().all()}
+    assert rows["old@example.test"] == InvitationStatus.EXPIRED.value
+    assert rows["new@example.test"] == InvitationStatus.PENDING.value
+    assert lapsed.organization_id == live.organization_id
+
+
+async def test_expire_scoped_to_org(db):
+    """The sweep only touches the caller's own organizations."""
+    org_a, admin_a = await _org_with_admin(db, "acme")
+    org_b, admin_b = await _org_with_admin(db, "globex")
+    stale = datetime.utcnow() - timedelta(days=1)
+    await _invite(db, org_a, admin_a, email="a@example.test", expires_at=stale)
+    await _invite(db, org_b, admin_b, email="b@example.test", expires_at=stale)
+
+    result = await invitations_router.cleanup_expired_invitations(current_user=admin_a, db=db)
+    assert result["count"] == 1
+
+    db.expire_all()
+    rows = {r.email: r.status for r in (await db.execute(select(Invitation))).scalars().all()}
+    assert rows["a@example.test"] == InvitationStatus.EXPIRED.value
+    assert rows["b@example.test"] == InvitationStatus.PENDING.value
+
+
+async def test_validate_ok(db):
+    """A live token validates and reports the fields the accept page needs."""
+    org, admin = await _org_with_admin(db, "acme")
+    invitation = await _invite(db, org, admin)
+
+    result = await invitations_router.validate_invitation_token(token=invitation.token, db=db)
+
+    assert result["valid"] is True
+    assert result["email"] == "invitee@example.test"
+    assert result["organization_name"] == "acme"
+    assert result["role"] == "member"
+    assert result["message"] == "join us"
+
+
+async def test_validate_expired(db):
+    """A lapsed token reports itself invalid rather than raising."""
+    org, admin = await _org_with_admin(db, "acme")
+    invitation = await _invite(db, org, admin, expires_at=datetime.utcnow() - timedelta(days=1))
+
+    result = await invitations_router.validate_invitation_token(token=invitation.token, db=db)
+
+    assert result["valid"] is False
+    assert result["reason"] == "Invitation has expired"
+
+
+async def test_list_status_counts(db):
+    """The status breakdown describes the whole scoped set."""
+    org, admin = await _org_with_admin(db, "acme")
+    await _invite(db, org, admin, email="p@example.test")
+    await _invite(db, org, admin, email="a@example.test", status=InvitationStatus.ACCEPTED.value)
+    await _invite(db, org, admin, email="e@example.test", status=InvitationStatus.EXPIRED.value)
+
+    result = await invitations_router.list_invitations(current_user=admin, db=db, skip=0, limit=100)
+    assert (result.pending_count, result.accepted_count, result.expired_count) == (1, 1, 1)
+    assert result.total == 3
+
+    filtered = await invitations_router.list_invitations(
+        status=InvitationStatus.ACCEPTED, current_user=admin, db=db, skip=0, limit=100
+    )
+    assert filtered.total == 1
+    assert filtered.invitations[0].email == "a@example.test"
+    # The breakdown still describes the whole set, not just the filtered page.
+    assert filtered.pending_count == 1
+
+
+async def test_bad_uuid_is_404(db):
+    """A non-UUID path id is a 404, not a database error."""
+    org, admin = await _org_with_admin(db, "acme")
+
+    with pytest.raises(Exception) as exc:
+        await invitations_router.get_invitation(
+            invitation_id="not-a-uuid", current_user=admin, db=db
+        )
+    assert getattr(exc.value, "status_code", None) == 404


### PR DESCRIPTION
Every endpoint on `/v1/invitations` raised before it reached the database.

## The drift

`invitations` has ten columns — (id, organization_id, email, role, status, token, expires_at, accepted_at, created_by, created_at) — and the SQLAlchemy model matches it exactly. Model and migration agreed; the **router** was the drift, in four separate ways:

| Referenced | Reality |
|---|---|
| `Invitation.tenant_id` (list, get, update) | not a column, and never has been |
| `role_name`, `invited_by` (every response) | real fields under different names: `role`, `created_by` |
| `message`, `email_sent` (every response; `message` also written by PATCH) | not columns at all |
| `generate_invite_url()`, `is_expired`, `User.get_organizations()`, `settings.APP_URL` | defined nowhere |

`PATCH /invitations/{id}` was the quiet one. `invitation.role_name = ...` and `invitation.message = ...` land on plain Python attributes, so the endpoint answered `200` echoing the caller's new values and committed none of them.

This is the same defect class as #527 (policies) and #524 (magic links), and it survived for the same reason: the tests mocked the manager, and a mock answers to any attribute name.

## Changes

**Schema.** Adds `message` and `email_sent`, following #527's precedent of adding the columns the code always read.

`message` is offered by `InvitationCreate`, returned by `InvitationResponse` and updatable through `InvitationUpdate`. Persisting it is what lets those three schemas describe one field. The alternative — deleting it from the request and response models — would remove a documented field from the public API and every generated SDK to work around a missing column on an empty table. `email_sent` is reported by the read endpoints, which load a row and therefore have no request-scoped send outcome to borrow.

The table is empty, so the `NOT NULL` column takes a server default with no backfill. `IF NOT EXISTS` keeps it idempotent against environments that ran `Base.metadata.create_all` (the test suite does).

Migration `011_invitation_columns` — 22 chars, within `alembic_version.version_num`'s VARCHAR(32). Chain: `010_policy_authz_columns` → `011_invitation_columns`, single head. Migrations are opt-in behind `JANUA_APPLY_MIGRATIONS`, so this does not auto-apply.

**Model.** Defines `is_expired`, `is_valid` and `generate_invite_url` — all pure functions of existing columns, no migration needed.

**Tenancy.** Scopes reads by organization membership or ownership. `organization_id` throughout, consistent with #525/#527; no `tenant_id` introduced.

**Authorization.** `require_org_admin` only proves the caller administers *some* organization. Update, resend and revoke now check that the caller administers the invitation's *own* organization — without it, an admin of one organization could reach another's invitations by id. Covered by `test_patch_other_org_404`.

**Expiry.** `POST /cleanup` called a synchronous `Session.query` helper on an AsyncSession, which has no `.query`, and swept every organization's invitations. Now one statement, scoped to the caller's own organizations.

**Session type.** The handlers annotated `db: Session` while `get_db` yields an `AsyncSession` — and already `await`ed on it. Annotation corrected; ruff caught the last two.

## Tests

`tests/unit/routers/test_invitations_schema_drift.py` — 18 tests driving the real handlers against a real session, because a mocked manager cannot tell a real column from a missing one. Six are structural guards (no reference to a non-existent attribute, no `tenant_id` scoping, no `APP_URL`); twelve are behavioural round-trips over every field the router reports, plus org-scoping and expiry.

**17 of the 18 fail against the current router.** The one that passes asserts `app.models.invitation.Invitation` is a re-export rather than a second model, which was already true.

Unit suite: `13 failed, 2781 passed, 84 errors` vs `13 failed, 2761 passed, 84 errors` on main — the 97 pre-existing failures/errors are identical **by name** (xmlsec/lxml + pollution); zero new.

## Overlap with #530

#530 (`feat/signup-locale-and-invitation-email`) fixes the same drift in `app/services/invitation_service.py` and the email send path. **This PR does not touch either file** — the diff is router, model, migration and tests only.

Two deliberate seams:

- Both PRs define `is_expired` / `is_valid` / `generate_invite_url` on `Invitation`, written identically, so the conflict resolves by keeping one copy. Both also add `Optional` to the same `typing` import — an identical change git merges cleanly.
- #530 rebuilds `create_invitation`'s response with `message` echoed from the request and `email_sent` computed per-request, because neither was a column when it was written. Once both land, `message` should be passed to the `Invitation(...)` constructor and `email_sent` set in the send path — two lines, in #530's file, so they are left to it.

**Recommended merge order: #530 first, then this.** #530 is the larger diff and is already conflicting with main; landing it first keeps the conflict resolution here to the duplicate model helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
