### PR TITLE
The tests and the docs now say what the code sends

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,8 +46,10 @@ SECRET_KEY=replace-with-secret-key
 # EMAIL (Resend - MADFAM centralized)
 # ============================================
 RESEND_API_KEY=replace-with-resend-api-key
-EMAIL_FROM_ADDRESS=noreply@janua.dev
-EMAIL_FROM_NAME=Janua
+# One sender for every platform, on the one Resend-verified domain.
+# See docs/EMAIL_SENDER_POLICY.md before changing either of these.
+EMAIL_FROM_ADDRESS=hola@madfam.io
+EMAIL_FROM_NAME=MADFAM
 
 # ============================================
 # OPTIONAL: Monitoring

--- a/.env.production.example
+++ b/.env.production.example
@@ -103,8 +103,8 @@ RATE_LIMIT_TENANT_ENTERPRISE=10000
 EMAIL_ENABLED=true
 EMAIL_PROVIDER=resend
 RESEND_API_KEY=${RESEND_API_KEY}
-EMAIL_FROM_ADDRESS=noreply@janua.dev
-EMAIL_FROM_NAME=Janua Security
+EMAIL_FROM_ADDRESS=hola@madfam.io
+EMAIL_FROM_NAME=MADFAM
 EMAIL_REPLY_TO=support@janua.dev
 
 # ============================================

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -378,7 +378,8 @@ SMTP_FROM=noreply@janua.dev
 # Email (Resend)
 EMAIL_ENABLED=true               # Enable email sending (default: false)
 EMAIL_PROVIDER=resend             # Email provider (resend)
-EMAIL_FROM_ADDRESS=noreply@janua.dev
+EMAIL_FROM_ADDRESS=hola@madfam.io  # see docs/EMAIL_SENDER_POLICY.md
+EMAIL_FROM_NAME=MADFAM            # one sender for every platform
 RESEND_API_KEY=re_XXXXX           # Resend API key (sending access)
 ```
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -35,7 +35,9 @@ CORS_ORIGINS=["http://localhost:3000","http://localhost:3001","http://localhost:
 
 # Email (Resend)
 EMAIL_PROVIDER=resend  # console | resend | smtp | sendgrid
-EMAIL_FROM=noreply@janua.dev
+# The setting is EMAIL_FROM_ADDRESS; nothing reads EMAIL_FROM, which this
+# line used to name. See docs/EMAIL_SENDER_POLICY.md for the address.
+EMAIL_FROM_ADDRESS=hola@madfam.io
 RESEND_API_KEY=replace-with-resend-api-key
 
 # Internal API (service-to-service communication for MADFAM apps)

--- a/apps/api/docs/RESEND_EMAIL_MIGRATION.md
+++ b/apps/api/docs/RESEND_EMAIL_MIGRATION.md
@@ -261,7 +261,7 @@ HTML Preview: <!DOCTYPE html><html>...
 
 1. **Add Domain to Resend**:
    ```bash
-   Domain: janua.dev
+   Domain: madfam.io
    Add DNS records as shown in Resend dashboard
    Verify domain ownership
    ```
@@ -270,9 +270,13 @@ HTML Preview: <!DOCTYPE html><html>...
    ```bash
    RESEND_API_KEY=re_xxxxxxxxxxxxx
    EMAIL_ENABLED=true
-   EMAIL_FROM_ADDRESS=noreply@janua.dev
-   EMAIL_FROM_NAME=Janua
+   EMAIL_FROM_ADDRESS=hola@madfam.io
+   EMAIL_FROM_NAME=MADFAM
    ```
+
+   One sender across every MADFAM platform, on the one Resend-verified
+   domain. `docs/EMAIL_SENDER_POLICY.md` explains why, and what has to be
+   true before this may change.
 
 3. **Test Email Delivery**:
    ```bash
@@ -281,7 +285,7 @@ HTML Preview: <!DOCTYPE html><html>...
      -H "Authorization: Bearer $RESEND_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{
-       "from": "noreply@janua.dev",
+       "from": "hola@madfam.io",
        "to": ["test@example.com"],
        "subject": "Test Email",
        "html": "<p>Testing Resend integration</p>"

--- a/apps/api/tests/unit/services/test_email_delivery.py
+++ b/apps/api/tests/unit/services/test_email_delivery.py
@@ -236,7 +236,11 @@ class TestTemplateLocalization:
         """This is localization, not replacement."""
         service = EmailService()
         rendered = service._render_template("magic_link.html", TEMPLATE_CONTEXT, "en")
-        assert "Sign in to Janua" in rendered
+        # Was "Sign in to Janua". The headline names the recipient's portal, not
+        # the platform, because the platform is credited and never branded as
+        # the sender (docs/EMAIL_SENDER_POLICY.md). Still a locale-specific
+        # string, so this keeps proving English rendered rather than Spanish.
+        assert "Sign in to your portal" in rendered
         assert 'lang="en"' in rendered
 
     def test_untranslated_message_falls_back_to_english_rather_than_failing(self):
@@ -256,7 +260,10 @@ class TestTemplateLocalization:
         # The tagline is MADFAM's now, not one platform's — the header reads
         # MADFAM on every message (see docs/EMAIL_SENDER_POLICY.md). What this
         # test guards is unchanged: the frame's language must match the body's.
-        assert "Tecnología, diseñada para tu operación" in spanish
+        # "tu operación" → "su operación": the frame settled on the usted
+        # register with the rest of the es-MX copy, so this asserts the string
+        # the frame actually carries rather than the tú-form it used to.
+        assert "Tecnología, diseñada para su operación" in spanish
         assert "Technology, engineered for your operation" not in spanish
 
         # Untranslated body → English body → English frame, not a mix.
@@ -266,12 +273,15 @@ class TestTemplateLocalization:
 
     def test_default_locale_setting_drives_unspecified_sends(self):
         service = EmailService()
+        # Headlines were "Sign in to Janua" / "Inicie sesión en Janua" before the
+        # sender-identity change. They still differ per locale, which is the
+        # whole point of this test — DEFAULT_EMAIL_LOCALE must pick the body.
         with patch.object(email_module.settings, "DEFAULT_EMAIL_LOCALE", "en"):
-            assert "Sign in to Janua" in service._render_template(
+            assert "Sign in to your portal" in service._render_template(
                 "magic_link.html", TEMPLATE_CONTEXT
             )
         with patch.object(email_module.settings, "DEFAULT_EMAIL_LOCALE", "es"):
-            assert "Inicie sesión en Janua" in service._render_template(
+            assert "Inicie sesión en su portal" in service._render_template(
                 "magic_link.html", TEMPLATE_CONTEXT
             )
 
@@ -317,7 +327,11 @@ class TestSubjectLocalization:
 
         with patch.object(service, "_send_email", new=AsyncMock(return_value=True)) as send:
             await service.send_magic_link_email("a@b.test", "tok", locale="en")
-        assert send.await_args.kwargs["subject"] == "Your Janua sign-in link"
+        # Was "Your Janua sign-in link". The subject dropped the platform name
+        # for the same reason the headline did. Deliberately still the literal
+        # English string rather than subject_for(...): comparing against the
+        # table the code reads would pass whatever the table said.
+        assert send.await_args.kwargs["subject"] == "Your sign-in link"
 
 
 class TestSendersAcceptLocale:

--- a/docs/EMAIL_SENDER_POLICY.md
+++ b/docs/EMAIL_SENDER_POLICY.md
@@ -9,7 +9,7 @@ managing that client's web presence.
 Applies from first contact until we manage the client's domain.
 
 ```
-From:    MADFAM <noreply@madfam.io>
+From:    MADFAM <hola@madfam.io>
 Header:  MADFAM
 Footer:  © Innovaciones MADFAM S.A.S. de C.V.
          Con tecnología de <platform>   ("Powered by" in en)

--- a/docs/guides/COMPLIANCE_FEATURES_GUIDE.md
+++ b/docs/guides/COMPLIANCE_FEATURES_GUIDE.md
@@ -946,7 +946,7 @@ async function handleDataSubjectRequest(
 ## Support & Resources
 
 - **Documentation**: https://docs.janua.dev/compliance
-- **Privacy Policy**: https://janua.dev/privacy
+- **Privacy Policy**: https://madfam.io/en/privacy
 - **GDPR Guide**: https://docs.janua.dev/gdpr
 - **CCPA Guide**: https://docs.janua.dev/ccpa
 - **Email Support**: compliance@janua.dev


### PR DESCRIPTION
Stacked on #538 — **base is `fix/sender-identity-madfam`, not `main`.** The policy doc it introduces lives only on that branch, and pointing docs at `hola@madfam.io` before #538 merges would make them wrong on `main`. Merge #538 first; this retargets to `main` automatically.

## The suite fails on #538 today

Five assertions in `test_email_delivery.py` still pin the pre-MADFAM strings. `#538` edited this file — it even updated the *comment* above the tagline assertion — but not these:

| assertion | was | is |
|---|---|---|
| `test_english_is_still_available` | `Sign in to Janua` | `Sign in to your portal` |
| `test_default_locale_setting_drives_unspecified_sends` (en) | `Sign in to Janua` | `Sign in to your portal` |
| `test_default_locale_setting_drives_unspecified_sends` (es) | `Inicie sesión en Janua` | `Inicie sesión en su portal` |
| `test_sender_passes_the_localized_subject_to_the_transport` | `Your Janua sign-in link` | `Your sign-in link` |
| `test_frame_language_matches_body_language` | `para tu operación` | `para su operación` |

The last one is the usted normalisation, not the sender change — same commit, different reason.

**Nothing is weakened.** Each still pins a literal, locale-specific string; that is the only thing making the locale tests non-vacuous. Comparing against `subject_for(...)` instead would have passed whatever the table said, so the subject assertion stays a literal. Every change carries a comment naming the old value.

## The docs disagreed with the code the same way

- **`docs/EMAIL_SENDER_POLICY.md` printed `MADFAM <noreply@madfam.io>`** while `config.py:218`, both k8s env entries and `scripts/send-sender-identity-test.sh` all say `hola@madfam.io` — and the script's own checklist reads *"The From reads `MADFAM <hola@madfam.io>` — not Janua, not noreply."* This is the doc people will cite, so it is the worst place to carry the wrong address.
- **`.env.example`, `.env.production.example`, `apps/api/.env.example`, `AGENTS.md`** told an operator to configure `noreply@janua.dev` — the exact sender this branch exists to stop using.
- **`apps/api/docs/RESEND_EMAIL_MIGRATION.md`** — under *Production Deployment → Configuration Steps*, so it is live guidance, not history. It said to verify `janua.dev` in Resend and send from it. Following it sends from an unverified domain, which per the policy doc is worse than the wrong brand: it does not arrive at all.
- **`apps/api/.env.example` named `EMAIL_FROM`**, which nothing reads. The setting is `EMAIL_FROM_ADDRESS`.
- **`docs/guides/COMPLIANCE_FEATURES_GUIDE.md`** linked `janua.dev/privacy`, which 404s. Now `madfam.io/en/privacy`, matching the footer #538 ships.

## Deliberately not touched

- `email_i18n.py`, `email_service.py`, `templates/email/**` — owned by other branches. **`email_service.py:45,56` still documents the sender as `noreply@madfam.io` in its docstring** and needs the same one-word fix from whoever owns it.
- `docs/design/RESEND_EMAIL_SERVICE_DESIGN.md:673` and `docs/enterprise/white-label-branding.md:600` — dated design proposals, accurate as records of what was planned in Nov 2025.
- **`apps/api/app/services/email/resend_service.py:77`** — `os.getenv("RESEND_FROM_EMAIL", "noreply@janua.dev")`. A real residual: with that variable unset, this service still sends from the old address. Code, not docs, so it is not in this PR.
- `EMAIL_REPLY_TO` / `SMTP_FROM` in the env examples name settings that do not exist. Pre-existing, and there is no unambiguous correct replacement, so they are reported rather than guessed at.
- `apps/docs/src/components/layout/footer.tsx:18,24,25`, `apps/api/app/main.py:419` and `apps/api/openapi.yaml:42` still point at the 404ing `janua.dev/{privacy,terms,support}`.

## Verification

```
131 passed   tests/unit/services/{test_email_delivery,test_email_service}.py
ruff check   All checks passed!
```

`ruff format --check` flags `test_email_delivery.py`, but it flagged the file *before* these edits too — the venv carries ruff 0.15.21 while `.pre-commit-config.yaml` pins v0.1.9. Left alone deliberately rather than reformatting with the wrong version.