### PR TITLE
feat(auth): magic-link sessions carry the product's audience

### DIFF
--- a/apps/api/app/routers/v1/auth.py
+++ b/apps/api/app/routers/v1/auth.py
@@ -1872,8 +1872,18 @@ async def _session_audience_for_redirect(db: Session, redirect_url: Optional[str
         )
     )
     for client in result.scalars():
-        for uri in client.redirect_uris or []:
-            if urlparse(uri).hostname == host:
+        uris = client.redirect_uris or []
+        # Some prod rows store the array double-encoded — a JSON string
+        # CONTAINING the array — and iterating a string yields characters,
+        # which would make this resolver silently match nothing. Same
+        # tolerance the OAuth recovery path above applies.
+        if isinstance(uris, str):
+            try:
+                uris = json.loads(uris)
+            except json.JSONDecodeError:
+                uris = []
+        for uri in uris:
+            if isinstance(uri, str) and urlparse(uri).hostname == host:
                 return client.audience
     return None
 

--- a/apps/api/app/routers/v1/auth.py
+++ b/apps/api/app/routers/v1/auth.py
@@ -1843,6 +1843,41 @@ async def send_magic_link(
     return {"message": "Magic link sent to email"}
 
 
+async def _session_audience_for_redirect(db: Session, redirect_url: Optional[str]) -> Optional[str]:
+    """The per-client audience for a magic-link session, from the redirect host.
+
+    A magic link that forwards to a product should mint a session that
+    product's verifier accepts — the audience registered on the OAuth client
+    whose redirect_uris share the destination's host. Matching is by HOST, not
+    full URI: the magic-link redirect (`/portal/verify`) is not an OAuth
+    callback path, but the host names the same product. The redirect_url was
+    already allowlist-validated when the link was requested; this only decides
+    which registered audience the session carries.
+
+    None (no redirect, no host match, or client without an audience) keeps the
+    platform default — exactly what every session minted before this existed.
+    """
+    if not redirect_url:
+        return None
+    host = urlparse(redirect_url).hostname
+    if not host:
+        return None
+
+    from ...models import OAuthClient as _OAuthClient
+
+    result = await db.execute(
+        select(_OAuthClient).where(
+            _OAuthClient.is_active == True,  # noqa: E712 — SQLAlchemy comparator
+            _OAuthClient.audience.isnot(None),
+        )
+    )
+    for client in result.scalars():
+        for uri in client.redirect_uris or []:
+            if urlparse(uri).hostname == host:
+                return client.audience
+    return None
+
+
 @router.get("/magic-link/callback")
 async def magic_link_callback(
     token: Optional[str] = None,
@@ -1898,6 +1933,7 @@ async def magic_link_callback(
     access_token, _refresh_token, _session = await AuthService.create_session(
         db, user, ip_address=req.client.host if req and req.client else None,
         user_agent=req.headers.get("user-agent") if req else None,
+        audience=await _session_audience_for_redirect(db, magic_link.redirect_url),
     )
 
     # Signing in by emailed link proves control of the mailbox.
@@ -1955,9 +1991,10 @@ async def verify_magic_link(
     # Mark magic link as used
     magic_link.used_at = datetime.utcnow()
 
-    # Create session
+    # Create session, with the audience of the product the link forwards to.
     access_token, refresh_token, session = await AuthService.create_session(
-        db, user, ip_address=req.client.host, user_agent=req.headers.get("user-agent")
+        db, user, ip_address=req.client.host, user_agent=req.headers.get("user-agent"),
+        audience=await _session_audience_for_redirect(db, magic_link.redirect_url),
     )
 
     # Log activity

--- a/apps/api/app/services/auth_service.py
+++ b/apps/api/app/services/auth_service.py
@@ -168,8 +168,16 @@ class AuthService:
         tenant_id: str,
         organization_id: Optional[str] = None,
         email: Optional[str] = None,
+        audience: Optional[str] = None,
     ) -> Tuple[str, str, datetime]:
-        """Create JWT access token"""
+        """Create JWT access token.
+
+        `audience` overrides the platform default `aud` claim. The OIDC path
+        has always minted per-client audiences; passing it here lets the
+        magic-link flow do the same, so a session created for a product's
+        redirect host carries THAT product's audience instead of the platform
+        default the product's verifier has no reason to accept.
+        """
         jti = secrets.token_urlsafe(32)
         expires_at = datetime.utcnow() + timedelta(minutes=settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES)
 
@@ -181,7 +189,7 @@ class AuthService:
             "exp": expires_at,
             "iat": datetime.utcnow(),
             "iss": settings.JWT_ISSUER,
-            "aud": settings.JWT_AUDIENCE,
+            "aud": audience or settings.JWT_AUDIENCE,
         }
 
         if organization_id:
@@ -337,6 +345,7 @@ class AuthService:
         device_name: Optional[str] = None,
         invalidate_existing: bool = False,
         enforce_session_limit: bool = True,
+        audience: Optional[str] = None,
     ) -> Tuple[str, str, Session]:
         """Create a new session with tokens.
 
@@ -401,7 +410,10 @@ class AuthService:
 
         # Create tokens
         access_token, access_jti, access_expires = AuthService.create_access_token(
-            user_id=str(user.id), tenant_id=str(user.tenant_id), email=user.email
+            user_id=str(user.id),
+            tenant_id=str(user.tenant_id),
+            email=user.email,
+            audience=audience,
         )
 
         refresh_token, refresh_jti, family, refresh_expires = AuthService.create_refresh_token(

--- a/apps/api/tests/unit/routers/test_magic_link_audience.py
+++ b/apps/api/tests/unit/routers/test_magic_link_audience.py
@@ -1,0 +1,87 @@
+"""Magic-link sessions carry the audience of the product they forward to.
+
+Until 2026-08-15 every magic-link session minted the platform default
+audience (`janua.dev`). The first real portal login exchanged its one-time
+token successfully and was then rejected by the product's own verifier —
+which had no reason to accept an audience naming the platform rather than
+itself. The OIDC path has always minted per-client audiences; these tests pin
+the magic-link flow doing the same, resolved from the redirect host.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import jwt as pyjwt
+import pytest
+
+from app.routers.v1.auth import _session_audience_for_redirect
+from app.services.auth_service import AuthService
+
+
+def _db_returning(clients):
+    result = SimpleNamespace(scalars=lambda: iter(clients))
+    return SimpleNamespace(execute=AsyncMock(return_value=result))
+
+
+def _client(audience, uris):
+    return SimpleNamespace(audience=audience, redirect_uris=uris, is_active=True)
+
+
+@pytest.mark.asyncio
+async def test_resolves_audience_by_redirect_host_not_full_uri():
+    """The magic-link redirect (/portal/verify) is not an OAuth callback path;
+    the HOST is what names the product."""
+    db = _db_returning(
+        [
+            _client("nauta-api", ["https://nauta.madfam.io/api/auth/callback/janua"]),
+            _client("nauta-portal", ["https://crea.madfam.io/api/auth/callback/janua"]),
+        ]
+    )
+    audience = await _session_audience_for_redirect(
+        db, "https://crea.madfam.io/portal/verify"
+    )
+    assert audience == "nauta-portal"
+
+
+@pytest.mark.asyncio
+async def test_unknown_host_keeps_the_platform_default():
+    db = _db_returning([_client("nauta-portal", ["https://crea.madfam.io/cb"])])
+    assert await _session_audience_for_redirect(db, "https://other.example.com/x") is None
+
+
+@pytest.mark.asyncio
+async def test_no_redirect_means_no_override():
+    db = _db_returning([])
+    assert await _session_audience_for_redirect(db, None) is None
+    db.execute.assert_not_awaited()
+
+
+def test_access_token_carries_the_override_audience():
+    token, _jti, _exp = AuthService.create_access_token(
+        user_id="u-1", tenant_id="t-1", email="a@b.test", audience="nauta-portal"
+    )
+    claims = pyjwt.decode(token, options={"verify_signature": False}, algorithms=["HS256", "RS256"])
+    assert claims["aud"] == "nauta-portal"
+
+
+def test_access_token_without_override_keeps_the_platform_default():
+    from app.config import settings
+
+    token, _jti, _exp = AuthService.create_access_token(
+        user_id="u-1", tenant_id="t-1", email="a@b.test"
+    )
+    claims = pyjwt.decode(token, options={"verify_signature": False}, algorithms=["HS256", "RS256"])
+    assert claims["aud"] == settings.JWT_AUDIENCE
+
+
+def test_both_magic_link_paths_resolve_the_audience():
+    """Source-level pin: verify and callback must BOTH pass the resolved
+    audience into create_session — a session from either door is the same
+    session."""
+    import inspect
+
+    from app.routers.v1 import auth
+
+    for handler in (auth.magic_link_callback, auth.verify_magic_link):
+        source = inspect.getsource(handler)
+        assert "_session_audience_for_redirect" in source, handler.__name__

--- a/apps/api/tests/unit/routers/test_magic_link_audience.py
+++ b/apps/api/tests/unit/routers/test_magic_link_audience.py
@@ -44,6 +44,20 @@ async def test_resolves_audience_by_redirect_host_not_full_uri():
 
 
 @pytest.mark.asyncio
+async def test_double_encoded_redirect_uris_still_resolve():
+    """Some prod rows store redirect_uris as a JSON string CONTAINING the
+    array (both nauta clients did, 2026-08-15). Iterating that string yields
+    characters; the resolver must decode it or silently match nothing."""
+    db = _db_returning(
+        [_client("nauta-portal", '["https://crea.madfam.io/api/auth/callback/janua"]')]
+    )
+    audience = await _session_audience_for_redirect(
+        db, "https://crea.madfam.io/portal/verify"
+    )
+    assert audience == "nauta-portal"
+
+
+@pytest.mark.asyncio
 async def test_unknown_host_keeps_the_platform_default():
     db = _db_returning([_client("nauta-portal", ["https://crea.madfam.io/cb"])])
     assert await _session_audience_for_redirect(db, "https://other.example.com/x") is None


### PR DESCRIPTION
Closes the loop on the 2026-08-15 rehearsal finding (pairs with nauta#90/#91): magic-link sessions minted `aud=janua.dev` (platform default), so the product's verifier rejected the very token it had just obtained from `/magic-link/verify`.

- `_session_audience_for_redirect`: resolves the audience from the redirect host via active `OAuthClient.redirect_uris` (host match — `/portal/verify` is not an OAuth callback path, but the host names the product) and the client's registered `audience` column.
- `AuthService.create_session`/`create_access_token` accept an `audience` override; the OIDC path always had per-client audiences, this extends the same idea to magic links.
- Fallback unchanged: no redirect / no match / no registered audience → platform default, so every existing flow mints exactly what it minted before.
- Both doors (POST verify + GET callback) resolve it, pinned by test.

Consumer side already deployed: nauta's portal-exchange verifier accepts `[nauta-api, nauta-portal, janua.dev]` (nauta#91), so deploy order cannot break login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)