### PR TITLE
feat(email): let the reader choose tú or usted in Spanish mail

### DIFF
--- a/apps/api/alembic/versions/012_user_spanish_formality.py
+++ b/apps/api/alembic/versions/012_user_spanish_formality.py
@@ -1,0 +1,75 @@
+"""Add users.spanish_formality — how Spanish should address this person.
+
+Spanish forces a choice English does not: every sentence addressed at the
+reader is either `tú` or `usted`, and there is no neutral second person.
+
+THE PRODUCT IS CURRENTLY SPLIT, and this column is the intended way to close
+that split rather than a janua-local nicety. Janua's transactional email is
+written in `usted` throughout. Nauta's client portal — the thing the same
+person signs into after clicking the link in that email — is written in `tú`
+throughout — measured 2026-08-14 across `apps/web/src` and `packages/ui/src`:
+ZERO usted markers against ~50 tú markers, down to "revisa tu bandeja de
+entrada" on its login page (apps/web/src/app/login/magic-link-form.tsx). One
+client, one journey, two registers.
+
+This column is meant to be the single source of truth for both surfaces. It
+only fixes the email half today: the portal hardcodes `tú` and does not read
+this value yet.
+
+Nullable, and NULL is meaningful: it means "has not chosen", which renders as
+`usted`. That is deliberately NOT the same as storing 'usted' on every row —
+NULL lets a later prompt ("¿te hablamos de tú o de usted?") tell the people
+who have expressed a preference apart from the people who never saw the
+question. A backfill would erase that distinction permanently, so there is no
+backfill here.
+
+VARCHAR(10) rather than a DB enum. The value set ('tu', 'usted') is owned by
+`app/services/email_i18n.py`; a Postgres enum would put a second copy of it in
+the schema and turn any future change into an ALTER TYPE on the users table.
+The application normalizes and validates on the way in, and
+`resolve_formality` treats anything unrecognized as "not chosen" — so an
+unexpected value degrades to the safe register instead of raising.
+
+RE-ENTRANT ON PURPOSE. Environments that ran `Base.metadata.create_all`
+(settings.AUTO_MIGRATE, and the test suite) already carry this column while
+`alembic_version` still reads an older revision; an unguarded add_column would
+raise DuplicateColumn and roll back the WHOLE chain, not just this step. Same
+idempotency contract as 003/006/007/009/010/011.
+
+Revision ID: 012_user_spanish_formality
+Revises: 011_invitation_columns
+Create Date: 2026-08-14
+"""
+
+import sqlalchemy as sa
+from sqlalchemy import inspect
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+# Keep revision ids <= 32 characters: `alembic_version.version_num` is
+# VARCHAR(32) and a longer id fails the stamp write, rolling back the upgrade
+# it just performed. Enforced by tests/unit/test_alembic_revision_graph.py.
+revision = "012_user_spanish_formality"
+down_revision = "011_invitation_columns"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in inspect(bind).get_columns("users")}
+
+    if "spanish_formality" not in existing:
+        op.add_column(
+            "users",
+            sa.Column("spanish_formality", sa.String(length=10), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    existing = {c["name"] for c in inspect(bind).get_columns("users")}
+
+    if "spanish_formality" in existing:
+        op.drop_column("users", "spanish_formality")

--- a/apps/api/app/models/__init__.py
+++ b/apps/api/app/models/__init__.py
@@ -66,6 +66,19 @@ class User(Base):
     phone_verified = Column(Boolean, default=False)
     timezone = Column(String(50))
     locale = Column(String(10))
+    # How Spanish should address this person: "tu" (informal) or "usted"
+    # (formal). NULL means "has not chosen" and renders as `usted` — the safe
+    # register for a first contact. Deliberately NOT a DB enum: the value set
+    # is owned by app.services.email_i18n (SPANISH_FORMALITIES), and an enum
+    # would make widening it a migration on a hot table. `vosotros` is not a
+    # supported value and is not coming; see email_i18n for why.
+    #
+    # Intended as the source of truth for EVERY surface, not just mail. Today
+    # only janua's transactional email reads it; nauta's client portal still
+    # hardcodes `tú` while this service's email is `usted`, so the same person
+    # is addressed two ways in one journey. Whoever fixes the portal side
+    # should read this column rather than introduce a second preference.
+    spanish_formality = Column(String(10))
     email_verified_at = Column(DateTime)
 
     # Timestamps

--- a/apps/api/app/services/email_i18n.py
+++ b/apps/api/app/services/email_i18n.py
@@ -16,9 +16,14 @@ Three moving parts live here so the email service stays about *sending*:
 Locale tags are normalized to a bare language subtag (`es-MX`, `es_419`,
 `ES-mx` all mean `es`), because a translation set is per-language; regional
 variants share it. The Spanish copy is written for es-MX specifically.
+
+Spanish additionally carries a *register* — how the reader is addressed. See
+the "Spanish formality" section below; `t()` resolves every Spanish string
+against the recipient's chosen register, so a template author picks a key and
+never picks a register.
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 from jinja2 import Environment, FileSystemLoader, pass_context
 
@@ -103,10 +108,79 @@ def template_candidates(template_name: str, locale: str) -> List[str]:
 
 
 # --------------------------------------------------------------------------
+# Spanish formality (register)
+#
+# Spanish forces a choice English does not: every sentence addressed at the
+# reader is either `tú` (informal) or `usted` (formal). There is no neutral
+# second person, so mail written in one register and read by someone who
+# expects the other lands as either presumptuous or cold — and that judgement
+# belongs to the reader, not to us.
+#
+# ONLY TWO REGISTERS ARE SUPPORTED, AND `vosotros` IS DELIBERATELY NOT ONE OF
+# THEM. `vosotros` is Peninsular Spanish; in Mexico it is not merely unused,
+# it reads as either foreign or comic — the register of a dubbed cartoon, not
+# of a clinic writing to its patients. The client this exists for is Mexican.
+# Please do not re-propose it: adding it would mean maintaining a third copy
+# of every string for an audience this platform does not have.
+# --------------------------------------------------------------------------
+FORMALITY_TU = "tu"
+FORMALITY_USTED = "usted"
+SPANISH_FORMALITIES: tuple = (FORMALITY_TU, FORMALITY_USTED)
+
+# `usted` is the default, and NULL on the user row means "has not chosen".
+# A first contact is with someone who has told us nothing about themselves;
+# `usted` is the register that is merely formal if wrong, where `tú` is
+# familiar if wrong. Formal-if-wrong is the cheaper error.
+DEFAULT_FORMALITY = FORMALITY_USTED
+
+
+def normalize_formality(raw: Any) -> Optional[str]:
+    """Reduce a stored/received formality value to a supported register.
+
+    Accepts the shapes that show up in practice: `tu`, `tú` (accented, as a
+    human would type it), `USTED`, surrounding whitespace. Returns None for
+    anything else — including `vosotros` — so callers fall through to the
+    next precedence tier instead of rendering a register nobody supports.
+    """
+    if not raw or not isinstance(raw, str):
+        return None
+    value = raw.strip().lower().replace("ú", "u")
+    if value in SPANISH_FORMALITIES:
+        return value
+    return None
+
+
+def resolve_formality(explicit: Any = None, user: Any = None) -> str:
+    """Resolve the Spanish register for one recipient, highest precedence first.
+
+    1. `explicit` — what the caller passed. A caller that knows the audience
+       (an operator resending on someone's behalf) always wins.
+    2. `user.spanish_formality` — the recipient's stored choice. Nullable;
+       NULL means "has not chosen" and falls through rather than meaning `tú`.
+    3. `DEFAULT_FORMALITY` — `usted`.
+
+    Deliberately has no deployment-wide tier the way `resolve_locale` does:
+    register is a property of the reader, not of the installation.
+    """
+    for candidate in (
+        explicit,
+        getattr(user, "spanish_formality", None) if user is not None else None,
+    ):
+        normalized = normalize_formality(candidate)
+        if normalized:
+            return normalized
+    return DEFAULT_FORMALITY
+
+
+# --------------------------------------------------------------------------
 # Subjects
 #
 # Keyed by message so the call sites stop carrying English string literals.
 # es-MX business register: usted-form, "correo electrónico", "iniciar sesión".
+#
+# The `es` entries here are the USTED register. Their `tú` counterparts live
+# in SUBJECTS_ES_TU below; every one of these five subjects addresses the
+# reader, so every one of them has a counterpart.
 # --------------------------------------------------------------------------
 SUBJECTS: Dict[str, Dict[str, str]] = {
     "verification": {
@@ -131,20 +205,43 @@ SUBJECTS: Dict[str, Dict[str, str]] = {
     },
 }
 
+# `tú` subjects. Keyed identically to SUBJECTS; a message missing from here
+# falls back to its usted subject rather than to English.
+# tests/unit/services/test_email_formality.py fails if a key here has no
+# Spanish counterpart in SUBJECTS, or if a Spanish subject has no entry here.
+SUBJECTS_ES_TU: Dict[str, str] = {
+    "verification": "Verifica tu cuenta de Janua",
+    "password_reset": "Restablece tu contraseña de Janua",
+    "magic_link": "Tu enlace de acceso a Janua",
+    "welcome": "Te damos la bienvenida a Janua",
+    "invitation": "Te invitaron a unirse a {organization_name} en Janua",
+}
 
-def subject_for(message_key: str, locale: Optional[str] = None, **fields: Any) -> str:
-    """Return the localized subject for a message.
+
+def subject_for(
+    message_key: str,
+    locale: Optional[str] = None,
+    formality: Optional[str] = None,
+    **fields: Any,
+) -> str:
+    """Return the localized subject for a message, in the reader's register.
 
     Falls back to English when the locale has no translation for this
     message, and to the message key itself only if the key is unknown — an
     unknown key is a programming error, and a visible one beats an email with
     an empty subject line.
+
+    `formality` applies to Spanish only and is ignored for every other
+    language; an absent `tú` variant falls back to the usted subject, never
+    to English.
     """
     per_locale = SUBJECTS.get(message_key)
     if not per_locale:
         return message_key
     resolved = normalize_locale(locale) or FALLBACK_LOCALE
     template = per_locale.get(resolved) or per_locale[FALLBACK_LOCALE]
+    if resolved == "es" and normalize_formality(formality) == FORMALITY_TU:
+        template = SUBJECTS_ES_TU.get(message_key, template)
     if fields:
         try:
             return template.format(**fields)
@@ -182,15 +279,344 @@ CHROME: Dict[str, Dict[str, str]] = {
 }
 
 
-def chrome_string(key: str, locale: Optional[str] = None) -> str:
-    """Look up a shared header/footer string.
+# --------------------------------------------------------------------------
+# Spanish body copy
+#
+# Prose that ADDRESSES THE READER lives here rather than inline in the `es/`
+# templates, because that is the only prose whose wording changes with the
+# register. Register-neutral text — a button that reads "Iniciar sesión", a
+# field label, a sentence about the product in the third person — stays inline
+# in the template on purpose: lifting it here would create two entries to keep
+# in sync for a string that is byte-identical in both registers.
+#
+# The split is enforced, not conventional:
+# tests/unit/services/test_email_formality.py scans the visible text of every
+# `es/` template for second-person-formal markers and fails if any survive
+# outside a `t()` call.
+#
+# Keys are `<message>.<slot>`; `<message>.txt_<slot>` where the plain-text
+# part words or wraps something differently from the HTML part. Embedded "\n"
+# reproduces the hand-wrapping the .txt templates already had.
+# --------------------------------------------------------------------------
+ES_BODY: Dict[str, str] = {
+    # -- shared across messages ------------------------------------------
+    "common.need_help": "¿Necesita ayuda? Escríbanos a",
+    # -- magic_link -------------------------------------------------------
+    "magic_link.heading": "Inicie sesión en Janua",
+    "magic_link.intro": (
+        "Use el siguiente botón para iniciar sesión. No necesita contraseña: "
+        "el enlace le da acceso directo."
+    ),
+    "magic_link.security_notice": (
+        "Si usted no solicitó iniciar sesión, puede ignorar este correo electrónico: "
+        "el enlace está ligado a su dirección y no hace nada hasta que se abre. "
+        "Nunca lo reenvíe, ya que cualquier persona que lo tenga podría entrar a su "
+        "cuenta hasta que el enlace expire."
+    ),
+    "magic_link.button_fallback": "Si el botón no funciona, copie esta dirección en su navegador:",
+    "magic_link.txt_intro": "Inicie sesión en Janua con este enlace:",
+    "magic_link.txt_security_notice": (
+        "Si usted no solicitó iniciar sesión, puede ignorar este correo electrónico. Nunca\n"
+        "reenvíe este enlace: cualquier persona que lo tenga podría entrar a su cuenta hasta\n"
+        "que expire."
+    ),
+    # -- password_reset ---------------------------------------------------
+    "password_reset.heading": "Restablezca su contraseña",
+    "password_reset.intro": (
+        "Recibimos una solicitud para restablecer la contraseña de su cuenta de Janua. "
+        "Si usted hizo esta solicitud, use el código que aparece abajo o haga clic en el "
+        "botón para crear una contraseña nueva."
+    ),
+    "password_reset.code_label": "Su código para restablecer la contraseña:",
+    "password_reset.security_notice": (
+        "Si usted no solicitó restablecer su contraseña, es posible que alguien esté "
+        "intentando acceder a su cuenta. Le recomendamos:"
+    ),
+    "password_reset.tip_change_password": "Cambiar su contraseña de inmediato",
+    "password_reset.tip_review_activity": "Revisar la actividad reciente de su cuenta",
+    "password_reset.link_lifetime": (
+        "Por seguridad, este enlace expira en 30 minutos. Si necesita un enlace nuevo, "
+        "puede solicitarlo desde la página de inicio de sesión."
+    ),
+    "password_reset.txt_intro": (
+        "Recibimos una solicitud para restablecer la contraseña de su cuenta de Janua."
+    ),
+    "password_reset.txt_cta": "Restablezca su contraseña con este enlace:",
+    "password_reset.txt_ignore": (
+        "Si usted no solicitó restablecer su contraseña, puede ignorar este correo\n"
+        "electrónico. Su contraseña no se modificará."
+    ),
+    # -- verification -----------------------------------------------------
+    "verification.heading": "Verifique su correo electrónico",
+    "verification.intro": (
+        "Le damos la bienvenida a Janua. Verifique su dirección de correo electrónico "
+        "para terminar de configurar su cuenta y acceder a todas las funciones."
+    ),
+    "verification.code_label": "Su código de verificación:",
+    "verification.or_click": (
+        "O haga clic en el siguiente botón para verificar su correo electrónico:"
+    ),
+    "verification.why_title": "¿Por qué verificar su correo electrónico?",
+    "verification.why_body": (
+        "La verificación nos ayuda a proteger su cuenta y habilita funciones importantes "
+        "como la recuperación de contraseña y las notificaciones de seguridad."
+    ),
+    "verification.not_you": (
+        "Si usted no creó una cuenta en Janua, puede ignorar este correo electrónico."
+    ),
+    "verification.txt_intro": (
+        "Le damos la bienvenida a Janua. Verifique su dirección de correo electrónico para\n"
+        "terminar de configurar su cuenta y acceder a todas las funciones."
+    ),
+    "verification.txt_cta": "Verifique su correo electrónico con este enlace:",
+    "verification.txt_why_body": (
+        "La verificación nos ayuda a proteger su cuenta y habilita funciones importantes\n"
+        "como la recuperación de contraseña y las notificaciones de seguridad."
+    ),
+    # -- welcome ----------------------------------------------------------
+    "welcome.heading": "Le damos la bienvenida a Janua 🎉",
+    "welcome.intro": (
+        "Su cuenta de Janua se creó correctamente. Ya forma parte de una plataforma de "
+        "identidad segura en la que confían organizaciones de todo el mundo."
+    ),
+    "welcome.account_details": "Datos de su cuenta:",
+    "welcome.steps_intro": "Le sugerimos empezar por aquí para aprovechar Janua al máximo:",
+    "welcome.step_mfa_title": "Active la autenticación de dos factores",
+    "welcome.step_mfa_body": "Añada una capa adicional de seguridad a su cuenta",
+    "welcome.step_org_title": "Configure su organización",
+    "welcome.step_org_body": "Invite a su equipo y defina roles y permisos",
+    "welcome.step_integrate_title": "Intégrelo con su aplicación",
+    "welcome.step_integrate_body": (
+        "Use nuestros SDK para añadir autenticación a sus aplicaciones"
+    ),
+    "welcome.step_passkeys_title": "Habilite las llaves de acceso",
+    "welcome.step_passkeys_body": "Configure el acceso sin contraseña para mayor seguridad",
+    "welcome.help_title": "¿Necesita ayuda?",
+    "welcome.help_body": "Nuestro equipo está a sus órdenes:",
+    "welcome.help_support": "Reciba ayuda de nuestro equipo",
+    "welcome.thanks": (
+        "Gracias por elegir Janua. Nos da gusto acompañarle en la seguridad de su plataforma."
+    ),
+    "welcome.txt_intro": (
+        "Le damos la bienvenida a Janua. Su cuenta se creó y se verificó correctamente."
+    ),
+    "welcome.txt_dashboard_cta": "Comience por su panel:",
+    "welcome.txt_capabilities": "Lo que puede hacer con Janua:",
+    "welcome.txt_capability_identity": "Administrar su identidad digital",
+    "welcome.txt_capability_privacy": "Controlar sus datos y su privacidad",
+    "welcome.txt_help": (
+        "¿Necesita ayuda para empezar? Consulte nuestra documentación o escríbanos a"
+    ),
+    "welcome.txt_closing": "Nos da mucho gusto tenerle con nosotros.",
+    # -- invitation -------------------------------------------------------
+    "invitation.heading": "Le invitaron a colaborar",
+    # Sentence fragment on purpose: the inviter and organization names are
+    # wrapped in <strong> in the HTML, so the sentence cannot be one string
+    # without either escaping the markup or marking user-supplied names
+    # |safe. The fragment is grammatically stable in both registers.
+    "invitation.invited_to_join": "le invitó a unirse a",
+    "invitation.txt_invited_to_join": "Le invitaron a unirse a",
+    "invitation.accept_before": "Le pedimos aceptarla antes de esa fecha.",
+    "invitation.button_fallback": (
+        "Si el botón anterior no funciona, copie y pegue esta dirección en su navegador:"
+    ),
+    "invitation.questions": "¿Tiene alguna duda? Escriba a",
+    "invitation.txt_open_link": "Abra el siguiente enlace para aceptar su invitación:",
+    "invitation.txt_questions": "¿Tiene alguna duda? Escríbanos a",
+}
+
+# Every Spanish string a template can ask for, in the USTED register. Built
+# from CHROME so the shared frame and the body copy resolve through one map.
+ES_STRINGS: Dict[str, str] = {**CHROME["es"], **ES_BODY}
+
+# --------------------------------------------------------------------------
+# `tú` variants.
+#
+# ONLY the keys whose wording actually differs. A key absent from here falls
+# back to its usted string at render time, so a missing variant degrades to
+# the safe register rather than to a blank paragraph — but it cannot be
+# missing by accident: ES_STRINGS must partition exactly into
+# `set(ES_TU) | ES_REGISTER_NEUTRAL`, and the test fails on any key that is
+# in neither.
+#
+# NOTE ON PRONOUN DROPPING. Where the usted copy spells out the subject
+# pronoun ("Si USTED no solicitó..."), the tú copy drops it ("Si no
+# solicitaste..."). This is not an oversight. In usted the pronoun does real
+# work — "solicitó" alone is also third person, so without it the sentence
+# could be read as being about someone else. "Solicitaste" is unambiguous, and
+# an explicit "tú" there reads contrastive/emphatic, as if arguing with the
+# reader. Dropping it is what a Mexican writer would do.
+# --------------------------------------------------------------------------
+ES_TU: Dict[str, str] = {
+    # -- chrome -----------------------------------------------------------
+    "why_received": "Recibiste este correo electrónico porque tienes una cuenta en Janua.",
+    # -- shared -----------------------------------------------------------
+    "common.need_help": "¿Necesitas ayuda? Escríbenos a",
+    # -- magic_link -------------------------------------------------------
+    "magic_link.heading": "Inicia sesión en Janua",
+    "magic_link.intro": (
+        "Usa el siguiente botón para iniciar sesión. No necesitas contraseña: "
+        "el enlace te da acceso directo."
+    ),
+    "magic_link.security_notice": (
+        "Si no solicitaste iniciar sesión, puedes ignorar este correo electrónico: "
+        "el enlace está ligado a tu dirección y no hace nada hasta que se abre. "
+        "Nunca lo reenvíes, ya que cualquier persona que lo tenga podría entrar a tu "
+        "cuenta hasta que el enlace expire."
+    ),
+    "magic_link.button_fallback": "Si el botón no funciona, copia esta dirección en tu navegador:",
+    "magic_link.txt_intro": "Inicia sesión en Janua con este enlace:",
+    "magic_link.txt_security_notice": (
+        "Si no solicitaste iniciar sesión, puedes ignorar este correo electrónico. Nunca\n"
+        "reenvíes este enlace: cualquier persona que lo tenga podría entrar a tu cuenta hasta\n"
+        "que expire."
+    ),
+    # -- password_reset ---------------------------------------------------
+    "password_reset.heading": "Restablece tu contraseña",
+    "password_reset.intro": (
+        "Recibimos una solicitud para restablecer la contraseña de tu cuenta de Janua. "
+        "Si hiciste esta solicitud, usa el código que aparece abajo o haz clic en el "
+        "botón para crear una contraseña nueva."
+    ),
+    "password_reset.code_label": "Tu código para restablecer la contraseña:",
+    "password_reset.security_notice": (
+        "Si no solicitaste restablecer tu contraseña, es posible que alguien esté "
+        "intentando acceder a tu cuenta. Te recomendamos:"
+    ),
+    "password_reset.tip_change_password": "Cambiar tu contraseña de inmediato",
+    "password_reset.tip_review_activity": "Revisar la actividad reciente de tu cuenta",
+    "password_reset.link_lifetime": (
+        "Por seguridad, este enlace expira en 30 minutos. Si necesitas un enlace nuevo, "
+        "puedes solicitarlo desde la página de inicio de sesión."
+    ),
+    "password_reset.txt_intro": (
+        "Recibimos una solicitud para restablecer la contraseña de tu cuenta de Janua."
+    ),
+    "password_reset.txt_cta": "Restablece tu contraseña con este enlace:",
+    "password_reset.txt_ignore": (
+        "Si no solicitaste restablecer tu contraseña, puedes ignorar este correo\n"
+        "electrónico. Tu contraseña no se modificará."
+    ),
+    # -- verification -----------------------------------------------------
+    "verification.heading": "Verifica tu correo electrónico",
+    "verification.intro": (
+        "Te damos la bienvenida a Janua. Verifica tu dirección de correo electrónico "
+        "para terminar de configurar tu cuenta y acceder a todas las funciones."
+    ),
+    "verification.code_label": "Tu código de verificación:",
+    "verification.or_click": (
+        "O haz clic en el siguiente botón para verificar tu correo electrónico:"
+    ),
+    "verification.why_title": "¿Por qué verificar tu correo electrónico?",
+    "verification.why_body": (
+        "La verificación nos ayuda a proteger tu cuenta y habilita funciones importantes "
+        "como la recuperación de contraseña y las notificaciones de seguridad."
+    ),
+    "verification.not_you": (
+        "Si no creaste una cuenta en Janua, puedes ignorar este correo electrónico."
+    ),
+    "verification.txt_intro": (
+        "Te damos la bienvenida a Janua. Verifica tu dirección de correo electrónico para\n"
+        "terminar de configurar tu cuenta y acceder a todas las funciones."
+    ),
+    "verification.txt_cta": "Verifica tu correo electrónico con este enlace:",
+    "verification.txt_why_body": (
+        "La verificación nos ayuda a proteger tu cuenta y habilita funciones importantes\n"
+        "como la recuperación de contraseña y las notificaciones de seguridad."
+    ),
+    # -- welcome ----------------------------------------------------------
+    "welcome.heading": "Te damos la bienvenida a Janua 🎉",
+    "welcome.intro": (
+        "Tu cuenta de Janua se creó correctamente. Ya formas parte de una plataforma de "
+        "identidad segura en la que confían organizaciones de todo el mundo."
+    ),
+    "welcome.account_details": "Datos de tu cuenta:",
+    "welcome.steps_intro": "Te sugerimos empezar por aquí para aprovechar Janua al máximo:",
+    "welcome.step_mfa_title": "Activa la autenticación de dos factores",
+    "welcome.step_mfa_body": "Añade una capa adicional de seguridad a tu cuenta",
+    "welcome.step_org_title": "Configura tu organización",
+    "welcome.step_org_body": "Invita a tu equipo y define roles y permisos",
+    "welcome.step_integrate_title": "Intégralo con tu aplicación",
+    "welcome.step_integrate_body": "Usa nuestros SDK para añadir autenticación a tus aplicaciones",
+    "welcome.step_passkeys_title": "Habilita las llaves de acceso",
+    "welcome.step_passkeys_body": "Configura el acceso sin contraseña para mayor seguridad",
+    "welcome.help_title": "¿Necesitas ayuda?",
+    # "a tus órdenes" is idiomatic in Mexico in exactly the same courtesy
+    # slot as "a sus órdenes"; it is not a literal-but-odd calque.
+    "welcome.help_body": "Nuestro equipo está a tus órdenes:",
+    "welcome.help_support": "Recibe ayuda de nuestro equipo",
+    "welcome.thanks": (
+        "Gracias por elegir Janua. Nos da gusto acompañarte en la seguridad de tu plataforma."
+    ),
+    "welcome.txt_intro": (
+        "Te damos la bienvenida a Janua. Tu cuenta se creó y se verificó correctamente."
+    ),
+    "welcome.txt_dashboard_cta": "Comienza por tu panel:",
+    "welcome.txt_capabilities": "Lo que puedes hacer con Janua:",
+    "welcome.txt_capability_identity": "Administrar tu identidad digital",
+    "welcome.txt_capability_privacy": "Controlar tus datos y tu privacidad",
+    "welcome.txt_help": (
+        "¿Necesitas ayuda para empezar? Consulta nuestra documentación o escríbenos a"
+    ),
+    "welcome.txt_closing": "Nos da mucho gusto tenerte con nosotros.",
+    # -- invitation -------------------------------------------------------
+    "invitation.heading": "Te invitaron a colaborar",
+    "invitation.invited_to_join": "te invitó a unirse a",
+    "invitation.txt_invited_to_join": "Te invitaron a unirse a",
+    "invitation.accept_before": "Te pedimos aceptarla antes de esa fecha.",
+    "invitation.button_fallback": (
+        "Si el botón anterior no funciona, copia y pega esta dirección en tu navegador:"
+    ),
+    "invitation.questions": "¿Tienes alguna duda? Escribe a",
+    "invitation.txt_open_link": "Abre el siguiente enlace para aceptar tu invitación:",
+    "invitation.txt_questions": "¿Tienes alguna duda? Escríbenos a",
+}
+
+# --------------------------------------------------------------------------
+# Register-neutral Spanish keys.
+#
+# These are byte-identical in `tú` and `usted` — they name a thing rather than
+# address the reader — so they are DELIBERATELY NOT duplicated into ES_TU.
+# Duplicating them would mean two strings to keep in sync with no
+# reader-visible difference between them.
+#
+# This set is not documentation: it is half of the partition the tests check.
+# Adding a Spanish key without either a `tú` variant or a line here fails
+# tests/unit/services/test_email_formality.py, which is the point — a
+# register-sensitive string cannot reach a reader unreviewed.
+# --------------------------------------------------------------------------
+ES_REGISTER_NEUTRAL: Set[str] = {
+    "tagline",  # "Plataforma de identidad segura" — names the product
+    "rights",  # "Todos los derechos reservados." — boilerplate, no addressee
+    "privacy",  # "Aviso de privacidad" — the name of a document
+    "terms",  # "Términos del servicio" — the name of a document
+    "support",  # "Soporte" — a noun
+    "location",  # a postal address
+}
+
+
+def chrome_string(key: str, locale: Optional[str] = None, formality: Optional[str] = None) -> str:
+    """Look up a localized string by key: shared chrome or Spanish body copy.
 
     Defaults to English when no locale is in scope so that rendering a
     template directly — without going through the service, as the template
     guards in the test suite do — produces exactly the frame it produced
     before localization existed.
+
+    For Spanish, `formality` selects the register. An absent `tú` variant
+    falls back to the usted string, NEVER to English: a Spanish reader who
+    asked for `tú` and hits an untranslated key should get slightly formal
+    Spanish, not a language they did not ask for.
     """
     resolved = normalize_locale(locale) or FALLBACK_LOCALE
+    if resolved == "es":
+        if normalize_formality(formality) == FORMALITY_TU:
+            informal = ES_TU.get(key)
+            if informal is not None:
+                return informal
+        formal = ES_STRINGS.get(key)
+        if formal is not None:
+            return formal
     return CHROME.get(resolved, CHROME[FALLBACK_LOCALE]).get(
         key, CHROME[FALLBACK_LOCALE].get(key, "")
     )
@@ -205,14 +631,17 @@ def html_lang(locale: Optional[str] = None) -> str:
 
 @pass_context
 def _chrome_global(ctx, key: str) -> str:
-    """`t('key')` inside a template: the shared header/footer strings.
+    """`t('key')` inside a template: any localized string, by key.
 
     Context-aware so base.html renders in the same language as the body
     without every template forwarding the locale explicitly. With no locale in
     context — a template rendered directly rather than through a service —
     this yields the English frame the templates had before localization.
+
+    The register is read from context the same way, so a template author picks
+    a key and never picks a register; `formality` absent means `usted`.
     """
-    return chrome_string(key, ctx.get("locale"))
+    return chrome_string(key, ctx.get("locale"), ctx.get("formality"))
 
 
 @pass_context

--- a/apps/api/app/services/email_service.py
+++ b/apps/api/app/services/email_service.py
@@ -20,7 +20,10 @@ import structlog
 from app.config import settings
 from app.services.email_i18n import (
     FALLBACK_LOCALE,
+    FORMALITY_TU,
+    FORMALITY_USTED,
     build_email_environment,
+    resolve_formality,
     resolve_locale,
     subject_for,
     template_candidates,
@@ -56,11 +59,13 @@ class EmailService:
         user_name: str = None,
         user_id: str = None,
         locale: Optional[str] = None,
+        formality: Optional[str] = None,
         user: Any = None,
     ) -> str:
         """Send email verification email and return verification token"""
 
         recipient_locale = resolve_locale(locale, user=user, default=self._default_locale())
+        recipient_formality = resolve_formality(formality, user=user)
 
         # Generate verification token
         verification_token = self._generate_verification_token()
@@ -97,9 +102,13 @@ class EmailService:
         }
 
         # Render email template
-        subject = subject_for("verification", recipient_locale)
-        html_content = self._render_template("verification.html", template_data, recipient_locale)
-        text_content = self._render_template("verification.txt", template_data, recipient_locale)
+        subject = subject_for("verification", recipient_locale, recipient_formality)
+        html_content = self._render_template(
+            "verification.html", template_data, recipient_locale, recipient_formality
+        )
+        text_content = self._render_template(
+            "verification.txt", template_data, recipient_locale, recipient_formality
+        )
 
         # Send email
         success = await self._send_email(
@@ -161,6 +170,7 @@ class EmailService:
         user_name: str = None,
         redirect_base: str = None,
         locale: Optional[str] = None,
+        formality: Optional[str] = None,
         user: Any = None,
     ) -> str:
         """Send password reset email for an already-issued token.
@@ -172,6 +182,7 @@ class EmailService:
         """
 
         recipient_locale = resolve_locale(locale, user=user, default=self._default_locale())
+        recipient_formality = resolve_formality(formality, user=user)
 
         # Mirror to Redis for observability (audit 2026-04-23 M2: JSON).
         if self.redis_client:
@@ -208,9 +219,13 @@ class EmailService:
         }
 
         # Render email template
-        subject = subject_for("password_reset", recipient_locale)
-        html_content = self._render_template("password_reset.html", template_data, recipient_locale)
-        text_content = self._render_template("password_reset.txt", template_data, recipient_locale)
+        subject = subject_for("password_reset", recipient_locale, recipient_formality)
+        html_content = self._render_template(
+            "password_reset.html", template_data, recipient_locale, recipient_formality
+        )
+        text_content = self._render_template(
+            "password_reset.txt", template_data, recipient_locale, recipient_formality
+        )
 
         # Send email
         success = await self._send_email(
@@ -229,11 +244,13 @@ class EmailService:
         email: str,
         user_name: str = None,
         locale: Optional[str] = None,
+        formality: Optional[str] = None,
         user: Any = None,
     ) -> bool:
         """Send welcome email to new user"""
 
         recipient_locale = resolve_locale(locale, user=user, default=self._default_locale())
+        recipient_formality = resolve_formality(formality, user=user)
 
         template_data = {
             "user_name": user_name or email.split("@")[0],
@@ -245,9 +262,13 @@ class EmailService:
         }
 
         # Render email template
-        subject = subject_for("welcome", recipient_locale)
-        html_content = self._render_template("welcome.html", template_data, recipient_locale)
-        text_content = self._render_template("welcome.txt", template_data, recipient_locale)
+        subject = subject_for("welcome", recipient_locale, recipient_formality)
+        html_content = self._render_template(
+            "welcome.html", template_data, recipient_locale, recipient_formality
+        )
+        text_content = self._render_template(
+            "welcome.txt", template_data, recipient_locale, recipient_formality
+        )
 
         # Send email
         success = await self._send_email(
@@ -270,7 +291,11 @@ class EmailService:
         return token_hash[:64]  # 64-char hex string
 
     def _render_template(
-        self, template_name: str, data: Dict[str, Any], locale: Optional[str] = None
+        self,
+        template_name: str,
+        data: Dict[str, Any],
+        locale: Optional[str] = None,
+        formality: Optional[str] = None,
     ) -> str:
         """Render email template with data, in the recipient's language.
 
@@ -285,8 +310,14 @@ class EmailService:
         takes the first that exists, so a language with no translation for
         this particular message still sends — in English — rather than
         raising into the fallback text below.
+
+        `formality` is the Spanish register (`tu` / `usted`). It goes into the
+        context rather than into the template name, so it costs zero extra
+        template files: `t()` resolves each key against it. An absent or
+        unrecognized value renders `usted`.
         """
         resolved_locale = resolve_locale(locale, default=self._default_locale())
+        resolved_formality = resolve_formality(formality)
         try:
             template = self.jinja_env.select_template(
                 template_candidates(template_name, resolved_locale)
@@ -305,6 +336,9 @@ class EmailService:
                 "current_year": datetime.utcnow().year,
                 "subject": data.get("subject", "Janua"),
                 "locale": body_locale,
+                # `t()` reads this off the context, which is why base.html and
+                # every es/ template pick up the register without naming it.
+                "formality": resolved_formality,
                 **data,
             }
             return template.render(**context)
@@ -315,7 +349,7 @@ class EmailService:
                 locale=resolved_locale,
                 error_type=type(e).__name__,
             )
-            return self._fallback_body(template_name, data, resolved_locale)
+            return self._fallback_body(template_name, data, resolved_locale, resolved_formality)
 
     @staticmethod
     def _default_locale() -> Optional[str]:
@@ -324,15 +358,25 @@ class EmailService:
         return getattr(settings, "DEFAULT_EMAIL_LOCALE", None)
 
     @staticmethod
-    def _fallback_body(template_name: str, data: Dict[str, Any], locale: str) -> str:
+    def _fallback_body(
+        template_name: str,
+        data: Dict[str, Any],
+        locale: str,
+        formality: str = FORMALITY_USTED,
+    ) -> str:
         """Last-resort plain text when the template itself failed to render.
 
         Localized too: a recipient hitting the degraded path is no more
-        likely to read English than one hitting the happy path.
+        likely to read English than one hitting the happy path — and no more
+        likely to have changed their mind about being addressed as `tú`. The
+        degraded path is still an email someone reads.
         """
         spanish = locale == "es"
+        informal = spanish and formality == FORMALITY_TU
         if "verification" in template_name:
             url = data.get("verification_url", "")
+            if informal:
+                return f"Verifica tu correo electrónico aquí: {url}"
             return (
                 f"Verifique su correo electrónico aquí: {url}"
                 if spanish
@@ -340,6 +384,8 @@ class EmailService:
             )
         if "magic_link" in template_name:
             url = data.get("magic_url", "")
+            if informal:
+                return f"Inicia sesión en Janua aquí: {url}"
             return (
                 f"Inicie sesión en Janua aquí: {url}"
                 if spanish
@@ -347,6 +393,8 @@ class EmailService:
             )
         if "password_reset" in template_name:
             url = data.get("reset_url", "")
+            if informal:
+                return f"Restablece tu contraseña aquí: {url}"
             return (
                 f"Restablezca su contraseña aquí: {url}"
                 if spanish
@@ -354,6 +402,8 @@ class EmailService:
             )
         if "welcome" in template_name:
             name = data.get("user_name", "there")
+            if informal:
+                return f"Te damos la bienvenida a Janua, {name}."
             return (
                 f"Le damos la bienvenida a Janua, {name}."
                 if spanish
@@ -361,11 +411,14 @@ class EmailService:
             )
         if "invitation" in template_name:
             url = data.get("invitation_url", "")
+            if informal:
+                return f"Te han invitado a unirte a Janua: {url}"
             return (
                 f"Le han invitado a unirse a Janua: {url}"
                 if spanish
                 else f"You've been invited to join Janua: {url}"
             )
+        # Register-neutral: names a state, does not address the reader.
         return "Contenido no disponible" if spanish else "Email content unavailable"
 
     async def send_magic_link_email(
@@ -374,6 +427,7 @@ class EmailService:
         magic_token: str,
         redirect_url: Optional[str] = None,
         locale: Optional[str] = None,
+        formality: Optional[str] = None,
         user: Any = None,
     ) -> bool:
         """Send a passwordless sign-in link.
@@ -384,6 +438,7 @@ class EmailService:
         (already allowlist-validated when the link was requested).
         """
         recipient_locale = resolve_locale(locale, user=user, default=self._default_locale())
+        recipient_formality = resolve_formality(formality, user=user)
         callback = f"{settings.API_BASE_URL or settings.BASE_URL}/api/v1/auth/magic-link/callback"
         magic_url = f"{callback}?token={magic_token}"
 
@@ -396,9 +451,13 @@ class EmailService:
             "support_email": settings.SUPPORT_EMAIL or "support@janua.dev",
         }
 
-        subject = subject_for("magic_link", recipient_locale)
-        html_content = self._render_template("magic_link.html", template_data, recipient_locale)
-        text_content = self._render_template("magic_link.txt", template_data, recipient_locale)
+        subject = subject_for("magic_link", recipient_locale, recipient_formality)
+        html_content = self._render_template(
+            "magic_link.html", template_data, recipient_locale, recipient_formality
+        )
+        text_content = self._render_template(
+            "magic_link.txt", template_data, recipient_locale, recipient_formality
+        )
 
         sent = await self._send_email(
             to_email=email, subject=subject, html_content=html_content, text_content=text_content
@@ -571,6 +630,7 @@ async def send_password_reset_email_task(
     reset_token: str,
     redirect_base: Optional[str] = None,
     locale: Optional[str] = None,
+    formality: Optional[str] = None,
 ) -> None:
     """Background-task entrypoint for the forgot-password flow.
 
@@ -586,7 +646,11 @@ async def send_password_reset_email_task(
     try:
         service = EmailService()
         sent = await service.send_password_reset_email(
-            email, reset_token, redirect_base=redirect_base, locale=locale
+            email,
+            reset_token,
+            redirect_base=redirect_base,
+            locale=locale,
+            formality=formality,
         )
         if not sent:
             logger.warning(
@@ -602,6 +666,7 @@ async def send_magic_link_email_task(
     magic_token: str,
     redirect_url: Optional[str] = None,
     locale: Optional[str] = None,
+    formality: Optional[str] = None,
 ) -> None:
     """Background-task entrypoint for the magic-link flow.
 
@@ -614,7 +679,9 @@ async def send_magic_link_email_task(
     """
     try:
         service = EmailService()
-        sent = await service.send_magic_link_email(email, magic_token, redirect_url, locale=locale)
+        sent = await service.send_magic_link_email(
+            email, magic_token, redirect_url, locale=locale, formality=formality
+        )
         if not sent:
             logger.warning(
                 "Magic link email NOT sent — the recipient will never receive a sign-in link",
@@ -629,6 +696,7 @@ async def send_verification_email_task(
     verification_token: str,
     user_name: Optional[str] = None,
     locale: Optional[str] = None,
+    formality: Optional[str] = None,
 ) -> None:
     """Background-task entrypoint for email verification.
 
@@ -640,6 +708,7 @@ async def send_verification_email_task(
     try:
         service = EmailService()
         recipient_locale = resolve_locale(locale, default=service._default_locale())
+        recipient_formality = resolve_formality(formality)
         verification_url = (
             f"{settings.FRONTEND_URL}/auth/verify-email?token={verification_token}"
         )
@@ -656,12 +725,12 @@ async def send_verification_email_task(
         }
         sent = await service._send_email(
             to_email=email,
-            subject=subject_for("verification", recipient_locale),
+            subject=subject_for("verification", recipient_locale, recipient_formality),
             html_content=service._render_template(
-                "verification.html", template_data, recipient_locale
+                "verification.html", template_data, recipient_locale, recipient_formality
             ),
             text_content=service._render_template(
-                "verification.txt", template_data, recipient_locale
+                "verification.txt", template_data, recipient_locale, recipient_formality
             ),
         )
         if not sent:

--- a/apps/api/app/templates/email/es/invitation.html
+++ b/apps/api/app/templates/email/es/invitation.html
@@ -1,14 +1,23 @@
 {% extends "base.html" %}
 
+{# Prose that addresses the reader goes through t() and follows the tú/usted
+   choice; register-neutral text — the labels, the button, the paragraph
+   describing Janua in the third person — stays inline. See es/magic_link.html.
+
+   The "X le invitó a unirse a Y" sentence is fragmented on purpose: both
+   names are wrapped in <strong>, so the sentence cannot be one catalog
+   string without marking user-supplied names |safe. The fragment is
+   grammatically stable in both registers. #}
+
 {% block content %}
-<h1 style="margin: 0 0 20px 0; font-size: 28px; color: #1f2937;">Le invitaron a colaborar</h1>
+<h1 style="margin: 0 0 20px 0; font-size: 28px; color: #1f2937;">{{ t('invitation.heading') }}</h1>
 
 <p style="margin: 0 0 15px 0; font-size: 16px; color: #4b5563;">
     Hola:
 </p>
 
 <p style="margin: 0 0 15px 0; font-size: 16px; color: #4b5563;">
-    <strong>{{ inviter_name }}</strong> le invitó a unirse a <strong>{{ organization_name }}</strong> en Janua.
+    <strong>{{ inviter_name }}</strong> {{ t('invitation.invited_to_join') }} <strong>{{ organization_name }}</strong> en Janua.
 </p>
 
 <div class="info" style="background-color: #dbeafe; border-left: 4px solid #3b82f6; padding: 15px; margin: 20px 0; border-radius: 4px;">
@@ -26,7 +35,7 @@
 <div class="warning" style="background-color: #fef3c7; border-left: 4px solid #f59e0b; padding: 15px; margin: 20px 0; border-radius: 4px;">
     <p style="margin: 0; font-size: 14px; color: #92400e;">
         <strong>⏰ Esta invitación expira el {{ expires_at }}</strong><br>
-        Le pedimos aceptarla antes de esa fecha.
+        {{ t('invitation.accept_before') }}
     </p>
 </div>
 
@@ -40,11 +49,11 @@
 </div>
 
 <p style="margin-top: 32px; font-size: 13px; color: #6b7280; line-height: 1.5;">
-    Si el botón anterior no funciona, copie y pegue esta dirección en su navegador:<br>
+    {{ t('invitation.button_fallback') }}<br>
     <span style="word-break: break-all; color: #3b82f6;">{{ invitation_url }}</span>
 </p>
 
 <p style="margin-top: 24px; font-size: 14px; color: #6b7280;">
-    ¿Tiene alguna duda? Escriba a <a href="mailto:{{ support_email }}" style="color: #3b82f6; text-decoration: none;">{{ support_email }}</a>
+    {{ t('invitation.questions') }} <a href="mailto:{{ support_email }}" style="color: #3b82f6; text-decoration: none;">{{ support_email }}</a>
 </p>
 {% endblock %}

--- a/apps/api/app/templates/email/es/invitation.txt
+++ b/apps/api/app/templates/email/es/invitation.txt
@@ -1,8 +1,8 @@
-Le invitaron a unirse a {{ organization_name }}
+{{ t('invitation.txt_invited_to_join') }} {{ organization_name }}
 
 Hola:
 
-{{ inviter_name }} le invitó a unirse a {{ organization_name }} en Janua.
+{{ inviter_name }} {{ t('invitation.invited_to_join') }} {{ organization_name }} en Janua.
 
 DETALLES DE LA INVITACIÓN
 -------------------------
@@ -11,7 +11,7 @@ Rol: {{ role }}
 
 ACEPTAR LA INVITACIÓN
 ---------------------
-Abra el siguiente enlace para aceptar su invitación:
+{{ t('invitation.txt_open_link') }}
 {{ invitation_url }}
 
 ⏰ IMPORTANTE: esta invitación expira el {{ expires_at }}
@@ -22,7 +22,7 @@ Janua es una plataforma de autenticación empresarial que ofrece administración
 segura de accesos, integración con inicio de sesión único (SSO), autenticación de
 varios factores y funciones completas de identidad de usuarios.
 
-¿Tiene alguna duda? Escríbanos a {{ support_email }}
+{{ t('invitation.txt_questions') }} {{ support_email }}
 
 ---
 Janua by Innovaciones MADFAM

--- a/apps/api/app/templates/email/es/magic_link.html
+++ b/apps/api/app/templates/email/es/magic_link.html
@@ -1,14 +1,21 @@
 {% extends "base.html" %}
 
+{# Prose that ADDRESSES THE READER goes through t(), so it follows the
+   recipient's tú/usted choice. Register-neutral text — the greeting, the
+   button label, a sentence about the link rather than about the reader —
+   stays inline on purpose: it is byte-identical in both registers, and
+   lifting it into the catalog would create two strings to keep in sync for
+   no reader-visible difference. See app/services/email_i18n.py. #}
+
 {% block content %}
-<h2 style="color: #1f2937; margin: 0 0 20px 0;">Inicie sesión en Janua</h2>
+<h2 style="color: #1f2937; margin: 0 0 20px 0;">{{ t('magic_link.heading') }}</h2>
 
 <p style="margin: 0 0 20px 0;">
     Hola {{ user_name }}:
 </p>
 
 <p style="margin: 0 0 20px 0;">
-    Use el siguiente botón para iniciar sesión. No necesita contraseña: el enlace le da acceso directo.
+    {{ t('magic_link.intro') }}
 </p>
 
 <div style="text-align: center;">
@@ -21,13 +28,11 @@
 
 <div class="warning">
     <strong>⚠️ Aviso de seguridad</strong><br>
-    Si usted no solicitó iniciar sesión, puede ignorar este correo electrónico: el enlace
-    está ligado a su dirección y no hace nada hasta que se abre. Nunca lo reenvíe, ya que
-    cualquier persona que lo tenga podría entrar a su cuenta hasta que el enlace expire.
+    {{ t('magic_link.security_notice') }}
 </div>
 
 <p style="margin: 20px 0 0 0; color: #6b7280; font-size: 12px;">
-    Si el botón no funciona, copie esta dirección en su navegador:<br>
+    {{ t('magic_link.button_fallback') }}<br>
     {{ magic_link }}
 </p>
 {% endblock %}

--- a/apps/api/app/templates/email/es/magic_link.txt
+++ b/apps/api/app/templates/email/es/magic_link.txt
@@ -1,15 +1,13 @@
 Hola {{ user_name }}:
 
-Inicie sesión en Janua con este enlace:
+{{ t('magic_link.txt_intro') }}
 {{ magic_url }}
 
 Este enlace funciona una sola vez y expira en 15 minutos.
 
-Si usted no solicitó iniciar sesión, puede ignorar este correo electrónico. Nunca
-reenvíe este enlace: cualquier persona que lo tenga podría entrar a su cuenta hasta
-que expire.
+{{ t('magic_link.txt_security_notice') }}
 
-¿Necesita ayuda? Escríbanos a {{ support_email }}
+{{ t('common.need_help') }} {{ support_email }}
 
 ---
 Equipo Janua

--- a/apps/api/app/templates/email/es/password_reset.html
+++ b/apps/api/app/templates/email/es/password_reset.html
@@ -1,20 +1,23 @@
 {% extends "base.html" %}
 
+{# Prose that addresses the reader goes through t() and follows the tú/usted
+   choice; register-neutral text stays inline. See es/magic_link.html. #}
+
 {% block content %}
-<h2 style="color: #1f2937; margin: 0 0 20px 0;">Restablezca su contraseña</h2>
+<h2 style="color: #1f2937; margin: 0 0 20px 0;">{{ t('password_reset.heading') }}</h2>
 
 <p style="margin: 0 0 20px 0;">
     Hola {{ user_name }}:
 </p>
 
 <p style="margin: 0 0 20px 0;">
-    Recibimos una solicitud para restablecer la contraseña de su cuenta de Janua. Si usted hizo esta solicitud, use el código que aparece abajo o haga clic en el botón para crear una contraseña nueva.
+    {{ t('password_reset.intro') }}
 </p>
 
 {% if reset_code %}
 <div class="code-box">
     <p style="margin: 0 0 10px 0; color: #6b7280; font-size: 14px;">
-        Su código para restablecer la contraseña:
+        {{ t('password_reset.code_label') }}
     </p>
     <div class="code">{{ reset_code }}</div>
     <p style="margin: 10px 0 0 0; color: #6b7280; font-size: 12px;">
@@ -29,16 +32,16 @@
 
 <div class="warning">
     <strong>⚠️ Aviso de seguridad</strong><br>
-    Si usted no solicitó restablecer su contraseña, es posible que alguien esté intentando acceder a su cuenta. Le recomendamos:
+    {{ t('password_reset.security_notice') }}
     <ul style="margin: 10px 0 0 0; padding-left: 20px;">
-        <li>Cambiar su contraseña de inmediato</li>
+        <li>{{ t('password_reset.tip_change_password') }}</li>
         <li>Activar la autenticación de dos factores</li>
-        <li>Revisar la actividad reciente de su cuenta</li>
+        <li>{{ t('password_reset.tip_review_activity') }}</li>
     </ul>
 </div>
 
 <p style="margin: 20px 0 0 0; color: #6b7280; font-size: 14px;">
-    Por seguridad, este enlace expira en 30 minutos. Si necesita un enlace nuevo, puede solicitarlo desde la página de inicio de sesión.
+    {{ t('password_reset.link_lifetime') }}
 </p>
 
 <p style="margin: 20px 0 0 0; color: #6b7280; font-size: 14px;">

--- a/apps/api/app/templates/email/es/password_reset.txt
+++ b/apps/api/app/templates/email/es/password_reset.txt
@@ -1,16 +1,15 @@
 Hola {{ user_name }}:
 
-Recibimos una solicitud para restablecer la contraseña de su cuenta de Janua.
+{{ t('password_reset.txt_intro') }}
 
-Restablezca su contraseña con este enlace:
+{{ t('password_reset.txt_cta') }}
 {{ reset_url }}
 
 Este enlace expira en 1 hora.
 
-Si usted no solicitó restablecer su contraseña, puede ignorar este correo
-electrónico. Su contraseña no se modificará.
+{{ t('password_reset.txt_ignore') }}
 
-¿Necesita ayuda? Escríbanos a {{ support_email }}
+{{ t('common.need_help') }} {{ support_email }}
 
 ---
 Equipo Janua

--- a/apps/api/app/templates/email/es/verification.html
+++ b/apps/api/app/templates/email/es/verification.html
@@ -1,20 +1,23 @@
 {% extends "base.html" %}
 
+{# Prose that addresses the reader goes through t() and follows the tú/usted
+   choice; register-neutral text stays inline. See es/magic_link.html. #}
+
 {% block content %}
-<h2 style="color: #1f2937; margin: 0 0 20px 0;">Verifique su correo electrónico</h2>
+<h2 style="color: #1f2937; margin: 0 0 20px 0;">{{ t('verification.heading') }}</h2>
 
 <p style="margin: 0 0 20px 0;">
     Hola {{ user_name }}:
 </p>
 
 <p style="margin: 0 0 20px 0;">
-    Le damos la bienvenida a Janua. Verifique su dirección de correo electrónico para terminar de configurar su cuenta y acceder a todas las funciones.
+    {{ t('verification.intro') }}
 </p>
 
 {% if verification_code %}
 <div class="code-box">
     <p style="margin: 0 0 10px 0; color: #6b7280; font-size: 14px;">
-        Su código de verificación:
+        {{ t('verification.code_label') }}
     </p>
     <div class="code">{{ verification_code }}</div>
     <p style="margin: 10px 0 0 0; color: #6b7280; font-size: 12px;">
@@ -24,7 +27,7 @@
 {% endif %}
 
 <p style="margin: 0 0 20px 0; text-align: center;">
-    O haga clic en el siguiente botón para verificar su correo electrónico:
+    {{ t('verification.or_click') }}
 </p>
 
 <div style="text-align: center;">
@@ -32,11 +35,11 @@
 </div>
 
 <div class="info">
-    <strong>¿Por qué verificar su correo electrónico?</strong><br>
-    La verificación nos ayuda a proteger su cuenta y habilita funciones importantes como la recuperación de contraseña y las notificaciones de seguridad.
+    <strong>{{ t('verification.why_title') }}</strong><br>
+    {{ t('verification.why_body') }}
 </div>
 
 <p style="margin: 20px 0 0 0; color: #6b7280; font-size: 14px;">
-    Si usted no creó una cuenta en Janua, puede ignorar este correo electrónico.
+    {{ t('verification.not_you') }}
 </p>
 {% endblock %}

--- a/apps/api/app/templates/email/es/verification.txt
+++ b/apps/api/app/templates/email/es/verification.txt
@@ -1,20 +1,18 @@
 Hola {{ user_name }}:
 
-Le damos la bienvenida a Janua. Verifique su dirección de correo electrónico para
-terminar de configurar su cuenta y acceder a todas las funciones.
+{{ t('verification.txt_intro') }}
 
-Verifique su correo electrónico con este enlace:
+{{ t('verification.txt_cta') }}
 {{ verification_url }}
 
 Este enlace de verificación expira en 24 horas.
 
-¿Por qué verificar su correo electrónico?
-La verificación nos ayuda a proteger su cuenta y habilita funciones importantes
-como la recuperación de contraseña y las notificaciones de seguridad.
+{{ t('verification.why_title') }}
+{{ t('verification.txt_why_body') }}
 
-Si usted no creó una cuenta en Janua, puede ignorar este correo electrónico.
+{{ t('verification.not_you') }}
 
-¿Necesita ayuda? Escríbanos a {{ support_email }}
+{{ t('common.need_help') }} {{ support_email }}
 
 ---
 Equipo Janua

--- a/apps/api/app/templates/email/es/welcome.html
+++ b/apps/api/app/templates/email/es/welcome.html
@@ -1,18 +1,22 @@
 {% extends "base.html" %}
 
+{# Prose that addresses the reader goes through t() and follows the tú/usted
+   choice; register-neutral text — field labels, the button, link names —
+   stays inline. See es/magic_link.html. #}
+
 {% block content %}
-<h2 style="color: #1f2937; margin: 0 0 20px 0;">Le damos la bienvenida a Janua 🎉</h2>
+<h2 style="color: #1f2937; margin: 0 0 20px 0;">{{ t('welcome.heading') }}</h2>
 
 <p style="margin: 0 0 20px 0;">
     Hola {{ user_name }}:
 </p>
 
 <p style="margin: 0 0 20px 0;">
-    Su cuenta de Janua se creó correctamente. Ya forma parte de una plataforma de identidad segura en la que confían organizaciones de todo el mundo.
+    {{ t('welcome.intro') }}
 </p>
 
 <div class="info">
-    <strong>Datos de su cuenta:</strong><br>
+    <strong>{{ t('welcome.account_details') }}</strong><br>
     Correo electrónico: {{ user_email }}<br>
     Organización: {{ organization_name }}<br>
     Plan: {{ plan_name }}<br>
@@ -21,24 +25,24 @@
 
 <h3 style="color: #1f2937; margin: 30px 0 15px 0;">Primeros pasos en Janua</h3>
 
-<p style="margin: 0 0 20px 0;">Le sugerimos empezar por aquí para aprovechar Janua al máximo:</p>
+<p style="margin: 0 0 20px 0;">{{ t('welcome.steps_intro') }}</p>
 
 <ol style="margin: 0 0 20px 0; padding-left: 20px;">
     <li style="margin-bottom: 10px;">
-        <strong>Active la autenticación de dos factores</strong><br>
-        <span style="color: #6b7280; font-size: 14px;">Añada una capa adicional de seguridad a su cuenta</span>
+        <strong>{{ t('welcome.step_mfa_title') }}</strong><br>
+        <span style="color: #6b7280; font-size: 14px;">{{ t('welcome.step_mfa_body') }}</span>
     </li>
     <li style="margin-bottom: 10px;">
-        <strong>Configure su organización</strong><br>
-        <span style="color: #6b7280; font-size: 14px;">Invite a su equipo y defina roles y permisos</span>
+        <strong>{{ t('welcome.step_org_title') }}</strong><br>
+        <span style="color: #6b7280; font-size: 14px;">{{ t('welcome.step_org_body') }}</span>
     </li>
     <li style="margin-bottom: 10px;">
-        <strong>Intégrelo con su aplicación</strong><br>
-        <span style="color: #6b7280; font-size: 14px;">Use nuestros SDK para añadir autenticación a sus aplicaciones</span>
+        <strong>{{ t('welcome.step_integrate_title') }}</strong><br>
+        <span style="color: #6b7280; font-size: 14px;">{{ t('welcome.step_integrate_body') }}</span>
     </li>
     <li style="margin-bottom: 10px;">
-        <strong>Habilite las llaves de acceso</strong><br>
-        <span style="color: #6b7280; font-size: 14px;">Configure el acceso sin contraseña para mayor seguridad</span>
+        <strong>{{ t('welcome.step_passkeys_title') }}</strong><br>
+        <span style="color: #6b7280; font-size: 14px;">{{ t('welcome.step_passkeys_body') }}</span>
     </li>
 </ol>
 
@@ -47,19 +51,19 @@
 </div>
 
 <div style="background-color: #f9fafb; border-radius: 6px; padding: 20px; margin: 30px 0;">
-    <h4 style="margin: 0 0 10px 0; color: #1f2937;">¿Necesita ayuda?</h4>
+    <h4 style="margin: 0 0 10px 0; color: #1f2937;">{{ t('welcome.help_title') }}</h4>
     <p style="margin: 0 0 10px 0; font-size: 14px;">
-        Nuestro equipo está a sus órdenes:
+        {{ t('welcome.help_body') }}
     </p>
     <ul style="margin: 10px 0 0 0; padding-left: 20px; font-size: 14px;">
         <li><a href="https://docs.janua.dev" style="color: #3b82f6;">Documentación</a> - Guías y referencia de la API</li>
-        <li><a href="https://janua.dev/support" style="color: #3b82f6;">Centro de soporte</a> - Reciba ayuda de nuestro equipo</li>
+        <li><a href="https://janua.dev/support" style="color: #3b82f6;">Centro de soporte</a> - {{ t('welcome.help_support') }}</li>
         <li><a href="https://github.com/madfam-io/janua" style="color: #3b82f6;">GitHub</a> - Ejemplos de código y SDK</li>
     </ul>
 </div>
 
 <p style="margin: 20px 0 0 0; color: #6b7280; font-size: 14px;">
-    Gracias por elegir Janua. Nos da gusto acompañarle en la seguridad de su plataforma.
+    {{ t('welcome.thanks') }}
 </p>
 
 <p style="margin: 20px 0 0 0;">

--- a/apps/api/app/templates/email/es/welcome.txt
+++ b/apps/api/app/templates/email/es/welcome.txt
@@ -1,19 +1,19 @@
 Hola {{ user_name }}:
 
-Le damos la bienvenida a Janua. Su cuenta se creó y se verificó correctamente.
+{{ t('welcome.txt_intro') }}
 
-Comience por su panel:
+{{ t('welcome.txt_dashboard_cta') }}
 {{ dashboard_url }}
 
-Lo que puede hacer con Janua:
-• Administrar su identidad digital
+{{ t('welcome.txt_capabilities') }}
+• {{ t('welcome.txt_capability_identity') }}
 • Conectarse con aplicaciones de forma segura
-• Controlar sus datos y su privacidad
+• {{ t('welcome.txt_capability_privacy') }}
 
-¿Necesita ayuda para empezar? Consulte nuestra documentación o escríbanos a
+{{ t('welcome.txt_help') }}
 {{ support_email }}
 
-Nos da mucho gusto tenerle con nosotros.
+{{ t('welcome.txt_closing') }}
 
 ---
 Equipo Janua

--- a/apps/api/tests/unit/services/test_email_formality.py
+++ b/apps/api/tests/unit/services/test_email_formality.py
@@ -1,0 +1,567 @@
+"""Guards for the Spanish register (`tú` / `usted`) of transactional email.
+
+Spanish forces a choice English does not: every sentence addressed at the
+reader is either `tú` or `usted`, with no neutral second person. The failure
+mode this file exists to prevent is not a crash — it is a perfectly
+well-formed email that addresses a clinic's patient in the wrong register, or
+worse, addresses them in BOTH inside one message because someone added a
+paragraph and only wrote one variant.
+
+That failure is invisible to every other kind of test: the template renders,
+the send succeeds, the API returns 200. So the assertions here are about the
+TEXT A READER SEES, and three of them are structural rather than
+example-based, because an example-based test only covers the strings someone
+remembered to write an example for:
+
+* `TestCatalogPartition` — every Spanish string is either declared
+  register-sensitive (both variants present) or declared register-neutral.
+  A key that is neither fails, which is what makes forgetting impossible.
+* `TestNoRegisterLeakInCatalog` — a `tú` string containing usted markers (or
+  vice versa) is a half-done translation. Scanned, not eyeballed.
+* `TestTemplateLiteralsAreRegisterNeutral` — prose left inline in an `es/`
+  template can never follow the reader's choice, so inline prose must not
+  address the reader at all.
+
+The rest render the real templates in both registers and assert on the
+output, because reading a diff does not tell you what the reader gets.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.services.email_i18n import (
+    CHROME,
+    DEFAULT_FORMALITY,
+    ES_REGISTER_NEUTRAL,
+    ES_STRINGS,
+    ES_TU,
+    FORMALITY_TU,
+    FORMALITY_USTED,
+    SUBJECTS,
+    SUBJECTS_ES_TU,
+    build_email_environment,
+    chrome_string,
+    normalize_formality,
+    resolve_formality,
+    subject_for,
+)
+from app.services.email_service import EmailService
+
+# tests/unit/services/<this file> -> apps/api
+API_ROOT = Path(__file__).resolve().parents[3]
+TEMPLATE_DIR = API_ROOT / "app" / "templates" / "email"
+ES_TEMPLATE_DIR = TEMPLATE_DIR / "es"
+
+# Enough context that every button has an href and every optional block renders.
+TEMPLATE_CONTEXT = {
+    "user_name": "Ana",
+    "user_email": "ana@clinica.test",
+    "magic_link": "https://example.test/go?token=abc",
+    "magic_url": "https://example.test/go?token=abc",
+    "reset_link": "https://example.test/go?token=abc",
+    "reset_url": "https://example.test/go?token=abc",
+    "reset_code": "123456",
+    "verification_code": "654321",
+    "verification_link": "https://example.test/go?token=abc",
+    "verification_url": "https://example.test/go?token=abc",
+    "dashboard_link": "https://example.test/app",
+    "dashboard_url": "https://example.test/app",
+    "invitation_url": "https://example.test/invite",
+    "inviter_name": "Luis",
+    "organization_name": "Clinica Vida",
+    "role": "admin",
+    "teams": ["Recepcion"],
+    "expires_at": "1 de septiembre de 2026",
+    "plan_name": "Pro",
+    "account_id": "acct_1",
+    "request_ip": "203.0.113.10",
+    "request_browser": "Safari",
+    "request_time": "12:00",
+    "support_email": "hola@madfam.io",
+    "base_url": "https://janua.dev",
+}
+
+# ---------------------------------------------------------------------------
+# Register markers.
+#
+# Spanish marks the register in three places, and a scan has to look at all
+# three or it misses the majority of real strings:
+#   1. the pronoun itself           usted / tú
+#   2. possessives and clitics      su, sus, le, les / tu, tus, te
+#   3. the verb ending              "Verifique" vs "Verifica"
+#
+# (3) cannot be regexed generically, so the usted forms actually used in this
+# copy are listed.
+#
+# Three shapes are DELIBERATELY EXCLUDED, each because a real string tripped
+# on it while this was being written:
+#
+# * Preterites (`creó`, `recibió`, `solicitó`, `hizo`). "Su cuenta se creó
+#   correctamente" is third person about the account, not usted about the
+#   reader, and it is correct in BOTH registers. Excluding them loses nothing:
+#   `why_received` — the one usted string carrying no pronoun — is still
+#   caught by `tiene`.
+# * A generic enclitic regex (`\\w+arte\\b`). It matches "parte", "aparte",
+#   "comparte". The enclitics that appear in real copy attach to infinitives
+#   and are few, so they are listed by hand instead.
+# * URLs, stripped before scanning: a link ending in `/invite` is not a verb.
+#
+# `tiene`, `puede` and `necesita` are kept even though third person shares
+# them, because dropping them would blind the scan to the most common way
+# usted appears without a pronoun. If a genuine third-person sentence ever
+# trips one, rewrite the sentence rather than deleting the marker.
+# ---------------------------------------------------------------------------
+_USTED_VERBS = (
+    "abra|acepte|active|añada|cambie|comience|configure|consulte|copie|defina|escriba|"
+    "escríbanos|habilite|haga|ignore|inicie|intégrelo|invite|pegue|reciba|restablezca|"
+    "revise|solicite|use|verifique|necesita|puede|tiene"
+)
+_USTED_ENCLITICS = (
+    "acompañarle|atenderle|ayudarle|darle|enviarle|hacerle|informarle|mostrarle|"
+    "permitirle|tenerle|unirsele"
+)
+_TU_ENCLITICS = (
+    "acompañarte|atenderte|ayudarte|darte|enviarte|hacerte|informarte|mostrarte|"
+    "permitirte|tenerte|unirte"
+)
+USTED_MARKERS = (
+    ("pronoun 'usted'", re.compile(r"\busted(?:es)?\b", re.I)),
+    ("possessive 'su/sus'", re.compile(r"\bsus?\b", re.I)),
+    ("clitic 'le/les'", re.compile(r"\bles?\b", re.I)),
+    ("enclitic '-le'", re.compile(rf"\b(?:{_USTED_ENCLITICS})\b", re.I)),
+    ("usted verb form", re.compile(rf"\b(?:{_USTED_VERBS})\b", re.I)),
+)
+TU_MARKERS = (
+    ("pronoun 'tú'", re.compile(r"\bt[úu]\b", re.I)),
+    ("possessive 'tu/tus'", re.compile(r"\btus?\b", re.I)),
+    ("clitic 'te'", re.compile(r"\bte\b", re.I)),
+    ("enclitic '-te'", re.compile(rf"\b(?:{_TU_ENCLITICS})\b", re.I)),
+)
+
+
+def markers_found(text: str, markers) -> list[str]:
+    """Names of the register markers present in `text`."""
+    return [name for name, pattern in markers if pattern.search(text)]
+
+
+def visible_text(rendered: str) -> str:
+    """The words a reader actually sees: markup, CSS and URLs stripped.
+
+    Scanning raw HTML for `\\ble\\b` would hit attribute values and stylesheet
+    text; scanning the visible text cannot. URLs go too — a path segment is
+    not prose, and `https://example.test/invite` is not the usted imperative
+    "invite". `.txt` templates lose only their URLs, having no tags.
+    """
+    text = re.sub(r"<(script|style)[^>]*>.*?</\1>", " ", rendered, flags=re.S | re.I)
+    text = re.sub(r"<!--.*?-->", " ", text, flags=re.S)
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = re.sub(r"\b(?:https?://|www\.)\S+", " ", text)
+    return re.sub(r"\s+", " ", text)
+
+
+def template_literal_text(source: str) -> str:
+    """Visible text of a template with every Jinja construct removed.
+
+    What survives is exactly the prose hardcoded in the file — the prose that
+    can never follow the reader's register, because `t()` never sees it.
+    """
+    stripped = re.sub(r"\{[{%#].*?[}%#]\}", " ", source, flags=re.S)
+    return visible_text(stripped)
+
+
+@pytest.fixture(scope="module")
+def env():
+    return build_email_environment(TEMPLATE_DIR)
+
+
+def render_es(env, template_name: str, formality: str) -> str:
+    context = {
+        **TEMPLATE_CONTEXT,
+        "current_year": 2026,
+        "subject": "Asunto",
+        "locale": "es",
+        "legal_locale": "es",
+        "formality": formality,
+    }
+    return env.get_template(f"es/{template_name}").render(**context)
+
+
+ES_TEMPLATE_NAMES = sorted(p.name for p in ES_TEMPLATE_DIR.iterdir() if p.is_file())
+
+
+class TestCatalogPartition:
+    """Every Spanish key is explicitly register-sensitive or register-neutral.
+
+    This is the test that makes forgetting impossible. Adding a Spanish string
+    that addresses the reader and writing only the usted half leaves its key
+    in neither ES_TU nor ES_REGISTER_NEUTRAL, and this fails.
+    """
+
+    def test_every_spanish_key_declares_its_register_handling(self):
+        undecided = set(ES_STRINGS) - set(ES_TU) - ES_REGISTER_NEUTRAL
+        assert not undecided, (
+            "Spanish key(s) with neither a `tú` variant nor a register-neutral "
+            f"declaration: {sorted(undecided)}. Add the `tú` wording to ES_TU, or — "
+            "if the string reads identically in both registers — add the key to "
+            "ES_REGISTER_NEUTRAL with a comment saying why."
+        )
+
+    def test_no_tu_variant_without_an_usted_counterpart(self):
+        orphans = set(ES_TU) - set(ES_STRINGS)
+        assert not orphans, (
+            f"`tú` variant(s) for key(s) that have no usted string: {sorted(orphans)}. "
+            "usted is the fallback register, so an orphan `tú` string is "
+            "unreachable for anyone who has not opted in."
+        )
+
+    def test_a_key_is_not_both_sensitive_and_neutral(self):
+        contradictory = set(ES_TU) & ES_REGISTER_NEUTRAL
+        assert not contradictory, (
+            f"key(s) declared register-neutral but also given a `tú` variant: "
+            f"{sorted(contradictory)}"
+        )
+
+    def test_neutral_keys_exist(self):
+        missing = ES_REGISTER_NEUTRAL - set(ES_STRINGS)
+        assert not missing, (
+            f"ES_REGISTER_NEUTRAL names key(s) that no longer exist: {sorted(missing)}"
+        )
+
+    def test_every_spanish_subject_has_both_registers(self):
+        spanish_subjects = {key for key, per_locale in SUBJECTS.items() if "es" in per_locale}
+        assert spanish_subjects == set(SUBJECTS_ES_TU), (
+            "Every Spanish subject addresses the reader, so every one needs a `tú` "
+            f"variant. usted-only: {sorted(spanish_subjects - set(SUBJECTS_ES_TU))}; "
+            f"orphan tú: {sorted(set(SUBJECTS_ES_TU) - spanish_subjects)}"
+        )
+
+    def test_vosotros_is_not_a_supported_register(self):
+        """Peninsular Spanish reads as foreign or comic to a Mexican reader.
+
+        Pinned as a test so re-adding it is a deliberate act with a failing
+        test to delete, not a quiet dict entry.
+        """
+        assert normalize_formality("vosotros") is None
+        assert "vosotros" not in ES_TU
+        assert not any("vosotros" in str(v).lower() for v in ES_STRINGS.values())
+
+
+class TestNoRegisterLeakInCatalog:
+    """A half-translated string still renders; only a scan catches it."""
+
+    @pytest.mark.parametrize("key", sorted(ES_TU))
+    def test_tu_strings_carry_no_usted_markers(self, key):
+        found = markers_found(ES_TU[key], USTED_MARKERS)
+        assert not found, f"`tú` string {key!r} still contains {found}: {ES_TU[key]!r}"
+
+    @pytest.mark.parametrize("key", sorted(set(ES_STRINGS) - ES_REGISTER_NEUTRAL))
+    def test_usted_strings_carry_no_tu_markers(self, key):
+        found = markers_found(ES_STRINGS[key], TU_MARKERS)
+        assert not found, f"usted string {key!r} contains {found}: {ES_STRINGS[key]!r}"
+
+    @pytest.mark.parametrize("key", sorted(ES_REGISTER_NEUTRAL))
+    def test_neutral_strings_address_nobody(self, key):
+        value = ES_STRINGS[key]
+        found = markers_found(value, USTED_MARKERS) + markers_found(value, TU_MARKERS)
+        assert not found, (
+            f"key {key!r} is declared register-neutral but its wording is "
+            f"register-marked ({found}): {value!r}. Either rewrite it so it names a "
+            "thing instead of addressing the reader, or move it out of "
+            "ES_REGISTER_NEUTRAL and give it a `tú` variant."
+        )
+
+
+class TestTemplateLiteralsAreRegisterNeutral:
+    """Prose hardcoded in a template can never follow the reader's choice."""
+
+    @pytest.mark.parametrize("name", ES_TEMPLATE_NAMES)
+    def test_no_register_marked_prose_outside_t(self, name):
+        literals = template_literal_text((ES_TEMPLATE_DIR / name).read_text())
+        found = markers_found(literals, USTED_MARKERS) + markers_found(literals, TU_MARKERS)
+        assert not found, (
+            f"es/{name} hardcodes register-marked Spanish ({found}) outside a t() call, "
+            "so it renders the same way whichever register the reader chose. Move the "
+            f"sentence into ES_BODY/ES_TU and reference it with t(). Literal text: "
+            f"{literals.strip()[:400]!r}"
+        )
+
+    @pytest.mark.parametrize("name", ES_TEMPLATE_NAMES + ["../base.html"])
+    def test_every_referenced_key_resolves_in_both_registers(self, name):
+        """A missing key renders as an empty string, i.e. a blank paragraph."""
+        source = (ES_TEMPLATE_DIR / name).read_text()
+        keys = set(re.findall(r"\bt\(\s*['\"]([^'\"]+)['\"]\s*\)", source))
+        assert keys, f"{name} references no t() keys — did the key syntax change?"
+        for key in sorted(keys):
+            for formality in (FORMALITY_USTED, FORMALITY_TU):
+                value = chrome_string(key, "es", formality)
+                assert value, (
+                    f"{name} calls t({key!r}) but it resolves to an empty string in "
+                    f"{formality!r} — the message would ship with a blank line there."
+                )
+
+
+class TestNormalizeFormality:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("tu", FORMALITY_TU),
+            ("tú", FORMALITY_TU),
+            ("TU", FORMALITY_TU),
+            ("  Tú  ", FORMALITY_TU),
+            ("usted", FORMALITY_USTED),
+            ("USTED", FORMALITY_USTED),
+            ("Ud.", None),
+            ("vosotros", None),
+            ("vos", None),
+            ("", None),
+            (None, None),
+            (7, None),
+            (["tu"], None),
+        ],
+    )
+    def test_normalizes_or_rejects(self, raw, expected):
+        assert normalize_formality(raw) == expected
+
+
+class TestResolveFormality:
+    def test_default_is_usted(self):
+        """The safe register for someone who has told us nothing."""
+        assert resolve_formality() == FORMALITY_USTED
+        assert DEFAULT_FORMALITY == FORMALITY_USTED
+
+    def test_null_column_means_not_chosen_not_tu(self):
+        user = SimpleNamespace(spanish_formality=None)
+        assert resolve_formality(user=user) == FORMALITY_USTED
+
+    def test_stored_choice_is_honoured(self):
+        user = SimpleNamespace(spanish_formality="tu")
+        assert resolve_formality(user=user) == FORMALITY_TU
+
+    def test_explicit_argument_outranks_stored_choice(self):
+        user = SimpleNamespace(spanish_formality="usted")
+        assert resolve_formality(FORMALITY_TU, user=user) == FORMALITY_TU
+
+    def test_unrecognized_stored_value_falls_through_to_usted(self):
+        """Including 'vosotros' — a bad row must not raise, and must not guess."""
+        for stored in ("vosotros", "VOS", "", "  ", "nope"):
+            user = SimpleNamespace(spanish_formality=stored)
+            assert resolve_formality(user=user) == FORMALITY_USTED
+
+    def test_user_without_the_attribute_does_not_raise(self):
+        """Rows loaded before the column existed, and non-User callers."""
+        assert resolve_formality(user=SimpleNamespace()) == FORMALITY_USTED
+
+
+class TestUstedIsTheFallbackRegister:
+    def test_absent_tu_variant_falls_back_to_usted_not_to_english(self):
+        """A key with no `tú` wording must still render Spanish."""
+        neutral_key = sorted(ES_REGISTER_NEUTRAL)[0]
+        assert neutral_key not in ES_TU
+        assert chrome_string(neutral_key, "es", FORMALITY_TU) == ES_STRINGS[neutral_key]
+        assert chrome_string(neutral_key, "es", FORMALITY_TU) != CHROME["en"].get(neutral_key)
+
+    def test_unknown_formality_renders_usted(self):
+        assert chrome_string("why_received", "es", "vosotros") == ES_STRINGS["why_received"]
+        assert chrome_string("why_received", "es", None) == ES_STRINGS["why_received"]
+
+    def test_formality_does_not_leak_into_english(self):
+        assert chrome_string("why_received", "en", FORMALITY_TU) == CHROME["en"]["why_received"]
+
+
+class TestSubjects:
+    @pytest.mark.parametrize("key", sorted(SUBJECTS_ES_TU))
+    def test_spanish_subject_follows_the_register(self, key):
+        usted = subject_for(key, "es", FORMALITY_USTED, organization_name="Clinica Vida")
+        informal = subject_for(key, "es", FORMALITY_TU, organization_name="Clinica Vida")
+        assert usted != informal
+        assert not markers_found(informal, USTED_MARKERS)
+        assert not markers_found(usted, TU_MARKERS)
+
+    def test_interpolation_survives_the_register_switch(self):
+        subject = subject_for("invitation", "es", FORMALITY_TU, organization_name="Clinica Vida")
+        assert "Clinica Vida" in subject
+        assert "{organization_name}" not in subject
+
+    def test_default_subject_register_is_usted(self):
+        assert subject_for("welcome", "es") == SUBJECTS["welcome"]["es"]
+
+    def test_english_subject_ignores_formality(self):
+        assert subject_for("welcome", "en", FORMALITY_TU) == SUBJECTS["welcome"]["en"]
+
+
+class TestRenderedOutput:
+    """The real templates, rendered, asserted on the text a reader sees."""
+
+    @pytest.mark.parametrize("name", ES_TEMPLATE_NAMES)
+    def test_tu_render_contains_no_usted(self, env, name):
+        text = visible_text(render_es(env, name, FORMALITY_TU))
+        found = markers_found(text, USTED_MARKERS)
+        assert not found, (
+            f"es/{name} rendered for `tú` still addresses the reader as usted: {found}"
+        )
+
+    @pytest.mark.parametrize("name", ES_TEMPLATE_NAMES)
+    def test_usted_render_contains_no_tu(self, env, name):
+        text = visible_text(render_es(env, name, FORMALITY_USTED))
+        found = markers_found(text, TU_MARKERS)
+        assert not found, f"es/{name} rendered for usted addresses the reader as `tú`: {found}"
+
+    @pytest.mark.parametrize("name", ES_TEMPLATE_NAMES)
+    def test_the_two_registers_actually_differ(self, env, name):
+        """Catches a template wired to t() for nothing that matters."""
+        assert render_es(env, name, FORMALITY_TU) != render_es(env, name, FORMALITY_USTED)
+
+    @pytest.mark.parametrize("name", ES_TEMPLATE_NAMES)
+    def test_no_blank_t_output(self, env, name):
+        """An unresolved key renders as "" — visible only as a hole in the copy."""
+        rendered = render_es(env, name, FORMALITY_TU)
+        assert "{{" not in rendered and "{%" not in rendered
+        # Two consecutive blank-ish lines where a paragraph should be.
+        assert not re.search(r"\n[ \t]*\n[ \t]*\n[ \t]*\n", rendered), (
+            f"es/{name} has a run of empty lines, which is what a t() key that "
+            "resolved to nothing looks like in the .txt part"
+        )
+
+    @pytest.mark.parametrize(
+        "name,usted_phrase,tu_phrase",
+        [
+            ("magic_link.html", "Inicie sesión en Janua", "Inicia sesión en Janua"),
+            ("magic_link.txt", "¿Necesita ayuda?", "¿Necesitas ayuda?"),
+            ("verification.html", "Verifique su correo", "Verifica tu correo"),
+            ("password_reset.html", "Restablezca su contraseña", "Restablece tu contraseña"),
+            ("welcome.html", "Le damos la bienvenida", "Te damos la bienvenida"),
+            ("welcome.txt", "Comience por su panel", "Comienza por tu panel"),
+            ("invitation.html", "Le invitaron a colaborar", "Te invitaron a colaborar"),
+            ("invitation.txt", "le invitó a unirse", "te invitó a unirse"),
+        ],
+    )
+    def test_specific_sentences_switch(self, env, name, usted_phrase, tu_phrase):
+        usted = render_es(env, name, FORMALITY_USTED)
+        informal = render_es(env, name, FORMALITY_TU)
+        assert usted_phrase in usted and usted_phrase not in informal
+        assert tu_phrase in informal and tu_phrase not in usted
+
+    def test_shared_footer_follows_the_body_register(self, env):
+        """base.html sits outside every content block; it must not stay formal."""
+        usted = render_es(env, "welcome.html", FORMALITY_USTED)
+        informal = render_es(env, "welcome.html", FORMALITY_TU)
+        assert "Recibió este correo electrónico porque tiene una cuenta" in usted
+        assert "Recibiste este correo electrónico porque tienes una cuenta" in informal
+
+    def test_untouched_footer_elements_are_not_register_dependent(self, env):
+        """Another branch owns the sender identity and legal links; this one
+        must not move them in either register."""
+        for formality in (FORMALITY_USTED, FORMALITY_TU):
+            rendered = render_es(env, "welcome.html", formality)
+            assert "Innovaciones MADFAM" in rendered
+            assert "Aviso de privacidad" in rendered
+            assert "Términos del servicio" in rendered
+
+    def test_action_urls_survive_both_registers(self, env):
+        """A register switch that blanked a button href would be worse than
+        the wrong register."""
+        for name in ES_TEMPLATE_NAMES:
+            for formality in (FORMALITY_USTED, FORMALITY_TU):
+                rendered = render_es(env, name, formality)
+                assert "example.test" in rendered, f"es/{name} lost its links in {formality}"
+
+
+class TestServiceRenderPath:
+    """The bare Jinja env above is not what production uses."""
+
+    @pytest.mark.parametrize("formality", [FORMALITY_TU, FORMALITY_USTED])
+    def test_service_injects_the_register(self, formality):
+        html = EmailService()._render_template(
+            "magic_link.html", dict(TEMPLATE_CONTEXT), "es", formality
+        )
+        expected = "Inicia sesión" if formality == FORMALITY_TU else "Inicie sesión"
+        assert expected in html
+
+    def test_service_defaults_to_usted(self):
+        html = EmailService()._render_template("magic_link.html", dict(TEMPLATE_CONTEXT), "es")
+        assert "Inicie sesión en Janua" in html
+
+    def test_english_body_is_unaffected_by_the_register(self):
+        """`tú` is a Spanish concept; asking for it must not perturb English."""
+        formal = EmailService()._render_template(
+            "magic_link.html", dict(TEMPLATE_CONTEXT), "en", FORMALITY_USTED
+        )
+        informal = EmailService()._render_template(
+            "magic_link.html", dict(TEMPLATE_CONTEXT), "en", FORMALITY_TU
+        )
+        assert formal == informal
+
+    @pytest.mark.parametrize(
+        "template_name,url_key,tu_phrase",
+        [
+            ("verification.html", "verification_url", "Verifica tu correo electrónico"),
+            ("magic_link.html", "magic_url", "Inicia sesión en Janua"),
+            ("password_reset.html", "reset_url", "Restablece tu contraseña"),
+        ],
+    )
+    def test_degraded_fallback_body_keeps_the_register(self, template_name, url_key, tu_phrase):
+        """The last-resort body is still an email somebody reads."""
+        data = {url_key: "https://example.test/go"}
+        body = EmailService._fallback_body(template_name, data, "es", FORMALITY_TU)
+        assert tu_phrase in body
+        assert not markers_found(body, USTED_MARKERS)
+
+
+class TestUserColumn:
+    def test_column_exists_and_is_nullable(self):
+        from app.models import User
+
+        column = User.__table__.columns["spanish_formality"]
+        assert column.nullable, "NULL must stay expressible: it means 'has not chosen'"
+        assert column.type.length >= len(FORMALITY_USTED)
+
+    def test_resolve_reads_the_column_name_the_model_defines(self):
+        """Guards a rename on one side of the pair."""
+        from app.models import User
+
+        assert "spanish_formality" in User.__table__.columns
+        user = SimpleNamespace(spanish_formality=FORMALITY_TU)
+        assert resolve_formality(user=user) == FORMALITY_TU
+
+
+class TestMigration:
+    """012 must be re-entrant: one unguarded add_column rolls back the chain."""
+
+    MIGRATION = API_ROOT / "alembic" / "versions" / "012_user_spanish_formality.py"
+
+    def test_migration_exists_and_chains_to_011(self):
+        source = self.MIGRATION.read_text()
+        assert 'revision = "012_user_spanish_formality"' in source
+        assert 'down_revision = "011_invitation_columns"' in source
+
+    def test_add_column_is_guarded_by_an_inspection(self):
+        """`Base.metadata.create_all` environments already have the column."""
+        source = self.MIGRATION.read_text()
+        assert 'inspect(bind).get_columns("users")' in source
+        add_column_line = next(
+            i for i, line in enumerate(source.splitlines()) if "op.add_column" in line
+        )
+        guard_line = next(
+            i
+            for i, line in enumerate(source.splitlines())
+            if 'if "spanish_formality" not in existing' in line
+        )
+        assert guard_line < add_column_line
+
+    def test_downgrade_is_guarded_too(self):
+        source = self.MIGRATION.read_text()
+        assert 'if "spanish_formality" in existing' in source
+
+    def test_no_backfill(self):
+        """Writing 'usted' onto every row would erase the difference between
+        'chose usted' and 'never saw the question'."""
+        source = self.MIGRATION.read_text()
+        assert "UPDATE users" not in source.upper().replace("UPDATE USERS", "UPDATE users")
+
+    def test_revision_id_fits_the_alembic_version_column(self):
+        assert len("012_user_spanish_formality") <= 32


### PR DESCRIPTION
## What this does

Lets a user choose how Spanish addresses them — `tú` or `usted` — and renders transactional email in their choice.

- `users.spanish_formality` (`'tu' | 'usted'`, nullable, migration `012`). NULL means **"has not chosen"** and renders `usted`.
- The register travels in the Jinja **context**, not in the template name, so it costs zero extra template files and `base.html` needed no change — its footer follows the body register on its own.
- `t('key')` resolves against the chosen register with **`usted` as the fallback** when a `tú` variant is absent, so a missing variant degrades to the safe register rather than to English or to a blank paragraph.
- Spanish prose that *addresses the reader* moved out of the `es/` templates into a keyed catalog with both registers. Register-neutral text (button labels, field names, sentences about the product in the third person) **stays inline and is deliberately not duplicated** — noted in `ES_REGISTER_NEUTRAL` and in each template's header comment.

### `vosotros` is not supported, on purpose

It is Peninsular Spanish and reads as foreign or comic to a Mexican clinic, which is the client this is for. There is a comment saying so in `email_i18n.py` and a test (`test_vosotros_is_not_a_supported_register`) so that re-adding it is a deliberate act with a failing test to delete, not a quiet dict entry.

### Default is `usted`

First contact is with someone who has told us nothing. `usted` is merely formal if wrong; `tú` is familiar if wrong. Formal-if-wrong is the cheaper error.

## The product is split across surfaces — this fixes half of it

Worth stating plainly because it is wider than this repo, and an earlier framing of this work assumed the product was uniformly `usted`. It is not:

| Surface | Register |
|---|---|
| **janua** transactional email (this repo) | `usted` throughout |
| **nauta** client portal (`apps/web/src`, `packages/ui/src`) | `tú` throughout |

Measured in nauta on 2026-08-14: **zero** usted markers against **~50** tú markers (the original report was 54 with a slightly broader marker set; I re-measured independently at 51 — same conclusion). It goes down to `revisa tu bandeja de entrada` on the login page, `apps/web/src/app/login/magic-link-form.tsx:121`.

So the same client, in one journey, is addressed two ways: `usted` in the email that sends her to the portal, `tú` the moment she lands on it.

**`users.spanish_formality` is intended as the single source of truth for both surfaces.** This PR only wires the email half. Whoever picks up the portal side should read this column rather than introduce a second preference — there is a note to that effect on the model field and in the migration docstring.

## How forgetting a variant is made impossible

Three structural guards, not example-based tests. Each was **mutation-tested** — I broke the code three ways and confirmed the right test fails with an actionable message:

| Guard | Mutation | Result |
|---|---|---|
| `test_every_spanish_key_declares_its_register_handling` | added a Spanish key with only the `usted` half | fails, names the key, says what to do |
| same | deleted an existing `tú` variant | fails — caught by **two** independent tests |
| `test_no_register_marked_prose_outside_t` | hardcoded `Revise su configuración…` inline in `welcome.html` | fails, quotes the offending literal |

Plus: no `tú` string may contain usted markers (or vice versa); every `t()` key referenced by a template must resolve non-empty in **both** registers.

## What I verified by RENDERING

Not by reading the diff. I rendered against a `git worktree` of `origin/main` and diffed the output.

- **`usted` output is byte-identical to main** for all ten `es/` templates, with exactly one exception: `magic_link.html`'s security notice was hand-wrapped across three source lines and is now one line. Rendered *text* is identical; HTML collapses whitespace. All five `.txt` files — where whitespace *is* significant — are byte-for-byte identical, including their hand-wrapping.
- **English output is byte-identical to main** across all 22 root templates.
- **`tú` output** rendered and read end to end for all ten templates, HTML and text.
- The **shared footer in `base.html` switches register** (`Recibió … tiene una cuenta` → `Recibiste … tienes una cuenta`) without `base.html` being edited.
- **Action URLs survive both registers** — a register switch that blanked a button href would be worse than the wrong register.
- The **degraded `_fallback_body`** path keeps the register too; it is still an email somebody reads.
- Subjects switch register and still interpolate (`{organization_name}`).

Also verified untouched in both registers: the MADFAM branding, `Innovaciones MADFAM`, `Aviso de privacidad` / `Términos del servicio`. There is a test asserting these do not move (`test_untouched_footer_elements_are_not_register_dependent`). The From address and the "Con tecnología de" footer are not in this diff at all.

## What I did NOT verify

Stated plainly so nobody assumes otherwise:

- **No email was sent.** Nothing was put on a real transport, in any environment. Deliverability, client rendering (Gmail/Outlook/Apple Mail), and how the copy looks on a phone are all unverified.
- **The migration was not run against a database.** Its re-entrancy is asserted by reading the file (guard precedes `add_column`, both directions), not by applying it to Postgres twice. `alembic upgrade head` on a real DB is still owed.
- **Nothing writes the column yet.** There is no API endpoint and no UI to set `spanish_formality`; there is no existing preference-update surface for `locale` either, so adding one was out of scope. Until something writes it, every reader gets `usted` — i.e. today's behaviour, which is the intended no-op landing.
- **The `tú` Spanish has not been reviewed by a native es-MX speaker.** I am confident in it, but three calls below are judgement, not fact.
- **Not tested against a real `User` row.** `resolve_formality` is tested with `SimpleNamespace`; the SQLAlchemy column is asserted to exist and be nullable, but no round-trip through a session.
- The marker scan is a **heuristic safety net**, not a proof. It deliberately excludes ambiguous preterites (`se creó` is third person about the account, not `usted` about the reader) and generic enclitic regexes (`\w+arte\b` matches `parte`). Both exclusions are documented with the string that forced them.

## Judgement calls on the `tú` side

1. **Pronoun dropping.** Where the `usted` copy spells out the pronoun (`Si usted no solicitó…`), the `tú` copy drops it (`Si no solicitaste…`) rather than saying `Si tú no solicitaste…`. In `usted` the pronoun does real work — `solicitó` alone is also third person. `Solicitaste` is unambiguous, so an explicit `tú` there reads contrastive, as if arguing with the reader. Applied consistently across five strings; documented in `ES_TU`'s header.
2. **`Nuestro equipo está a sus órdenes` → `a tus órdenes`.** The phrase is an inherently deferential courtesy. `a tus órdenes` is idiomatic in Mexico in the same slot, so it is not a literal-but-odd calque — but it is the one string where the *register* and the *politeness* pull in different directions.
3. **`Hola {{ user_name }}:` left unchanged in both registers.** The colon is formal Mexican business style; `Hola Ana,` or `¡Hola, Ana!` would be more natural in `tú`. I treated the greeting as register-neutral rather than changing punctuation, which felt like a separate copy decision. Same for `Saludos cordiales,`. Easy to revisit — both are one catalog entry away.

## Test / lint

- `tests/unit/services/test_email_formality.py` — **246 passing**.
- Existing `test_email_delivery.py` (86) and `test_alembic_revision_graph.py` (30) still green; the graph test picks up `012` automatically.
- Full `tests/unit/` suite: 3355 passed. One unrelated failure, `test_oauth_userinfo_audience.py`, is **pre-existing** — it fails identically with this branch's changes stashed, caused by a local untracked `.env`; it passes on `main` in a clean worktree.
- `ruff check` and `ruff format --check` clean on every file this PR touches. `app/services/email_service.py` has five *pre-existing* format deviations under the repo's `line-length = 100`; I left them alone rather than add unrelated churn.

## Merge note for the sender-identity branch

The partition test asserts every key in `CHROME["es"]` is either register-sensitive or declared neutral. `fix/sender-identity-madfam` adds a `powered_by` key. When these two branches meet, that test will fail until `powered_by` is added to `ES_REGISTER_NEUTRAL` — one line, and it is the guard working as designed rather than a defect. Flagging it so it is not a surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
