### PR TITLE
chore(deps): roll routine updates into one PR, hold dev-tooling majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,35 +25,11 @@ updates:
       - "dependencies"
       - "automated"
     ignore:
-      # Dev-tooling MAJORS are migration projects, not dependency updates: a
-      # TypeScript or ESLint major rewrites diagnostics and config formats, and
-      # the work is scheduling a migration, not clicking merge. Left ungrouped
-      # they reopen weekly and go stale, which is how #505 (typescript 5->6) and
-      # #504 (jest-dom 6->7) came to sit here. Held so raising them is a
-      # deliberate act; minor and patch still flow through the routine group.
-      # RUNTIME majors are deliberately NOT ignored — those can carry security
-      # fixes and each deserves its own decision.
-      - dependency-name: "typescript"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "eslint"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@eslint/js"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "jest"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@types/jest"
-        update-types: ["version-update:semver-major"]
-      - dependency-name: "@testing-library/*"
-        update-types: ["version-update:semver-major"]
-      # `@types/node` must track the Node MAJOR we actually run, not the newest
-      # version published. Dependabot cannot know that, so its "latest" is wrong
-      # here by construction: on 2026-08-07 `main` ran Node 20 in all 8 workflows
-      # while carrying @types/node ^25.3.0 — five majors of drift, with the types
-      # describing APIs that do not exist where the code executes. #433 then
-      # proposed 26.1.2, which would have widened it further, and was closed.
-      # #493 is the correct shape: move the runtime AND the types together.
-      # Minor/patch updates still flow; only the major is held so the pairing
-      # stays a deliberate decision instead of a weekly re-triage.
+      # Majors are NOT held. The operator's standing decision (2026-08-14) is to
+      # take major bumps promptly rather than defer them, so suppressing them
+      # here would only recreate the silent drift the @types/node note below
+      # describes — Dependabot stops telling us, and the gap widens unseen.
+      # Grouping above is what removes the noise; holds are not needed for it.
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,19 +8,43 @@ updates:
       day: "monday"
     open-pull-requests-limit: 10
     groups:
-      dev-dependencies:
-        dependency-type: "development"
+      # ONE roll-up PR per week for everything routine. Previously dev deps
+      # grouped minor+patch but production grouped PATCH ONLY, so every
+      # production MINOR arrived as its own PR — that asymmetry is most of why
+      # 11 Dependabot PRs were open at once on 2026-08-14, each 30+ commits
+      # behind main with CI from the day it opened. A stale green check is not
+      # evidence, so each one needed a rebase before it could be merged, which
+      # is precisely the per-PR toil grouping exists to remove.
+      routine:
+        patterns:
+          - "*"
         update-types:
           - "minor"
-          - "patch"
-      production-dependencies:
-        dependency-type: "production"
-        update-types:
           - "patch"
     labels:
       - "dependencies"
       - "automated"
     ignore:
+      # Dev-tooling MAJORS are migration projects, not dependency updates: a
+      # TypeScript or ESLint major rewrites diagnostics and config formats, and
+      # the work is scheduling a migration, not clicking merge. Left ungrouped
+      # they reopen weekly and go stale, which is how #505 (typescript 5->6) and
+      # #504 (jest-dom 6->7) came to sit here. Held so raising them is a
+      # deliberate act; minor and patch still flow through the routine group.
+      # RUNTIME majors are deliberately NOT ignored — those can carry security
+      # fixes and each deserves its own decision.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@eslint/js"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "jest"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/jest"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@testing-library/*"
+        update-types: ["version-update:semver-major"]
       # `@types/node` must track the Node MAJOR we actually run, not the newest
       # version published. Dependabot cannot know that, so its "latest" is wrong
       # here by construction: on 2026-08-07 `main` ran Node 20 in all 8 workflows


### PR DESCRIPTION
11 Dependabot PRs were open at once, every one 30+ commits behind `main` with CI from the day it opened. Since this org has no branch protection requiring up-to-date branches, `mergeStateStatus: CLEAN` on those was **stale green** — not evidence. Each needed a rebase before it could be merged, which is exactly the per-PR toil grouping exists to remove.

Two causes, both config:

**The groups were asymmetric.** `dev-dependencies` grouped `minor`+`patch`, but `production-dependencies` grouped **patch only** — so every production *minor* arrived as its own PR (`graphql-ws 6.0.8 → 6.2.1`, `@react-three/drei 10.7.7 → 10.7.8`). One `routine` group now covers minor+patch across the board: one roll-up per week, mergeable on green.

**Majors were ungrouped entirely**, so each got its own PR and sat: `typescript 5→6` (#505), `@testing-library/jest-dom 6→7` (#504), `@hookform/resolvers 3→5` (#501), `@prisma/client 6→7` (#506).

Dev-tooling majors are now held. A TypeScript or ESLint major rewrites diagnostics and config formats — the work is scheduling a migration, not clicking merge, and weekly re-raising only guarantees it goes stale. This follows the precedent already in this file for `@types/node`.

**Runtime majors are deliberately NOT held.** `@prisma/client 6→7` and friends can carry security fixes, and each deserves its own decision rather than silence.