### PR TITLE
The message signs off as MADFAM, like the rest of it already did

### DIFF
--- a/apps/api/app/services/email_i18n.py
+++ b/apps/api/app/services/email_i18n.py
@@ -269,9 +269,19 @@ CHROME: Dict[str, Dict[str, str]] = {
         "support": "Support",
         "why_received": "You received this email because you have an account with MADFAM.",
         "location": "Innovaciones MADFAM S.A.S. de C.V. • Cuernavaca, Morelos, Mexico",
+        # The name the message signs off with. It is MADFAM for the same reason
+        # the header and the From address are: the reader has a relationship
+        # with MADFAM and has never heard of the platform underneath. Ten
+        # plain-text and HTML templates hard-coded "the Janua Team", so a
+        # message arrived under a MADFAM header, from hola@madfam.io, and then
+        # signed off as a company the reader does not know — which is the exact
+        # confusion the sender work existed to remove, surviving in the part of
+        # the email people actually read last.
+        "signoff": "The MADFAM Team",
     },
     "es": {
         "tagline": "Tecnología, diseñada para su operación",
+        "signoff": "Equipo MADFAM",
         "rights": "Todos los derechos reservados.",
         # "Con tecnología de" is the standard es-MX rendering of "Powered by".
         # "Impulsado por" reads as marketing; this reads as an attribution.
@@ -610,6 +620,9 @@ ES_REGISTER_NEUTRAL: Set[str] = {
     "terms",  # "Términos del servicio" — the name of a document
     "support",  # "Soporte" — a noun
     "location",  # a postal address
+    # "Equipo MADFAM" — the sender's own name. It has no addressee, so it is
+    # byte-identical in `tú` and `usted` and must NOT be duplicated into ES_TU.
+    "signoff",
 }
 
 

--- a/apps/api/app/templates/email/es/magic_link.txt
+++ b/apps/api/app/templates/email/es/magic_link.txt
@@ -10,5 +10,5 @@ Este enlace funciona una sola vez y expira en 15 minutos.
 {{ t('common.need_help') }} {{ support_email }}
 
 ---
-Equipo Janua
+{{ t('signoff') }}
 {{ base_url }}

--- a/apps/api/app/templates/email/es/password_reset.txt
+++ b/apps/api/app/templates/email/es/password_reset.txt
@@ -12,5 +12,5 @@ Este enlace expira en 1 hora.
 {{ t('common.need_help') }} {{ support_email }}
 
 ---
-Equipo Janua
+{{ t('signoff') }}
 {{ base_url }}

--- a/apps/api/app/templates/email/es/verification.txt
+++ b/apps/api/app/templates/email/es/verification.txt
@@ -15,5 +15,5 @@ Este enlace de verificación expira en 24 horas.
 {{ t('common.need_help') }} {{ support_email }}
 
 ---
-Equipo Janua
+{{ t('signoff') }}
 {{ base_url }}

--- a/apps/api/app/templates/email/es/welcome.html
+++ b/apps/api/app/templates/email/es/welcome.html
@@ -68,6 +68,6 @@
 
 <p style="margin: 20px 0 0 0;">
     Saludos cordiales,<br>
-    <strong>El equipo de Janua</strong>
+    <strong>{{ t('signoff') }}</strong>
 </p>
 {% endblock %}

--- a/apps/api/app/templates/email/es/welcome.txt
+++ b/apps/api/app/templates/email/es/welcome.txt
@@ -16,5 +16,5 @@ Hola {{ user_name }}:
 {{ t('welcome.txt_closing') }}
 
 ---
-Equipo Janua
+{{ t('signoff') }}
 {{ base_url }}

--- a/apps/api/app/templates/email/magic_link.txt
+++ b/apps/api/app/templates/email/magic_link.txt
@@ -11,5 +11,5 @@ link — anyone holding it can sign in as you until it expires.
 Need help? Contact us at {{ support_email }}
 
 ---
-Janua Team
+{{ t('signoff') }}
 {{ base_url }}

--- a/apps/api/app/templates/email/password_reset.txt
+++ b/apps/api/app/templates/email/password_reset.txt
@@ -12,5 +12,5 @@ If you didn't request a password reset, you can safely ignore this email. Your p
 Need help? Contact us at {{ support_email }}
 
 ---
-Janua Team
+{{ t('signoff') }}
 {{ base_url }}

--- a/apps/api/app/templates/email/verification.txt
+++ b/apps/api/app/templates/email/verification.txt
@@ -15,5 +15,5 @@ If you didn't create an account with Janua, you can safely ignore this email.
 Need help? Contact us at {{ support_email }}
 
 ---
-Janua Team
+{{ t('signoff') }}
 {{ base_url }}

--- a/apps/api/app/templates/email/welcome.html
+++ b/apps/api/app/templates/email/welcome.html
@@ -64,6 +64,6 @@
 
 <p style="margin: 20px 0 0 0;">
     Best regards,<br>
-    <strong>The Janua Team</strong>
+    <strong>{{ t('signoff') }}</strong>
 </p>
 {% endblock %}

--- a/apps/api/app/templates/email/welcome.txt
+++ b/apps/api/app/templates/email/welcome.txt
@@ -15,5 +15,5 @@ Need help getting started? Check out our documentation or contact us at {{ suppo
 We're excited to have you on board!
 
 ---
-Janua Team
+{{ t('signoff') }}
 {{ base_url }}


### PR DESCRIPTION
## The gap

#538 and #541 moved the sender identity to MADFAM — From address, header, tagline, legal links — and left **ten templates** hard-coding the sign-off:

```
Equipo Janua        (5 Spanish)
The Janua Team      (5 English)
```

So the first email MADFAM's first real client receives would arrive **from `hola@madfam.io`, under a MADFAM header, and sign off as a company she has never heard of.**

That's the exact confusion the sender work existed to remove, surviving in the part of an email people read last. The shared frame was fixed; the per-template bodies weren't, and nothing pointed at the gap because each template reads fine on its own.

## The fix

A `signoff` catalogue key resolved through `t()`, like every other string in these templates.

**Register-neutral, deliberately.** "Equipo MADFAM" names the *sender* — it has no addressee, so it is byte-identical in `tú` and `usted` and belongs in `ES_REGISTER_NEUTRAL` rather than duplicated into `ES_TU`.

That partition is enforced: a Spanish key with neither a `tú` variant nor a neutral entry fails `test_email_formality`, which is how this repo stops a register-sensitive string reaching a reader unreviewed. **249 of those tests pass.**

## Verified by resolving the key, not by reading the diff

```
es/usted : 'Equipo MADFAM'
es/tu    : 'Equipo MADFAM'     ← identical, as a neutral key must be
en       : 'The MADFAM Team'
```

…and no register yields anything containing "Janua".

🤖 Generated with [Claude Code](https://claude.com/claude-code)