### PR TITLE
fix(auth): /session bearer fallback + issuer-side multi-audience verify

### DIFF
--- a/apps/api/app/routers/v1/auth.py
+++ b/apps/api/app/routers/v1/auth.py
@@ -470,11 +470,19 @@ async def check_session(
         - 200 with user info if session is valid
         - 401 if no session or invalid token
     """
-    # Try to get access token from cookies
+    # Cookie first (browser SSO), then the Authorization header: products ask
+    # this endpoint about a token they hold server-side — nauta's invitation
+    # redemption did, and every such call 401'd here for want of a cookie the
+    # server never had (found live 2026-08-15). The bearer token answers for
+    # itself exactly as the cookie does; nothing else changes.
     access_token = request.cookies.get("access_token")
+    if not access_token:
+        authorization = request.headers.get("authorization", "")
+        if authorization.lower().startswith("bearer "):
+            access_token = authorization[7:].strip()
 
     if not access_token:
-        raise HTTPException(status_code=401, detail="No session cookie found")
+        raise HTTPException(status_code=401, detail="No session cookie or bearer token found")
 
     # Validate access token
     payload = AuthService.verify_token(access_token, token_type="access")

--- a/apps/api/app/services/auth_service.py
+++ b/apps/api/app/services/auth_service.py
@@ -471,13 +471,32 @@ class AuthService:
                 # RS256 requested but no public key, fall back to HS256
                 algorithm = "HS256"
 
-            payload = jwt.decode(
-                token,
-                verify_key,
-                algorithms=[algorithm],
-                audience=settings.JWT_AUDIENCE,
-                issuer=settings.JWT_ISSUER,
-            )
+            try:
+                payload = jwt.decode(
+                    token,
+                    verify_key,
+                    algorithms=[algorithm],
+                    audience=settings.JWT_AUDIENCE,
+                    issuer=settings.JWT_ISSUER,
+                )
+            except jwt.InvalidAudienceError:
+                # Janua is the ISSUER validating its own tokens here, and it
+                # mints more than one audience: magic-link sessions carry the
+                # audience of the product they forward to (per-client, e.g.
+                # nauta-portal) — see _session_audience_for_redirect. Audience
+                # restriction exists for RESOURCE SERVERS deciding which
+                # tokens to accept; the issuer accepts every audience it
+                # minted, still enforcing signature, issuer, expiry and type.
+                payload = jwt.decode(
+                    token,
+                    verify_key,
+                    algorithms=[algorithm],
+                    issuer=settings.JWT_ISSUER,
+                    options={"verify_aud": False},
+                )
+                if not isinstance(payload.get("aud"), str) or not payload.get("aud"):
+                    logger.warning("Token carries no usable audience claim")
+                    return None
 
             if payload.get("type") != token_type:
                 logger.warning("Token type mismatch", expected=token_type, got=payload.get("type"))

--- a/apps/api/tests/unit/routers/test_session_bearer_and_audience.py
+++ b/apps/api/tests/unit/routers/test_session_bearer_and_audience.py
@@ -1,0 +1,56 @@
+"""The issuer accepts what it minted, and /session answers bearers.
+
+Two halves of the same 2026-08-15 rehearsal finding:
+
+1. `/session` read ONLY the cookie, so every server-to-server bearer call
+   401'd instantly — nauta's invitation redemption among them.
+2. `verify_token` pinned the platform audience, so the moment magic-link
+   sessions started carrying per-client audiences (#545), janua would have
+   rejected its own tokens on its own session checks.
+"""
+
+import inspect
+
+import pytest
+
+from app.routers.v1 import auth
+from app.services.auth_service import AuthService
+
+
+def test_session_endpoint_reads_bearer_when_no_cookie():
+    source = inspect.getsource(auth.check_session)
+    assert 'request.cookies.get("access_token")' in source
+    assert "authorization" in source.lower()
+    assert "bearer " in source.lower()
+
+
+@pytest.mark.asyncio
+async def test_verify_token_accepts_a_per_client_audience():
+    token, _jti, _exp = AuthService.create_access_token(
+        user_id="00000000-0000-0000-0000-000000000001",
+        tenant_id="00000000-0000-0000-0000-000000000002",
+        email="a@b.test",
+        audience="nauta-portal",
+    )
+    payload = await AuthService.verify_token(token, token_type="access")
+    assert payload is not None
+    assert payload["aud"] == "nauta-portal"
+
+
+@pytest.mark.asyncio
+async def test_verify_token_still_accepts_the_platform_audience():
+    from app.config import settings
+
+    token, _jti, _exp = AuthService.create_access_token(
+        user_id="00000000-0000-0000-0000-000000000001",
+        tenant_id="00000000-0000-0000-0000-000000000002",
+        email="a@b.test",
+    )
+    payload = await AuthService.verify_token(token, token_type="access")
+    assert payload is not None
+    assert payload["aud"] == settings.JWT_AUDIENCE
+
+
+@pytest.mark.asyncio
+async def test_verify_token_still_rejects_garbage():
+    assert await AuthService.verify_token("not-a-token", token_type="access") is None

--- a/apps/api/tests/unit/routers/test_session_bearer_and_audience.py
+++ b/apps/api/tests/unit/routers/test_session_bearer_and_audience.py
@@ -10,11 +10,23 @@ Two halves of the same 2026-08-15 rehearsal finding:
 """
 
 import inspect
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from app.routers.v1 import auth
 from app.services.auth_service import AuthService
+
+
+@contextmanager
+def _no_blacklist():
+    """verify_token consults redis for the JTI blacklist; unit tests have no
+    redis, and an unmocked call dies on `None.get` before the verdict."""
+    redis = AsyncMock()
+    redis.get = AsyncMock(return_value=None)
+    with patch("app.services.auth_service.get_redis", AsyncMock(return_value=redis)):
+        yield
 
 
 def test_session_endpoint_reads_bearer_when_no_cookie():
@@ -32,7 +44,8 @@ async def test_verify_token_accepts_a_per_client_audience():
         email="a@b.test",
         audience="nauta-portal",
     )
-    payload = await AuthService.verify_token(token, token_type="access")
+    with _no_blacklist():
+        payload = await AuthService.verify_token(token, token_type="access")
     assert payload is not None
     assert payload["aud"] == "nauta-portal"
 
@@ -46,7 +59,8 @@ async def test_verify_token_still_accepts_the_platform_audience():
         tenant_id="00000000-0000-0000-0000-000000000002",
         email="a@b.test",
     )
-    payload = await AuthService.verify_token(token, token_type="access")
+    with _no_blacklist():
+        payload = await AuthService.verify_token(token, token_type="access")
     assert payload is not None
     assert payload["aud"] == settings.JWT_AUDIENCE
 


### PR DESCRIPTION
Rides the un-promoted #545 train so one promote ships all of it. Pairs with nauta#93.

**1. `/session` accepts `Authorization: Bearer`** when no cookie is present. Products ask this endpoint about tokens they hold server-side (nauta's invitation redemption did); every such call 401'd for want of a browser cookie.

**2. `verify_token` accepts every audience janua itself mints.** It pinned `settings.JWT_AUDIENCE`, so post-#545 (magic-link sessions carrying per-client audiences like `nauta-portal`) janua's own session checks would reject janua's own tokens. On `InvalidAudienceError` it re-verifies signature/issuer/expiry/type with the audience check relaxed — the issuer reading its own tokens, not a resource server deciding whose to accept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)