### PR TITLE
fix(go-sdk): implement real HMAC-SHA256 webhook signature verification

### DIFF
--- a/packages/go-sdk/janua/client.go
+++ b/packages/go-sdk/janua/client.go
@@ -4,11 +4,15 @@ package janua
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -307,11 +311,29 @@ type WebhookEvent struct {
 	Signature string                 `json:"signature"`
 }
 
-// VerifyWebhookSignature verifies a webhook signature
+// VerifyWebhookSignature verifies the HMAC-SHA256 signature Janua sends with a
+// webhook delivery in the `X-Webhook-Signature` header. It recomputes
+// HMAC-SHA256(secret, payload) as lowercase hex and compares it to the provided
+// signature in constant time.
+//
+// This matches the server's signing (webhook_dispatcher._calculate_signature /
+// webhooks._generate_signature): hmac.new(secret, payload, sha256).hexdigest().
+//
+// Returns false on any mismatch, and on an empty signature or empty secret — a
+// caller must never treat an unsigned or unconfigured delivery as verified.
 func VerifyWebhookSignature(payload []byte, signature string, secret string) bool {
-	// Implementation would verify HMAC signature
-	// This is a placeholder
-	return true
+	if signature == "" || secret == "" {
+		return false
+	}
+
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	expected := hex.EncodeToString(mac.Sum(nil))
+
+	// Constant-time compare (hmac.Equal). Tolerate a `sha256=` prefix in case a
+	// caller forwards the header verbatim from a proxy that adds one.
+	provided := strings.TrimPrefix(signature, "sha256=")
+	return hmac.Equal([]byte(provided), []byte(expected))
 }
 
 // GenerateState generates a random state for OAuth flows

--- a/packages/go-sdk/janua/webhook_test.go
+++ b/packages/go-sdk/janua/webhook_test.go
@@ -1,0 +1,88 @@
+package janua
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+)
+
+// sign reproduces the server's signing exactly (webhook_dispatcher
+// ._calculate_signature / webhooks._generate_signature):
+// hmac.new(secret, payload, sha256).hexdigest().
+func sign(secret string, payload []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestVerifyWebhookSignature_Valid(t *testing.T) {
+	secret := "whsec_test_secret"
+	payload := []byte(`{"event":"user.created","data":{"id":"abc"}}`)
+	if !VerifyWebhookSignature(payload, sign(secret, payload), secret) {
+		t.Fatal("valid signature was rejected")
+	}
+}
+
+// KnownAnswer pins the exact wire format so Go and the Python server can never
+// silently diverge. `want` is HMAC-SHA256("test-secret", "hello") as produced by
+// Python's hmac.new(b"test-secret", b"hello", sha256).hexdigest() — computed
+// independently, not by this package's own sign() helper.
+func TestVerifyWebhookSignature_KnownAnswer(t *testing.T) {
+	secret := "test-secret"
+	payload := []byte("hello")
+	const want = "bcc889a40667cab715e1dc22ad280692cf4bf1c3a280eeeca60d8dbcd8e4b993"
+
+	if got := sign(secret, payload); got != want {
+		t.Fatalf("Go HMAC disagrees with the Python server format:\n got  %s\n want %s", got, want)
+	}
+	// And the verifier accepts that exact server-produced signature.
+	if !VerifyWebhookSignature(payload, want, secret) {
+		t.Fatal("verify rejected the known-good server signature")
+	}
+}
+
+func TestVerifyWebhookSignature_WrongSecret(t *testing.T) {
+	payload := []byte(`{"event":"user.created"}`)
+	sig := sign("correct-secret", payload)
+	if VerifyWebhookSignature(payload, sig, "attacker-secret") {
+		t.Fatal("signature verified under the wrong secret")
+	}
+}
+
+func TestVerifyWebhookSignature_TamperedPayload(t *testing.T) {
+	secret := "whsec_test_secret"
+	sig := sign(secret, []byte(`{"amount":100}`))
+	// Attacker keeps the signature but changes the body.
+	if VerifyWebhookSignature([]byte(`{"amount":1000000}`), sig, secret) {
+		t.Fatal("tampered payload passed verification")
+	}
+}
+
+func TestVerifyWebhookSignature_EmptySignatureRejected(t *testing.T) {
+	// The whole point of the fix: an unsigned delivery must NOT verify.
+	if VerifyWebhookSignature([]byte(`{}`), "", "secret") {
+		t.Fatal("empty signature was accepted — the placeholder bug is back")
+	}
+}
+
+func TestVerifyWebhookSignature_EmptySecretRejected(t *testing.T) {
+	payload := []byte(`{}`)
+	if VerifyWebhookSignature(payload, sign("", payload), "") {
+		t.Fatal("empty secret was accepted — an unconfigured consumer must fail closed")
+	}
+}
+
+func TestVerifyWebhookSignature_Sha256PrefixTolerated(t *testing.T) {
+	secret := "whsec_test_secret"
+	payload := []byte(`{"event":"ping"}`)
+	if !VerifyWebhookSignature(payload, "sha256="+sign(secret, payload), secret) {
+		t.Fatal("a sha256= prefixed signature (proxy-forwarded) was rejected")
+	}
+}
+
+func TestVerifyWebhookSignature_GarbageSignature(t *testing.T) {
+	if VerifyWebhookSignature([]byte(`{}`), "not-hex-!!!", "secret") {
+		t.Fatal("non-hex garbage verified")
+	}
+}


### PR DESCRIPTION
## Security fix

`VerifyWebhookSignature` in the Go SDK was a placeholder that **always returned `true`**:

```go
func VerifyWebhookSignature(payload []byte, signature string, secret string) bool {
	// Implementation would verify HMAC signature
	// This is a placeholder
	return true
}
```

Any consumer relying on it to authenticate inbound Janua webhooks accepted **forged deliveries** — no origin authentication at all. Live security defect (surfaced in the 2026-08-17 ecosystem parity/security sweep).

## The fix

Recompute `HMAC-SHA256(secret, payload)` as lowercase hex and compare in **constant time** (`hmac.Equal`), matching the server's own signing:

- `webhook_dispatcher._calculate_signature` and `webhooks._generate_signature`: `hmac.new(secret.encode(), payload, hashlib.sha256).hexdigest()`
- Header: `X-Webhook-Signature`

Behavior:
- **Fails closed** on empty signature or empty secret (an unsigned or unconfigured delivery must never verify).
- Tolerates a `sha256=` prefix in case a proxy forwards the header verbatim.

## Tests (8, all green)

Known-answer test pins Go↔Python wire compatibility: `HMAC-SHA256("test-secret","hello") == bcc889a4…`, the value computed independently from Python's `hmac`. Plus valid, wrong-secret, tampered-payload, empty-signature (the regression guard for the placeholder bug), empty-secret, `sha256=` prefix, and garbage-signature cases.

`go build ./...` and `go test ./janua/` both pass.

## Note

SDK **publishing** is a separate operator-gated step (per AGENTS.md) — this PR is the code + tests only; it does not publish a new `go-sdk` version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)