### PR TITLE
fix(migrations): make 004, 006 and 008 survive an already-populated schema

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -116,6 +116,11 @@ jobs:
         env:
           ENVIRONMENT: test
           DATABASE_URL: postgresql+asyncpg://janua:janua_test@localhost:5432/janua_test
+          # pytest.ini pins DATABASE_URL to sqlite for every run, so the
+          # migration re-entrancy guard reads this instead -- it is the only way
+          # that test can reach the postgres service above. Unset in CI, it
+          # fails rather than skips; see tests/unit/test_migration_reentrancy.py.
+          MIGRATION_TEST_DATABASE_URL: postgresql+asyncpg://janua:janua_test@localhost:5432/janua_test
           REDIS_URL: redis://localhost:6379/0
           SECRET_KEY: test-secret-key-do-not-use-in-production
           PYTHONPATH: ${{ github.workspace }}/apps/api

--- a/apps/api/alembic/versions/004_add_guest_invites.py
+++ b/apps/api/alembic/versions/004_add_guest_invites.py
@@ -15,6 +15,8 @@ migration from 004 onwards could ever be applied. Keep this pointing at '003'.
 import uuid
 
 import sqlalchemy as sa
+from sqlalchemy import inspect
+
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -25,6 +27,17 @@ depends_on = None
 
 
 def upgrade() -> None:
+    bind = op.get_bind()
+
+    # Environments that ran `Base.metadata.create_all` (settings.AUTO_MIGRATE)
+    # already have this table even though alembic_version still reads an older
+    # revision -- see the same note in 007. Creating it unconditionally raises
+    # DuplicateTable and rolls back the whole chain, which is what keeps every
+    # later migration from ever being applied. Same idempotency contract as
+    # 003/007/009/010/011.
+    if inspect(bind).has_table("guest_invites"):
+        return
+
     op.create_table(
         "guest_invites",
         sa.Column("id", sa.Uuid(), primary_key=True, default=uuid.uuid4),

--- a/apps/api/alembic/versions/006_api_key_rate_limit_revoked.py
+++ b/apps/api/alembic/versions/006_api_key_rate_limit_revoked.py
@@ -19,6 +19,8 @@ safe precisely because no database can ever have stored it. Keep revision ids
 """
 
 import sqlalchemy as sa
+from sqlalchemy import inspect
+
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -29,23 +31,37 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # Add rate_limit_per_min with a sensible default
-    op.add_column(
-        "api_keys",
-        sa.Column("rate_limit_per_min", sa.Integer(), nullable=True, server_default="60"),
-    )
-    # Add revoked_at timestamp (nullable -- NULL means not revoked)
-    op.add_column(
-        "api_keys",
-        sa.Column("revoked_at", sa.DateTime(), nullable=True),
-    )
-    # Add key_prefix for visible short prefix (e.g. "sk_live_ab3f")
-    op.add_column(
-        "api_keys",
-        sa.Column("key_prefix", sa.String(length=12), nullable=True),
-    )
+    bind = op.get_bind()
 
-    # Backfill revoked_at for already-revoked keys (is_active=false)
+    # Each column is added only if absent. Environments that ran
+    # `Base.metadata.create_all` (settings.AUTO_MIGRATE) already carry all three
+    # while alembic_version reads an older revision; add_column would raise
+    # DuplicateColumn and roll the whole chain back. Guarding per column rather
+    # than early-returning on the first one means a partially-migrated table
+    # still converges. Same idempotency contract as 003/007/009/010/011.
+    existing = {c["name"] for c in inspect(bind).get_columns("api_keys")}
+
+    # rate_limit_per_min: per-key rate limiting, with a sensible default
+    if "rate_limit_per_min" not in existing:
+        op.add_column(
+            "api_keys",
+            sa.Column("rate_limit_per_min", sa.Integer(), nullable=True, server_default="60"),
+        )
+    # revoked_at timestamp (nullable -- NULL means not revoked)
+    if "revoked_at" not in existing:
+        op.add_column(
+            "api_keys",
+            sa.Column("revoked_at", sa.DateTime(), nullable=True),
+        )
+    # key_prefix for visible short prefix (e.g. "sk_live_ab3f")
+    if "key_prefix" not in existing:
+        op.add_column(
+            "api_keys",
+            sa.Column("key_prefix", sa.String(length=12), nullable=True),
+        )
+
+    # Backfill revoked_at for already-revoked keys (is_active=false). The
+    # `revoked_at IS NULL` predicate makes this safe to re-run.
     op.execute(
         "UPDATE api_keys SET revoked_at = updated_at WHERE is_active = false AND revoked_at IS NULL"
     )

--- a/apps/api/alembic/versions/008_connected_accounts.py
+++ b/apps/api/alembic/versions/008_connected_accounts.py
@@ -6,6 +6,8 @@ Create Date: 2026-06-19
 """
 
 import sqlalchemy as sa
+from sqlalchemy import inspect
+
 from alembic import op
 
 revision = "008_connected_accounts"
@@ -20,69 +22,86 @@ def upgrade() -> None:
     uuid_type = sa.dialects.postgresql.UUID(as_uuid=True) if dialect == "postgresql" else sa.String(36)
     json_type = sa.JSON() if dialect == "sqlite" else sa.dialects.postgresql.JSONB()
 
-    op.create_table(
-        "provider_types",
-        sa.Column("id", uuid_type, primary_key=True),
-        sa.Column("type_code", sa.String(50), nullable=False, unique=True),
-        sa.Column("display_name", sa.String(100), nullable=False),
-        sa.Column("category", sa.String(50), nullable=False, server_default="integration"),
-        sa.Column("supports_oauth", sa.String(5), server_default="true"),
-        sa.Column("is_active", sa.String(5), server_default="true"),
-        sa.Column("created_at", sa.DateTime(), nullable=True),
-        sa.Column("updated_at", sa.DateTime(), nullable=True),
-    )
+    # Both tables may already exist where `Base.metadata.create_all`
+    # (settings.AUTO_MIGRATE) ran instead of migrations -- see the same note in
+    # 007. create_table would raise DuplicateTable and roll the whole chain
+    # back. Guarded per object rather than early-returning on the first table,
+    # so a half-created schema still converges. Same idempotency contract as
+    # 003/007/009/010/011.
+    inspector = inspect(bind)
+    has_provider_types = inspector.has_table("provider_types")
+    has_connected_accounts = inspector.has_table("connected_accounts")
 
-    op.create_table(
-        "connected_accounts",
-        sa.Column("id", uuid_type, primary_key=True),
-        sa.Column("user_id", uuid_type, sa.ForeignKey("users.id"), nullable=False),
-        sa.Column("organization_id", uuid_type, sa.ForeignKey("organizations.id"), nullable=True),
-        sa.Column("provider_type", sa.String(50), nullable=False),
-        sa.Column("provider_name", sa.String(100), nullable=False),
-        sa.Column("provider_id", sa.String(255), nullable=True),
-        sa.Column("access_token_encrypted", sa.Text(), nullable=True),
-        sa.Column("refresh_token_encrypted", sa.Text(), nullable=True),
-        sa.Column("oauth_scopes", json_type, nullable=True),
-        sa.Column("oauth_expires_at", sa.DateTime(), nullable=True),
-        sa.Column("status", sa.String(20), server_default="active"),
-        sa.Column("account_metadata", json_type, nullable=True),
-        sa.Column("last_used_at", sa.DateTime(), nullable=True),
-        sa.Column("created_at", sa.DateTime(), nullable=True),
-        sa.Column("updated_at", sa.DateTime(), nullable=True),
-        sa.Column("created_by", uuid_type, sa.ForeignKey("users.id"), nullable=True),
-    )
-    op.create_index("ix_connected_accounts_user_id", "connected_accounts", ["user_id"])
-    op.create_index("ix_connected_accounts_provider_type", "connected_accounts", ["provider_type"])
-
-    op.bulk_insert(
-        sa.table(
+    if not has_provider_types:
+        op.create_table(
             "provider_types",
-            sa.column("id", uuid_type),
-            sa.column("type_code", sa.String),
-            sa.column("display_name", sa.String),
-            sa.column("category", sa.String),
-            sa.column("supports_oauth", sa.String),
-            sa.column("is_active", sa.String),
-        ),
-        [
-            {
-                "id": "00000000-0000-4000-8000-000000000001",
-                "type_code": "github",
-                "display_name": "GitHub",
-                "category": "development",
-                "supports_oauth": "true",
-                "is_active": "true",
-            },
-            {
-                "id": "00000000-0000-4000-8000-000000000002",
-                "type_code": "slack",
-                "display_name": "Slack",
-                "category": "communication",
-                "supports_oauth": "true",
-                "is_active": "true",
-            },
-        ],
-    )
+            sa.Column("id", uuid_type, primary_key=True),
+            sa.Column("type_code", sa.String(50), nullable=False, unique=True),
+            sa.Column("display_name", sa.String(100), nullable=False),
+            sa.Column("category", sa.String(50), nullable=False, server_default="integration"),
+            sa.Column("supports_oauth", sa.String(5), server_default="true"),
+            sa.Column("is_active", sa.String(5), server_default="true"),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+        )
+
+    if not has_connected_accounts:
+        op.create_table(
+            "connected_accounts",
+            sa.Column("id", uuid_type, primary_key=True),
+            sa.Column("user_id", uuid_type, sa.ForeignKey("users.id"), nullable=False),
+            sa.Column("organization_id", uuid_type, sa.ForeignKey("organizations.id"), nullable=True),
+            sa.Column("provider_type", sa.String(50), nullable=False),
+            sa.Column("provider_name", sa.String(100), nullable=False),
+            sa.Column("provider_id", sa.String(255), nullable=True),
+            sa.Column("access_token_encrypted", sa.Text(), nullable=True),
+            sa.Column("refresh_token_encrypted", sa.Text(), nullable=True),
+            sa.Column("oauth_scopes", json_type, nullable=True),
+            sa.Column("oauth_expires_at", sa.DateTime(), nullable=True),
+            sa.Column("status", sa.String(20), server_default="active"),
+            sa.Column("account_metadata", json_type, nullable=True),
+            sa.Column("last_used_at", sa.DateTime(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.Column("created_by", uuid_type, sa.ForeignKey("users.id"), nullable=True),
+        )
+        op.create_index("ix_connected_accounts_user_id", "connected_accounts", ["user_id"])
+        op.create_index("ix_connected_accounts_provider_type", "connected_accounts", ["provider_type"])
+
+    # The seed belongs to `provider_types`, not to `connected_accounts`, and its
+    # real precondition is that the table is empty -- `type_code` is unique, so
+    # re-inserting raises. Gating it on the row count rather than on either
+    # has_table keeps it correct in all four combinations of pre-existing tables.
+    if bind.execute(sa.text("SELECT COUNT(*) FROM provider_types")).scalar() == 0:
+        op.bulk_insert(
+            sa.table(
+                "provider_types",
+                sa.column("id", uuid_type),
+                sa.column("type_code", sa.String),
+                sa.column("display_name", sa.String),
+                sa.column("category", sa.String),
+                sa.column("supports_oauth", sa.String),
+                sa.column("is_active", sa.String),
+            ),
+            [
+                {
+                    "id": "00000000-0000-4000-8000-000000000001",
+                    "type_code": "github",
+                    "display_name": "GitHub",
+                    "category": "development",
+                    "supports_oauth": "true",
+                    "is_active": "true",
+                },
+                {
+                    "id": "00000000-0000-4000-8000-000000000002",
+                    "type_code": "slack",
+                    "display_name": "Slack",
+                    "category": "communication",
+                    "supports_oauth": "true",
+                    "is_active": "true",
+                },
+            ],
+        )
 
 
 def downgrade() -> None:

--- a/apps/api/tests/unit/test_migration_reentrancy.py
+++ b/apps/api/tests/unit/test_migration_reentrancy.py
@@ -1,0 +1,175 @@
+"""Every migration's upgrade() must survive its objects already existing.
+
+WHY THIS EXISTS. Production runs `Base.metadata.create_all`
+(settings.AUTO_MIGRATE), so the schema is populated by the models while
+`alembic_version` still records an old revision -- it read '002' on 2026-08-13
+with nine migrations unapplied. In that state a migration that creates
+unconditionally does not "skip harmlessly"; it raises DuplicateTable and, since
+alembic wraps the upgrade in one transaction, rolls the *whole chain* back. One
+unguarded migration therefore pins the database at its parent revision forever,
+and every later migration is dead behind it. That is how 004 blocked 005-011.
+
+Reproduced exactly: upgrade to head on a fresh database, `stamp` back to 002 so
+the schema is populated but the version is stale, then upgrade again. Against
+the migrations as they stood, step three failed with
+`DuplicateTableError: relation "guest_invites" already exists`.
+
+The alembic invocations are subprocesses because alembic/env.py resolves the
+URL from `settings` at import time; a subprocess gets a clean read of the
+scratch DATABASE_URL without mutating this process's settings.
+
+This lives in tests/unit/ because CI passes `--ignore=tests/integration`, so a
+file there would never run. It skips when no PostgreSQL is reachable, which is
+the normal local case; CI's api-tests job provides one as a service.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+import pytest
+
+API_ROOT = Path(__file__).resolve().parents[2]
+
+# The revision production was stamped at while its schema was already populated.
+# Any revision would exercise re-entrancy; this one reproduces the real incident.
+STALE_REVISION = "002"
+
+# Set by CI's api-tests job to its `postgres` service. See _postgres_url().
+URL_ENV_VAR = "MIGRATION_TEST_DATABASE_URL"
+
+
+def _sync_url(url: str) -> str:
+    """asyncpg URL -> psycopg2 URL. Only the driver differs."""
+    return url.replace("postgresql+asyncpg://", "postgresql://").split("?")[0]
+
+
+def _with_database(url: str, name: str) -> str:
+    parts = urlsplit(url)
+    return urlunsplit((parts.scheme, parts.netloc, f"/{name}", "", ""))
+
+
+def _postgres_url() -> str | None:
+    """The scratch server's URL, or None when this environment has no PostgreSQL.
+
+    Deliberately NOT `DATABASE_URL`: pytest.ini pins that to
+    `sqlite+aiosqlite:///:memory:` for every run, so keying off it would make
+    this test skip permanently -- including in CI, where it is the only place a
+    real server exists. A silently-skipped guard is the failure mode this file
+    is meant to prevent, so it reads a variable nothing else overrides and
+    fails loudly below when CI forgets to set it.
+    """
+    url = os.environ.get(URL_ENV_VAR, "")
+    if "postgresql" not in url:
+        return None
+    try:
+        import psycopg2
+    except ImportError:  # pragma: no cover - driver absent locally
+        return None
+    try:
+        psycopg2.connect(_sync_url(url)).close()
+    except Exception:  # pragma: no cover - no server reachable
+        return None
+    return url
+
+
+def _alembic(args: list[str], url: str) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "DATABASE_URL": url,
+        # env.py prefers DIRECT_DATABASE_URL when set; the ambient value would
+        # point every subprocess at the wrong database and silently migrate it.
+        "DIRECT_DATABASE_URL": url,
+    }
+    return subprocess.run(
+        [sys.executable, "-m", "alembic", *args],
+        cwd=API_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+
+
+@pytest.fixture
+def scratch_database() -> str:
+    """A throwaway database on the configured server, dropped afterwards."""
+    base = _postgres_url()
+    if base is None:
+        if os.environ.get("CI"):
+            # Fail rather than skip: CI is the only environment with a server,
+            # so a skip here means this guard silently stopped protecting
+            # anything while the job still reported green.
+            pytest.fail(
+                f"{URL_ENV_VAR} is unset or unreachable in CI. The api-tests job "
+                "runs a postgres service; point this variable at it, or this "
+                "migration guard runs nowhere."
+            )
+        pytest.skip(f"{URL_ENV_VAR} not set to a reachable PostgreSQL")
+
+    import psycopg2
+
+    name = f"janua_reentrancy_{uuid.uuid4().hex[:12]}"
+    admin = psycopg2.connect(_sync_url(base))
+    admin.autocommit = True
+    try:
+        with admin.cursor() as cur:
+            cur.execute(f'CREATE DATABASE "{name}"')
+    finally:
+        admin.close()
+
+    try:
+        yield _with_database(base, name)
+    finally:
+        admin = psycopg2.connect(_sync_url(base))
+        admin.autocommit = True
+        try:
+            with admin.cursor() as cur:
+                cur.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
+        finally:
+            admin.close()
+
+
+def test_upgrade_is_reentrant_over_an_already_populated_schema(scratch_database: str) -> None:
+    first = _alembic(["upgrade", "head"], scratch_database)
+    assert first.returncode == 0, f"fresh upgrade failed:\n{first.stdout}\n{first.stderr}"
+
+    # Populated schema, stale version -- production's exact condition.
+    stamped = _alembic(["stamp", STALE_REVISION], scratch_database)
+    assert stamped.returncode == 0, f"stamp failed:\n{stamped.stdout}\n{stamped.stderr}"
+
+    second = _alembic(["upgrade", "head"], scratch_database)
+    assert second.returncode == 0, (
+        "re-running the chain over an already-populated schema failed. A migration "
+        "creates an object without checking whether it exists; in production that "
+        "aborts the whole upgrade and pins the database at its parent revision.\n"
+        f"{second.stdout}\n{second.stderr}"
+    )
+
+    import psycopg2
+
+    conn = psycopg2.connect(_sync_url(scratch_database))
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT version_num FROM alembic_version")
+            recorded = cur.fetchone()[0]
+            # Head must actually be *recorded*, not merely reached: a revision id
+            # longer than alembic_version.version_num's VARCHAR(32) raises on write
+            # and rolls the upgrade back, which is how 006 was dead for months.
+            assert recorded != STALE_REVISION, "upgrade recorded no progress past the stale revision"
+
+            # The last migration's columns must be present, so a chain that
+            # "succeeded" without applying anything cannot pass this test.
+            cur.execute(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_schema = 'public' AND table_name = 'invitations' "
+                "AND column_name IN ('message', 'email_sent')"
+            )
+            assert {r[0] for r in cur.fetchall()} == {"message", "email_sent"}
+    finally:
+        conn.close()

--- a/apps/api/tests/unit/test_migration_reentrancy.py
+++ b/apps/api/tests/unit/test_migration_reentrancy.py
@@ -14,9 +14,12 @@ the schema is populated but the version is stale, then upgrade again. Against
 the migrations as they stood, step three failed with
 `DuplicateTableError: relation "guest_invites" already exists`.
 
-The alembic invocations are subprocesses because alembic/env.py resolves the
-URL from `settings` at import time; a subprocess gets a clean read of the
-scratch DATABASE_URL without mutating this process's settings.
+EVERY database interaction here is a subprocess, for two independent reasons.
+alembic/env.py resolves its URL from `settings` at import time, so only a fresh
+process reads the scratch DATABASE_URL. And `tests/fixtures/external_mocks.py`
+installs an autouse, session-scoped `patch.dict("sys.modules", ...)` that
+replaces `psycopg2` with a `Mock` for the whole run -- an in-process
+`import psycopg2` here yields that Mock and dies on `with conn.cursor()`.
 
 This lives in tests/unit/ because CI passes `--ignore=tests/integration`, so a
 file there would never run. It skips when no PostgreSQL is reachable, which is
@@ -54,6 +57,31 @@ def _with_database(url: str, name: str) -> str:
     return urlunsplit((parts.scheme, parts.netloc, f"/{name}", "", ""))
 
 
+def _psql(sql: str, url: str, autocommit: bool = False) -> subprocess.CompletedProcess[str]:
+    """Run SQL in a subprocess, printing each result row tab-separated.
+
+    A subprocess because psycopg2 is a Mock inside this process (see module
+    docstring); the driver is only real on the other side of a fork+exec.
+    """
+    prog = (
+        "import os,sys,psycopg2\n"
+        "c=psycopg2.connect(os.environ['U'])\n"
+        f"c.autocommit={autocommit!r}\n"
+        "cur=c.cursor()\n"
+        "cur.execute(os.environ['Q'])\n"
+        "rows=cur.fetchall() if cur.description else []\n"
+        "c.commit() if not c.autocommit else None\n"
+        "print('\\n'.join('\\t'.join(map(str,r)) for r in rows))\n"
+    )
+    return subprocess.run(
+        [sys.executable, "-c", prog],
+        env={**os.environ, "U": _sync_url(url), "Q": sql},
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
 def _postgres_url() -> str | None:
     """The scratch server's URL, or None when this environment has no PostgreSQL.
 
@@ -67,13 +95,7 @@ def _postgres_url() -> str | None:
     url = os.environ.get(URL_ENV_VAR, "")
     if "postgresql" not in url:
         return None
-    try:
-        import psycopg2
-    except ImportError:  # pragma: no cover - driver absent locally
-        return None
-    try:
-        psycopg2.connect(_sync_url(url)).close()
-    except Exception:  # pragma: no cover - no server reachable
+    if _psql("SELECT 1", url).returncode != 0:  # pragma: no cover - no server
         return None
     return url
 
@@ -112,27 +134,15 @@ def scratch_database() -> str:
             )
         pytest.skip(f"{URL_ENV_VAR} not set to a reachable PostgreSQL")
 
-    import psycopg2
-
     name = f"janua_reentrancy_{uuid.uuid4().hex[:12]}"
-    admin = psycopg2.connect(_sync_url(base))
-    admin.autocommit = True
-    try:
-        with admin.cursor() as cur:
-            cur.execute(f'CREATE DATABASE "{name}"')
-    finally:
-        admin.close()
+    # CREATE/DROP DATABASE cannot run inside a transaction, hence autocommit.
+    created = _psql(f'CREATE DATABASE "{name}"', base, autocommit=True)
+    assert created.returncode == 0, f"could not create scratch database:\n{created.stderr}"
 
     try:
         yield _with_database(base, name)
     finally:
-        admin = psycopg2.connect(_sync_url(base))
-        admin.autocommit = True
-        try:
-            with admin.cursor() as cur:
-                cur.execute(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)')
-        finally:
-            admin.close()
+        _psql(f'DROP DATABASE IF EXISTS "{name}" WITH (FORCE)', base, autocommit=True)
 
 
 def test_upgrade_is_reentrant_over_an_already_populated_schema(scratch_database: str) -> None:
@@ -151,25 +161,23 @@ def test_upgrade_is_reentrant_over_an_already_populated_schema(scratch_database:
         f"{second.stdout}\n{second.stderr}"
     )
 
-    import psycopg2
+    # Head must actually be *recorded*, not merely reached: a revision id longer
+    # than alembic_version.version_num's VARCHAR(32) raises on write and rolls
+    # the upgrade back, which is how 006 stayed dead for months.
+    version = _psql("SELECT version_num FROM alembic_version", scratch_database)
+    assert version.returncode == 0, version.stderr
+    recorded = version.stdout.strip()
+    assert recorded and recorded != STALE_REVISION, (
+        f"upgrade recorded no progress past {STALE_REVISION!r} (read {recorded!r})"
+    )
 
-    conn = psycopg2.connect(_sync_url(scratch_database))
-    try:
-        with conn.cursor() as cur:
-            cur.execute("SELECT version_num FROM alembic_version")
-            recorded = cur.fetchone()[0]
-            # Head must actually be *recorded*, not merely reached: a revision id
-            # longer than alembic_version.version_num's VARCHAR(32) raises on write
-            # and rolls the upgrade back, which is how 006 was dead for months.
-            assert recorded != STALE_REVISION, "upgrade recorded no progress past the stale revision"
-
-            # The last migration's columns must be present, so a chain that
-            # "succeeded" without applying anything cannot pass this test.
-            cur.execute(
-                "SELECT column_name FROM information_schema.columns "
-                "WHERE table_schema = 'public' AND table_name = 'invitations' "
-                "AND column_name IN ('message', 'email_sent')"
-            )
-            assert {r[0] for r in cur.fetchall()} == {"message", "email_sent"}
-    finally:
-        conn.close()
+    # The last migration's columns must be present, so a chain that "succeeded"
+    # without applying anything cannot pass this test.
+    cols = _psql(
+        "SELECT column_name FROM information_schema.columns "
+        "WHERE table_schema = 'public' AND table_name = 'invitations' "
+        "AND column_name IN ('message', 'email_sent')",
+        scratch_database,
+    )
+    assert cols.returncode == 0, cols.stderr
+    assert set(cols.stdout.split()) == {"message", "email_sent"}


### PR DESCRIPTION
## The defect

Migration `007` already carries this note:

> `user_entitlements` may already exist in environments that ran `Base.metadata.create_all` (settings.AUTO_MIGRATE) instead of migrations.

`003`, `007`, `009`, `010` and `011` all guard for that. `004`, `006` and `008` do not.

That asymmetry is not cosmetic. When the schema is already populated but `alembic_version` records an older revision, an unguarded `create_table` / `add_column` raises `DuplicateTable` — and since alembic wraps the upgrade in one transaction, the **whole chain** rolls back. A single unguarded migration therefore pins the database at its parent revision, and every migration after it is dead behind it.

Reproduced against PostgreSQL 15 (same image CI uses): upgrade a fresh database to head, `stamp` it back to `002`, upgrade again — it fails at `004` with `relation "guest_invites" already exists`, taking `005`–`011` down with it.

## The fix

- **004** — `has_table("guest_invites")` early return, matching 007's contract.
- **006** — guarded per *column* rather than early-returning on the first, so a partially-migrated `api_keys` still converges. The backfill's `revoked_at IS NULL` predicate already made it re-runnable.
- **008** — `has_table` per table. The seed insert is gated on `provider_types` being **empty**, not on either table's presence: `type_code` is unique, so the row count is its actual precondition, and that stays correct in all four combinations of pre-existing tables.
- **005** — unchanged. It is a plain `UPDATE`, already idempotent.

No `upgrade()` in the chain performs a destructive operation; every drop is in `downgrade()`.

## The test

`tests/unit/test_migration_reentrancy.py` runs the real sequence — upgrade to head, stamp to `002`, upgrade again — and asserts head is *recorded*, not merely reached, plus that `011`'s columns actually landed (so a chain that "succeeds" without applying anything cannot pass).

Verified as a detector: with the guards it passes; with `alembic/versions` reverted it fails with the production error.

Two placement details, both deliberate:

- It lives in `tests/unit/` because CI runs pytest with `--ignore=tests/integration`; a file there would never execute.
- It reads `MIGRATION_TEST_DATABASE_URL`, **not** `DATABASE_URL`. `pytest.ini` pins `DATABASE_URL` to `sqlite+aiosqlite:///:memory:` for every run, so keying off it would have made this guard skip permanently — including in CI, the only place a real server exists. When the variable is unset **and** `CI` is set, the test fails rather than skips, so the guard cannot quietly stop protecting anything.

`tests.yml` points the new variable at the `postgres` service the job already runs.