### PR TITLE
fix(k8s): map internal-api-key into INTERNAL_API_KEY on the api

### DIFF
--- a/k8s/base/deployments/janua-api.yaml
+++ b/k8s/base/deployments/janua-api.yaml
@@ -73,6 +73,18 @@ spec:
                   name: janua-secrets
                   key: direct-database-url
                   optional: true
+            # The internal service-to-service door (email send-template et al).
+            # The vault value has been synced into janua-secrets all along —
+            # nothing ever mapped it into the env, so settings.INTERNAL_API_KEY
+            # was empty and the door answered 503 (found 2026-08-16 wiring the
+            # Nauta lifecycle notifications). Optional: environments without
+            # the key must still boot; the endpoints refuse per-request.
+            - name: INTERNAL_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: janua-secrets
+                  key: internal-api-key
+                  optional: true
             - name: REDIS_URL
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
The vault value (68 chars) has been syncing into `janua-secrets` as `internal-api-key` all along — verified live — but no deployment maps it into the env, so `settings.INTERNAL_API_KEY` is empty in the running pod and `verify_internal_api_key` 503s every internal-email call. One optional `secretKeyRef` mapping, mirroring `direct-database-url`. Found wiring the Nauta lifecycle notifications ([nauta#111](https://github.com/madfam-org/nauta/pull/111), templates in #547).

🤖 Generated with [Claude Code](https://claude.com/claude-code)