### PR TITLE
fix(docker): api image ships apps/api/templates — branded mail instead of the silent fallback

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -45,6 +45,14 @@ COPY --from=builder /usr/local/bin /usr/local/bin
 # Copy application code
 COPY apps/api/app ./app
 
+# Email templates. NEVER SHIPPED until 2026-08-16: this file copied only
+# app/ + alembic/, so every registered template resolved to a missing file in
+# production and send-template silently degraded to the bare-key-dump
+# fallback — repo tests pass because they check the repo, not the image. The
+# registry resolves Path(__file__).parents[3]/templates/emails == /app/
+# templates/emails, which this line is what makes true.
+COPY apps/api/templates ./templates
+
 # Copy alembic for database migrations
 COPY apps/api/alembic ./alembic
 COPY apps/api/alembic.ini ./alembic.ini


### PR DESCRIPTION
Post-promote drift-check finding (2026-08-16): `find / -name 'transactional_*.html'` returns **nothing** in the running prod pods — for the template promoted today *and* for every template registered since #547.

Cause: the real build (`docker-publish.yml` → `Dockerfile.api`, context `.`) copies `apps/api/app`, `alembic` and the entrypoint, never `apps/api/templates/`. (`apps/api/Dockerfile`, which does `COPY . /app`, is not what CI builds — a decoy during diagnosis.) The registry resolves `Path(__file__).parents[3]/templates/emails` = `/app/templates/emails`; with the template absent, `send-template` silently falls back to `generate_fallback_html` — exactly the degradation the template-existence test's docstring warns about, invisible because repo tests check the repo, not the image.

Fix: one `COPY apps/api/templates ./templates` with the doctrine comment. After merge → staging → 30-min soak → promote, the drift-check re-runs with the same probe and must find the files this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)