### PR TITLE
The tests and the docs now say what the code sends

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,8 +46,10 @@ SECRET_KEY=replace-with-secret-key
 # EMAIL (Resend - MADFAM centralized)
 # ============================================
 RESEND_API_KEY=replace-with-resend-api-key
-EMAIL_FROM_ADDRESS=noreply@janua.dev
-EMAIL_FROM_NAME=Janua
+# One sender for every platform, on the one Resend-verified domain.
+# See docs/EMAIL_SENDER_POLICY.md before changing either of these.
+EMAIL_FROM_ADDRESS=hola@madfam.io
+EMAIL_FROM_NAME=MADFAM
 
 # ============================================
 # OPTIONAL: Monitoring

--- a/.env.production.example
+++ b/.env.production.example
@@ -103,8 +103,8 @@ RATE_LIMIT_TENANT_ENTERPRISE=10000
 EMAIL_ENABLED=true
 EMAIL_PROVIDER=resend
 RESEND_API_KEY=${RESEND_API_KEY}
-EMAIL_FROM_ADDRESS=noreply@janua.dev
-EMAIL_FROM_NAME=Janua Security
+EMAIL_FROM_ADDRESS=hola@madfam.io
+EMAIL_FROM_NAME=MADFAM
 EMAIL_REPLY_TO=support@janua.dev
 
 # ============================================

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -378,7 +378,8 @@ SMTP_FROM=noreply@janua.dev
 # Email (Resend)
 EMAIL_ENABLED=true               # Enable email sending (default: false)
 EMAIL_PROVIDER=resend             # Email provider (resend)
-EMAIL_FROM_ADDRESS=noreply@janua.dev
+EMAIL_FROM_ADDRESS=hola@madfam.io  # see docs/EMAIL_SENDER_POLICY.md
+EMAIL_FROM_NAME=MADFAM            # one sender for every platform
 RESEND_API_KEY=re_XXXXX           # Resend API key (sending access)
 ```
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -35,7 +35,9 @@ CORS_ORIGINS=["http://localhost:3000","http://localhost:3001","http://localhost:
 
 # Email (Resend)
 EMAIL_PROVIDER=resend  # console | resend | smtp | sendgrid
-EMAIL_FROM=noreply@janua.dev
+# The setting is EMAIL_FROM_ADDRESS; nothing reads EMAIL_FROM, which this
+# line used to name. See docs/EMAIL_SENDER_POLICY.md for the address.
+EMAIL_FROM_ADDRESS=hola@madfam.io
 RESEND_API_KEY=replace-with-resend-api-key
 
 # Internal API (service-to-service communication for MADFAM apps)

--- a/apps/api/docs/RESEND_EMAIL_MIGRATION.md
+++ b/apps/api/docs/RESEND_EMAIL_MIGRATION.md
@@ -261,7 +261,7 @@ HTML Preview: <!DOCTYPE html><html>...
 
 1. **Add Domain to Resend**:
    ```bash
-   Domain: janua.dev
+   Domain: madfam.io
    Add DNS records as shown in Resend dashboard
    Verify domain ownership
    ```
@@ -270,9 +270,13 @@ HTML Preview: <!DOCTYPE html><html>...
    ```bash
    RESEND_API_KEY=re_xxxxxxxxxxxxx
    EMAIL_ENABLED=true
-   EMAIL_FROM_ADDRESS=noreply@janua.dev
-   EMAIL_FROM_NAME=Janua
+   EMAIL_FROM_ADDRESS=hola@madfam.io
+   EMAIL_FROM_NAME=MADFAM
    ```
+
+   One sender across every MADFAM platform, on the one Resend-verified
+   domain. `docs/EMAIL_SENDER_POLICY.md` explains why, and what has to be
+   true before this may change.
 
 3. **Test Email Delivery**:
    ```bash
@@ -281,7 +285,7 @@ HTML Preview: <!DOCTYPE html><html>...
      -H "Authorization: Bearer $RESEND_API_KEY" \
      -H "Content-Type: application/json" \
      -d '{
-       "from": "noreply@janua.dev",
+       "from": "hola@madfam.io",
        "to": ["test@example.com"],
        "subject": "Test Email",
        "html": "<p>Testing Resend integration</p>"

--- a/apps/api/tests/unit/services/test_email_delivery.py
+++ b/apps/api/tests/unit/services/test_email_delivery.py
@@ -236,6 +236,10 @@ class TestTemplateLocalization:
         """This is localization, not replacement."""
         service = EmailService()
         rendered = service._render_template("magic_link.html", TEMPLATE_CONTEXT, "en")
+        # Was "Sign in to Janua". The headline names the recipient's portal, not
+        # the platform, because the platform is credited and never branded as
+        # the sender (docs/EMAIL_SENDER_POLICY.md). Still a locale-specific
+        # string, so this keeps proving English rendered rather than Spanish.
         assert "Sign in to your portal" in rendered
         assert 'lang="en"' in rendered
 
@@ -256,6 +260,11 @@ class TestTemplateLocalization:
         # The tagline is MADFAM's now, not one platform's — the header reads
         # MADFAM on every message (see docs/EMAIL_SENDER_POLICY.md). What this
         # test guards is unchanged: the frame's language must match the body's.
+        # "tu operación" → "su operación": the frame settled on the usted
+        # register as the DEFAULT. It is no longer the only register — #540
+        # added the reader's tú/usted choice, and ES_TU carries the tú variant
+        # ("para tu operación"). This asserts the default the render path uses
+        # when no formality is passed.
         assert "Tecnología, diseñada para su operación" in spanish
         assert "Technology, engineered for your operation" not in spanish
 
@@ -266,6 +275,9 @@ class TestTemplateLocalization:
 
     def test_default_locale_setting_drives_unspecified_sends(self):
         service = EmailService()
+        # Headlines were "Sign in to Janua" / "Inicie sesión en Janua" before the
+        # sender-identity change. They still differ per locale, which is the
+        # whole point of this test — DEFAULT_EMAIL_LOCALE must pick the body.
         with patch.object(email_module.settings, "DEFAULT_EMAIL_LOCALE", "en"):
             assert "Sign in to your portal" in service._render_template(
                 "magic_link.html", TEMPLATE_CONTEXT
@@ -317,6 +329,10 @@ class TestSubjectLocalization:
 
         with patch.object(service, "_send_email", new=AsyncMock(return_value=True)) as send:
             await service.send_magic_link_email("a@b.test", "tok", locale="en")
+        # Was "Your Janua sign-in link". The subject dropped the platform name
+        # for the same reason the headline did. Deliberately still the literal
+        # English string rather than subject_for(...): comparing against the
+        # table the code reads would pass whatever the table said.
         assert send.await_args.kwargs["subject"] == "Your sign-in link"
 
 

--- a/docs/EMAIL_SENDER_POLICY.md
+++ b/docs/EMAIL_SENDER_POLICY.md
@@ -9,7 +9,7 @@ managing that client's web presence.
 Applies from first contact until we manage the client's domain.
 
 ```
-From:    MADFAM <noreply@madfam.io>
+From:    MADFAM <hola@madfam.io>
 Header:  MADFAM
 Footer:  © Innovaciones MADFAM S.A.S. de C.V.
          Con tecnología de <platform>   ("Powered by" in en)

--- a/docs/guides/COMPLIANCE_FEATURES_GUIDE.md
+++ b/docs/guides/COMPLIANCE_FEATURES_GUIDE.md
@@ -946,7 +946,7 @@ async function handleDataSubjectRequest(
 ## Support & Resources
 
 - **Documentation**: https://docs.janua.dev/compliance
-- **Privacy Policy**: https://janua.dev/privacy
+- **Privacy Policy**: https://madfam.io/en/privacy
 - **GDPR Guide**: https://docs.janua.dev/gdpr
 - **CCPA Guide**: https://docs.janua.dev/ccpa
 - **Email Support**: compliance@janua.dev


### PR DESCRIPTION
Successor to #539, which GitHub auto-closed when #538 merged and its base
branch `fix/sender-identity-madfam` was deleted. #539 could not be reopened
("the branch was force-pushed or recreated"), so this carries the same commit,
rebuilt on `main`.

**Scope shrank between then and now, in a good way.** #539 was written to fix
five stale assertions in `test_email_delivery.py`. #538's own later commits
(`0fd06f3d`, `986555ec`) made those same assertion changes before it merged,
so all five are already on `main`. What is left of the test half is the
*reasoning*: each assertion now carries a comment naming the value it replaced
and why, which is what stops the next person from "fixing" it back.

**Nothing here weakens a test.** No assertion changed in this PR. Every one of
them still pins a literal, locale-specific string, which is the only thing
making the locale tests non-vacuous.

## The docs disagreed with the code

- **`docs/EMAIL_SENDER_POLICY.md` printed `MADFAM <noreply@madfam.io>`** while
  `config.py:218`, both k8s env entries and `scripts/send-sender-identity-test.sh`
  all say `hola@madfam.io`. This is the doc people cite, so it is the worst
  place to carry the wrong address.
- **`.env.example`, `.env.production.example`, `apps/api/.env.example`,
  `AGENTS.md`** told an operator to configure `noreply@janua.dev` — the exact
  sender #538 exists to stop using.
- **`apps/api/docs/RESEND_EMAIL_MIGRATION.md`** — under *Production Deployment →
  Configuration Steps*, so it is live guidance, not history. It said to verify
  `janua.dev` in Resend and send from it. Following it sends from an unverified
  domain, which per the policy doc is worse than the wrong brand: it does not
  arrive at all.
- **`apps/api/.env.example` named `EMAIL_FROM`**, which nothing reads. The
  setting is `EMAIL_FROM_ADDRESS`.
- **`docs/guides/COMPLIANCE_FEATURES_GUIDE.md`** linked `janua.dev/privacy`,
  which 404s. Now `madfam.io/en/privacy`, matching the footer #538 ships.

## One comment rewritten rather than carried over

#539's comment on `test_frame_language_matches_body_language` said the frame
"settled on the usted register". #540 landed in between and made that false:
usted is now the *default*, not the only register, and `ES_TU` carries
"para tu operación". The comment says that instead.

## Reported, not fixed

- **`apps/api/app/services/email/resend_service.py:77`** —
  `os.getenv("RESEND_FROM_EMAIL", "noreply@janua.dev")`. With that variable
  unset, this service still sends from the old address. Code, not docs.
- `EMAIL_REPLY_TO` / `SMTP_FROM` in the env examples name settings that do not
  exist. Pre-existing, and there is no unambiguous correct replacement.
- `apps/docs/src/components/layout/footer.tsx:18,24,25`, `apps/api/app/main.py:419`
  and `apps/api/openapi.yaml:42` still point at the 404ing
  `janua.dev/{privacy,terms,support}`.
- Six per-template sign-offs still read "Equipo Janua" / "El equipo de Janua" /
  "The Janua Team" (`es/{magic_link,welcome,verification,password_reset}.txt`,
  `es/welcome.html`, `welcome.html`). #538 changed the shared frame; these are
  inside individual templates and neither PR touched them, so the plain-text
  part of a message signs off as Janua under a MADFAM header.

## Verification

```
379 passed   tests/unit/services/{test_email_delivery,test_email_service,test_email_formality}.py
ruff check   All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
