### PR TITLE
fix(auth): magic link lands on the product; bad destinations fail loudly

### DIFF
--- a/apps/api/app/routers/v1/auth.py
+++ b/apps/api/app/routers/v1/auth.py
@@ -1791,11 +1791,24 @@ async def send_magic_link(
         await db.commit()
         await db.refresh(user)
 
-    # SECURITY: Validate the redirect URL to prevent open redirect attacks
+    # SECURITY: Validate the redirect URL to prevent open redirect attacks.
+    # A supplied-but-disallowed destination is a 400 HERE, not a silent None:
+    # the emailed link is built ON the destination host, so nulling it would
+    # mail a link that signs the user in and then dead-ends — a failure the
+    # requesting product cannot see and the recipient cannot fix. (Found live
+    # 2026-08-15: the rehearsal host was missing from CORS_ORIGINS and the
+    # first client-ceremony walkthrough ended on the recovery page.)
     safe_redirect_url = None
     if magic_link_data.redirect_url:
         safe_redirect_url = validate_redirect_url(magic_link_data.redirect_url, default_url=None)
-        # If validation failed (returned None), we simply won't include a redirect
+        if safe_redirect_url is None:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "redirect_url host is not on the allowed list; "
+                    "add it to CORS_ORIGINS before requesting links for it"
+                ),
+            )
 
     # Create magic link token
     magic_token = secrets.token_urlsafe(32)

--- a/apps/api/app/services/email_i18n.py
+++ b/apps/api/app/services/email_i18n.py
@@ -25,7 +25,7 @@ never picks a register.
 
 from typing import Any, Dict, List, Optional, Set
 
-from jinja2 import Environment, FileSystemLoader, pass_context
+from jinja2 import Environment, FileSystemLoader, pass_context, select_autoescape
 
 # Languages that have a full translation set. Order is not significant.
 SUPPORTED_LOCALES: tuple = ("es", "en")
@@ -696,7 +696,20 @@ def install_template_globals(env: Environment) -> Environment:
 
 
 def build_email_environment(template_dir: Any) -> Environment:
-    """The Jinja environment for `templates/email`, globals included."""
+    """The Jinja environment for `templates/email`, globals included.
+
+    Autoescape by EXTENSION, not unconditionally: `autoescape=True` was
+    HTML-escaping the plain-text bodies too, so the .txt part of every email
+    carried `&amp;` inside its URLs — and a recipient copying the "if the
+    button doesn't work" address out of a text-mode client pasted a link
+    whose query string literally began `amp;token=` (found 2026-08-15 by the
+    magic-link destination tests). Entities belong in markup only.
+    """
     return install_template_globals(
-        Environment(loader=FileSystemLoader(template_dir), autoescape=True)
+        Environment(
+            loader=FileSystemLoader(template_dir),
+            autoescape=select_autoescape(
+                enabled_extensions=("html", "htm", "xml"), default=False
+            ),
+        )
     )

--- a/apps/api/app/services/email_service.py
+++ b/apps/api/app/services/email_service.py
@@ -495,15 +495,27 @@ class EmailService:
     ) -> bool:
         """Send a passwordless sign-in link.
 
-        The link points at Janua's own GET callback rather than at the product
-        page: a clicked link is a GET, and only Janua can trade the one-time
-        magic token for a session. The callback then forwards to redirect_url
-        (already allowlist-validated when the link was requested).
+        When the request named a redirect_url (allowlist-validated at request
+        time), the emailed link lives on THAT host: the recipient clicks a URL
+        on the product's own domain and the product exchanges the one-time
+        token via POST /api/v1/auth/magic-link/verify. A first-contact email
+        whose link points at api.janua.dev reads as phishing next to the
+        product the client was just told to trust; the sender, the link, and
+        the destination must all agree.
+
+        Without a redirect_url the link falls back to Janua's own GET callback
+        — a clicked link is a GET, and only Janua can trade the token then.
         """
         recipient_locale = resolve_locale(locale, user=user, default=self._default_locale())
         recipient_formality = resolve_formality(formality, user=user)
-        callback = f"{settings.API_BASE_URL or settings.BASE_URL}/api/v1/auth/magic-link/callback"
-        magic_url = f"{callback}?token={magic_token}"
+        if redirect_url:
+            separator = "&" if "?" in redirect_url else "?"
+            magic_url = f"{redirect_url}{separator}token={magic_token}"
+        else:
+            callback = (
+                f"{settings.API_BASE_URL or settings.BASE_URL}/api/v1/auth/magic-link/callback"
+            )
+            magic_url = f"{callback}?token={magic_token}"
 
         template_data = {
             "user_name": email.split("@")[0],

--- a/apps/api/tests/unit/services/test_magic_link_destination.py
+++ b/apps/api/tests/unit/services/test_magic_link_destination.py
@@ -47,8 +47,11 @@ async def test_redirect_host_with_existing_query_appends_with_ampersand():
             "tok",
             redirect_url="https://ensayo.madfam.io/portal/verify?next=%2Ffacturas",
         )
+    # HTML entity-escapes the ampersand; the plain-text body carries it raw.
     html = send.await_args.kwargs["html_content"]
-    assert "https://ensayo.madfam.io/portal/verify?next=%2Ffacturas&token=tok" in html
+    text = send.await_args.kwargs["text_content"]
+    assert "https://ensayo.madfam.io/portal/verify?next=%2Ffacturas&amp;token=tok" in html
+    assert "https://ensayo.madfam.io/portal/verify?next=%2Ffacturas&token=tok" in text
 
 
 @pytest.mark.asyncio

--- a/apps/api/tests/unit/services/test_magic_link_destination.py
+++ b/apps/api/tests/unit/services/test_magic_link_destination.py
@@ -1,0 +1,77 @@
+"""The emailed magic link lands on the PRODUCT, not on api.janua.dev.
+
+Found live 2026-08-15, mid client-ceremony rehearsal: the first email a new
+client receives asked them to click an api.janua.dev URL — a host they have
+never been told about — and, because the rehearsal host was missing from the
+allowlist, the click signed them in at Janua and dead-ended on a recovery
+page. Two rules fell out of that afternoon:
+
+1. When the request names a redirect_url, the link in the email is built ON
+   that host (`https://<product-host>/portal/verify?token=...`); the product
+   exchanges the one-time token via POST /api/v1/auth/magic-link/verify.
+2. A supplied-but-disallowed redirect_url fails the REQUEST with a 400. The
+   old behaviour nulled it silently and mailed a link that could only ever
+   dead-end — a failure neither the product nor the recipient could see
+   coming.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.email_service import EmailService
+
+
+@pytest.mark.asyncio
+async def test_link_is_built_on_the_redirect_host():
+    service = EmailService()
+    with patch.object(service, "_send_email", new=AsyncMock(return_value=True)) as send:
+        await service.send_magic_link_email(
+            "cliente@example.test",
+            "one-time-token",
+            redirect_url="https://ensayo.madfam.io/portal/verify",
+        )
+    html = send.await_args.kwargs["html_content"]
+    text = send.await_args.kwargs["text_content"]
+    assert "https://ensayo.madfam.io/portal/verify?token=one-time-token" in html
+    assert "https://ensayo.madfam.io/portal/verify?token=one-time-token" in text
+    assert "magic-link/callback" not in html
+
+
+@pytest.mark.asyncio
+async def test_redirect_host_with_existing_query_appends_with_ampersand():
+    service = EmailService()
+    with patch.object(service, "_send_email", new=AsyncMock(return_value=True)) as send:
+        await service.send_magic_link_email(
+            "cliente@example.test",
+            "tok",
+            redirect_url="https://ensayo.madfam.io/portal/verify?next=%2Ffacturas",
+        )
+    html = send.await_args.kwargs["html_content"]
+    assert "https://ensayo.madfam.io/portal/verify?next=%2Ffacturas&token=tok" in html
+
+
+@pytest.mark.asyncio
+async def test_no_redirect_still_falls_back_to_the_janua_callback():
+    """Products that never send redirect_url keep the GET-callback contract:
+    a clicked link is a GET and only Janua can trade the token then."""
+    service = EmailService()
+    with patch.object(service, "_send_email", new=AsyncMock(return_value=True)) as send:
+        await service.send_magic_link_email("cliente@example.test", "tok")
+    html = send.await_args.kwargs["html_content"]
+    assert "/api/v1/auth/magic-link/callback?token=tok" in html
+
+
+def test_send_route_refuses_a_disallowed_destination_loudly():
+    """The 400 must happen at request time. Silently nulling the redirect
+    mails a link that signs the user in and then strands them — the exact
+    rehearsal failure this file exists to prevent."""
+    import inspect
+
+    from app.routers.v1 import auth
+
+    source = inspect.getsource(auth.send_magic_link)
+    assert "raise HTTPException" in source.split("safe_redirect_url = validate_redirect_url")[1].split(
+        "magic_token"
+    )[0], "failed redirect validation must raise, not proceed"
+    assert "we simply won't include a redirect" not in source

--- a/k8s/base/deployments/janua-api.yaml
+++ b/k8s/base/deployments/janua-api.yaml
@@ -193,7 +193,7 @@ spec:
             # CORS - All allowed frontend origins
             - name: CORS_ORIGINS
               # Non-core app origins auto-derived from OAuth client redirect_uris via DynamicCORSMiddleware
-              value: "https://admin.janua.dev,https://app.janua.dev,https://api.enclii.dev,https://app.enclii.dev,https://admin.enclii.dev,https://auth.madfam.io,https://tezca.mx,https://admin.tezca.mx,https://www.tezca.mx,https://madfam.io,https://www.madfam.io,https://dhanam.madfam.io,https://forgesight.madfam.io,https://forgesight.quest,https://www.forgesight.quest,https://app.forgesight.quest,https://admin.forgesight.quest,https://pravara.madfam.io,https://dhan.am,https://app.dhan.am,https://rondel.io,https://fortuna.tube,https://selva.town,https://ceq.lol,https://crm.madfam.io,https://staging-crm.madfam.io,https://nauta.madfam.io,https://cto.madfam.io,https://crea.madfam.io"
+              value: "https://admin.janua.dev,https://app.janua.dev,https://api.enclii.dev,https://app.enclii.dev,https://admin.enclii.dev,https://auth.madfam.io,https://tezca.mx,https://admin.tezca.mx,https://www.tezca.mx,https://madfam.io,https://www.madfam.io,https://dhanam.madfam.io,https://forgesight.madfam.io,https://forgesight.quest,https://www.forgesight.quest,https://app.forgesight.quest,https://admin.forgesight.quest,https://pravara.madfam.io,https://dhan.am,https://app.dhan.am,https://rondel.io,https://fortuna.tube,https://selva.town,https://ceq.lol,https://crm.madfam.io,https://staging-crm.madfam.io,https://nauta.madfam.io,https://cto.madfam.io,https://crea.madfam.io,https://ensayo.madfam.io"
             # Cookie domain for cross-subdomain SSO (*.madfam.io for auth.madfam.io)
             - name: COOKIE_DOMAIN
               value: ".madfam.io"


### PR DESCRIPTION
Live findings from the first client-ceremony rehearsal walkthrough (ensayo.madfam.io, 2026-08-15).

**1. The emailed link now lives on the product host.** When `redirect_url` is present (already allowlist-validated at request time), the email links `https://<product-host>/portal/verify?token=<one-time-token>` and the product exchanges it via POST `/api/v1/auth/magic-link/verify`. A first-contact email whose link points at `api.janua.dev` reads as phishing next to the product the client was just told to trust. No `redirect_url` → GET-callback fallback unchanged.

**2. Disallowed destinations 400 at request time.** The old path silently nulled a failed validation and mailed a link that could only dead-end after sign-in ("destination is no longer an allowed address") — a failure neither the product nor the recipient could see coming. Now the requesting product gets an immediate, actionable 400.

**3. `ensayo.madfam.io` joins CORS_ORIGINS** (k8s base manifest) — its absence stranded the rehearsal.

Compat note: any product that relied on receiving the ACCESS token at its redirect_url via the callback redirect now receives the MAGIC token directly. nauta (the only known redirect_url consumer — the field was silently NULL for it until today, nauta#89) handles both shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)