### PR TITLE
fix(auth): send_magic_link populates the email the model has always demanded

### DIFF
--- a/apps/api/app/routers/v1/auth.py
+++ b/apps/api/app/routers/v1/auth.py
@@ -1801,6 +1801,16 @@ async def send_magic_link(
     magic_token = secrets.token_urlsafe(32)
     magic_link = MagicLink(
         user_id=user.id,
+        # The model declares email NOT NULL and this constructor never set it,
+        # so the moment migration backlog 003-011 landed in production
+        # (2026-08-15) every plain magic-link send 503'd with a
+        # NotNullViolation — found live, mid-rehearsal, on the first send of
+        # the CTM ceremony walkthrough. The stored, verified address is the
+        # right value: the request's raw input may differ in case or alias
+        # form, and the row is an audit record of who was actually mailed.
+        # (Prod's NOT NULL was dropped as the same-day unblock; restore it in
+        # a later migration once this code is promoted and NULLs backfilled.)
+        email=user.email,
         token=magic_token,
         redirect_url=safe_redirect_url,  # Use validated URL
         expires_at=datetime.utcnow() + timedelta(minutes=15),


### PR DESCRIPTION
Model says `email NOT NULL`; the constructor at auth.py:1802 never set it. Invisible until the alembic backlog (003–011) applied in prod today — from that moment **every plain magic-link send 503'd** (`NotNullViolation`), found live on the CTM ceremony rehearsal's first send. Fix: `email=user.email` (the verified stored address — the row is an audit record of who was mailed). Same-day prod unblock already applied: `ALTER TABLE magic_links ALTER COLUMN email DROP NOT NULL` (verified: sends 202 again). Follow-up owed after promote: backfill NULLs + a migration restoring NOT NULL.

**Promote remains the operator's call** per the blast-radius doctrine — this PR just makes the next promote carry the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)