### PR TITLE
feat(email): request-filed template — the operator hears a priority the moment it lands

### DIFF
--- a/apps/api/app/routers/v1/email.py
+++ b/apps/api/app/routers/v1/email.py
@@ -193,6 +193,22 @@ EMAIL_TEMPLATES: Dict[str, Dict[str, Any]] = {
         "optional": [],
         "subject": "Agreement accepted — {workspace_name}",
     },
+    "transactional/request-filed": {
+        "description": "Client priority filed — operator notification (Nauta)",
+        "required": [
+            "workspace_name",
+            "submitted_by",
+            "title",
+            "kind",
+            "severity",
+            "sla_line",
+            "filed_at",
+            "body_excerpt",
+            "cockpit_url",
+        ],
+        "optional": [],
+        "subject": "Priority filed — {workspace_name}: {title}",
+    },
     "transactional/workspace-activated": {
         "description": "Workspace activated — client notification (Nauta, register-composed)",
         "required": [
@@ -235,6 +251,7 @@ TEMPLATE_FILENAMES: Dict[str, str] = {
     "onboarding/complete": "onboarding_complete.html",
     "transactional/agreement-accepted": "transactional_agreement-accepted.html",
     "transactional/workspace-activated": "transactional_workspace-activated.html",
+    "transactional/request-filed": "transactional_request-filed.html",
 }
 
 

--- a/apps/api/templates/emails/transactional_request-filed.html
+++ b/apps/api/templates/emails/transactional_request-filed.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Client priority filed</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px; background: #f5f5f5; }
+        .container { background: white; border-radius: 12px; overflow: hidden; box-shadow: 0 4px 6px rgba(0,0,0,0.1); }
+        .header { background: #005293; color: white; padding: 28px 30px; }
+        .header h1 { margin: 0; font-size: 22px; }
+        .content { padding: 36px 30px; }
+        .fact-box { background: #f0f6fb; border: 1px solid #cfe3f2; border-radius: 10px; padding: 20px 24px; margin: 18px 0; }
+        .fact { margin: 4px 0; font-size: 14px; }
+        .fact .label { color: #6b7280; }
+        .body-box { background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 10px; padding: 16px 20px; margin: 18px 0; font-size: 14px; white-space: pre-wrap; }
+        .btn { display: inline-block; background: #005293; color: white; padding: 13px 26px; text-decoration: none; border-radius: 8px; font-weight: 600; margin: 16px 0; }
+        .footer { text-align: center; padding: 18px 30px; background: #f9fafb; color: #6b7280; font-size: 12px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <h1>Priority filed — {{workspace_name}}</h1>
+        </div>
+        <div class="content">
+            <p>{{submitted_by}} filed a priority. The SLA clock is running against the target
+            snapshotted at submission; moving it out of Submitted in the cockpit is what stamps
+            the first response.</p>
+            <div class="fact-box">
+                <p class="fact"><span class="label">Title:</span> {{title}}</p>
+                <p class="fact"><span class="label">Kind:</span> {{kind}} · <span class="label">Severity:</span> {{severity}}</p>
+                <p class="fact"><span class="label">Response target:</span> {{sla_line}}</p>
+                <p class="fact"><span class="label">Filed at:</span> {{filed_at}}</p>
+            </div>
+            <div class="body-box">{{body_excerpt}}</div>
+            <p><a href="{{cockpit_url}}" class="btn">Open the triage panel</a></p>
+        </div>
+        <div class="footer">
+            <p>Nauta cockpit notification · MADFAM</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/apps/api/tests/unit/services/test_engagement_templates.py
+++ b/apps/api/tests/unit/services/test_engagement_templates.py
@@ -13,6 +13,7 @@ from app.routers.v1.email import EMAIL_TEMPLATES, TEMPLATE_FILENAMES, _get_safe_
 ENGAGEMENT_IDS = [
     "transactional/agreement-accepted",
     "transactional/workspace-activated",
+    "transactional/request-filed",
 ]
 
 


### PR DESCRIPTION
The nauta triage panel (nauta#116) gave the client-priority queue its counter; this is the doorbell. `transactional/request-filed`, following the engagement-lifecycle pattern from #547:

- strict registry entry, 9 required variables (`workspace_name`, `submitted_by`, `title`, `kind`, `severity`, `sla_line`, `filed_at`, `body_excerpt`, `cockpit_url`), no optionals;
- filename-whitelist entry (no user input in path construction);
- the body excerpt renders `white-space: pre-wrap` so a client's pasted bullets survive into the operator's inbox;
- `test_engagement_templates.py` extended: both registries, file on disk, every required variable has a slot.

Nauta-side sender (fire-and-forget hook in `submitRequest`) follows as a nauta PR once this deploys — same sequencing as agreement-accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)