### PR TITLE
feat(admin): create-user endpoint + remove dead signup/email config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,9 +309,26 @@ POST   /api/v1/auth/mfa/setup      # Setup MFA
 POST   /api/v1/auth/passkey/register # Register passkey
 
 GET    /api/v1/users               # List users (admin)
+POST   /api/v1/admin/users         # Create user directly (admin; Supabase createUser parity)
 GET    /api/v1/organizations       # List organizations
 POST   /api/v1/organizations       # Create organization
 ```
+
+**Admin create-user** (`POST /api/v1/admin/users`): platform-admin-gated
+(`check_admin_permission`). Body: `email`, optional `name`, optional `password`,
+`is_admin`, `email_verified`, optional `organization_id` + `organization_role`
+(member|admin|owner). When `password` is omitted the user is created without a
+usable password and the response carries a one-time `set_password_token` (a
+`PasswordReset` token, 24h) that the new user redeems at
+`POST /api/v1/auth/password/reset` — no guessable default is ever set. The
+platform `is_admin` flag and org-scoped `organization_role` are disjoint (an org
+role never grants platform admin). The response never returns the password/hash.
+
+**Runtime signup switch**: `auth.allow_signups` (system setting) now overrides the
+`ENABLE_SIGNUPS` env default at signup time, so an operator can enable/disable
+self-signup without a redeploy. Precedence: DB `auth.allow_signups` if set, else
+`ENABLE_SIGNUPS`. `EMAIL_PROVIDER` accepts only `resend|smtp` (SendGrid was never
+wired on the auth path and its dep is not installed).
 
 ### Dhanam Billing Integration
 

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -211,7 +211,13 @@ class Settings(BaseSettings):
 
     # Email
     EMAIL_ENABLED: bool = Field(default=False)
-    EMAIL_PROVIDER: str = Field(default="resend", pattern="^(resend|smtp|sendgrid)$")
+    # `sendgrid` intentionally NOT accepted: there is no installed SendGrid dep
+    # (it is absent from requirements.txt) and no live SendGrid sender on the
+    # auth email path — only the dead enhanced_email_service.py referenced it, and
+    # that module imports the missing `sendgrid` package at top level so it cannot
+    # even load. Selecting "sendgrid" therefore did nothing silently; failing
+    # validation here surfaces the misconfiguration at config-load instead.
+    EMAIL_PROVIDER: str = Field(default="resend", pattern="^(resend|smtp)$")
     # madfam.io, not janua.dev. A client's first message is a sign-in link;
     # arriving from a brand they have never heard of, on an unrelated domain,
     # it is indistinguishable from phishing. madfam.io is Resend-verified.

--- a/apps/api/app/routers/v1/admin.py
+++ b/apps/api/app/routers/v1/admin.py
@@ -2,13 +2,14 @@
 Admin API endpoints for system management
 """
 
+import secrets
 import time
 import uuid
 from datetime import datetime, timedelta
 from typing import Any, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy import desc, func, or_, select, text, update
 from sqlalchemy.orm import Session
 
@@ -16,6 +17,8 @@ from app.config import settings
 from app.database import get_db
 from app.routers.v1.auth import get_current_user
 from app.services.account_lockout_service import AccountLockoutService
+from app.services.audit_logger import AuditEventType, AuditLogger
+from app.services.auth_service import AuthService
 from app.services.system_settings_service import SystemSettingsService, invalidate_cors_cache
 
 # Application start time for uptime calculation
@@ -26,7 +29,9 @@ from ...models import (
     OAuthAccount,
     OAuthProvider,
     Organization,
+    OrganizationMember,
     Passkey,
+    PasswordReset,
     User,
     UserStatus,
     organization_members,
@@ -121,6 +126,55 @@ class AdminUserUpdateRequest(BaseModel):
     status: Optional[UserStatus] = None
     is_admin: Optional[bool] = None
     email_verified: Optional[bool] = None
+
+
+# Org roles a membership may carry. Deliberately an allowlist: these are
+# ORG-SCOPED roles (member/admin/owner) entirely separate from the platform-wide
+# User.is_admin flag. Keeping the two disjoint is the no-privilege-escalation
+# boundary — an org "admin" must never confer platform admin, and vice-versa.
+_ALLOWED_ORG_ROLES = {"member", "admin", "owner"}
+
+
+class AdminUserCreateRequest(BaseModel):
+    """Admin create-user request (parity with Supabase Auth admin.createUser)."""
+
+    email: EmailStr
+    name: Optional[str] = Field(default=None, max_length=200)
+    # Optional. When omitted, the user is created WITHOUT a usable password and a
+    # one-time set-password token is returned (AdminUserCreateResponse.
+    # set_password_token). We never invent a guessable default. When provided it
+    # must satisfy the same strength policy as self-signup.
+    password: Optional[str] = Field(default=None)
+    is_admin: bool = Field(default=False)
+    email_verified: bool = Field(
+        default=False, description="Pre-verify the email (admin vouches for the address)."
+    )
+    organization_id: Optional[str] = Field(
+        default=None, description="Optional org to add the new user to as a member."
+    )
+    organization_role: str = Field(
+        default="member", description="Org-scoped role for the membership (member|admin|owner)."
+    )
+
+
+class AdminUserCreateResponse(BaseModel):
+    """Created user. Mirrors UserAdminResponse and NEVER carries the password.
+
+    `set_password_token` is present ONLY when the caller omitted a password: it
+    is a one-time PasswordReset token the operator hands to the new user, who
+    redeems it at POST /api/v1/auth/password/reset to choose their own password.
+    """
+
+    id: str
+    email: str
+    email_verified: bool
+    name: Optional[str]
+    status: str
+    is_admin: bool
+    organization_id: Optional[str] = None
+    organization_role: Optional[str] = None
+    set_password_token: Optional[str] = None
+    created_at: datetime
 
 
 def check_admin_permission(user: User):
@@ -382,6 +436,154 @@ async def list_all_users(
         )
 
     return result
+
+
+@router.post("/users", response_model=AdminUserCreateResponse, status_code=201)
+async def create_user_admin(
+    request: AdminUserCreateRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Create a user directly (admin only).
+
+    Parity with Supabase Auth's admin.createUser: janua previously had no way to
+    provision a user outside self-signup or invite acceptance.
+
+    Password handling:
+      * password provided -> validated for strength, hashed (bcrypt via
+        AuthService — hashing is NOT duplicated here); user is immediately usable.
+      * password omitted   -> user created with no usable password_hash and a
+        one-time set-password token returned. No default/guessable secret.
+
+    Privilege model: gated by check_admin_permission (platform admins only).
+    `is_admin` sets the platform flag; `organization_role` sets an org-scoped role
+    and can never grant platform admin (disjoint by construction).
+    """
+    check_admin_permission(current_user)
+
+    # Validate org role against the allowlist up front (before any writes).
+    if request.organization_role not in _ALLOWED_ORG_ROLES:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid organization_role. Allowed: {sorted(_ALLOWED_ORG_ROLES)}",
+        )
+
+    # Resolve org (if requested) before creating anything, so a bad org id fails
+    # cleanly instead of orphaning a half-created user.
+    org: Optional[Organization] = None
+    if request.organization_id is not None:
+        try:
+            org_uuid = uuid.UUID(request.organization_id)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid organization_id")
+        org_result = await db.execute(select(Organization).where(Organization.id == org_uuid))
+        org = org_result.scalar_one_or_none()
+        if not org:
+            raise HTTPException(status_code=404, detail="Organization not found")
+
+    # Reject duplicates (case-sensitive email match, consistent with the rest of
+    # the codebase's User.email lookups).
+    existing = await db.execute(select(User).where(User.email == request.email))
+    if existing.scalar_one_or_none():
+        raise HTTPException(status_code=409, detail="User with this email already exists")
+
+    # Password: validate + hash when provided; otherwise leave unusable and mint
+    # a set-password token afterwards.
+    password_hash: Optional[str] = None
+    set_password_token: Optional[str] = None
+    if request.password is not None:
+        valid, message = AuthService.validate_password_strength(request.password)
+        if not valid:
+            raise HTTPException(status_code=400, detail=message)
+        password_hash = AuthService.hash_password(request.password)
+
+    # A tenant_id is required on User; admin-created users get a fresh tenant,
+    # matching AuthService.create_user's behaviour for the no-tenant case.
+    tenant_id = org.id if org is not None else uuid.uuid4()
+
+    user = User(
+        email=request.email,
+        password_hash=password_hash,
+        first_name=request.name,
+        status=UserStatus.ACTIVE,
+        is_admin=request.is_admin,
+        email_verified=request.email_verified,
+        email_verified_at=datetime.utcnow() if request.email_verified else None,
+        tenant_id=tenant_id,
+    )
+    db.add(user)
+    await db.flush()  # assign user.id without ending the transaction
+
+    # Optional org membership. ORM constructor with only model-defined columns
+    # (organization_id, user_id, role, status, joined_at).
+    if org is not None:
+        member = OrganizationMember(
+            organization_id=org.id,
+            user_id=user.id,
+            role=request.organization_role,
+            status="active",
+            joined_at=datetime.utcnow(),
+        )
+        db.add(member)
+
+    # No-password path: issue a one-time PasswordReset token (same vehicle as
+    # /password/forgot). 24h window gives the operator time to relay it.
+    if password_hash is None:
+        set_password_token = secrets.token_urlsafe(32)
+        db.add(
+            PasswordReset(
+                user_id=user.id,
+                token=set_password_token,
+                expires_at=datetime.utcnow() + timedelta(hours=24),
+            )
+        )
+
+    # Audit-log the creation via the working AuditLogger hash-chain trail — the
+    # SAME mechanism the signup/signin handlers use (app.routers.v1.auth.
+    # log_audit_event). We deliberately do NOT call AuthService.create_audit_log:
+    # that helper references AuditLog columns (tenant_id/current_hash/event_type)
+    # that do not exist on the model and raises AttributeError. Records who
+    # created whom; never a secret. A failure here must not block creation.
+    try:
+        audit_logger = AuditLogger(db)
+        await audit_logger.log(
+            event_type=AuditEventType.USER_CREATE,
+            tenant_id=str(tenant_id),
+            identity_id=str(current_user.id),
+            resource_type="user",
+            resource_id=str(user.id),
+            organization_id=str(org.id) if org is not None else None,
+            details={
+                "email": request.email,
+                "created_by": str(current_user.id),
+                "is_admin": request.is_admin,
+                "email_verified": request.email_verified,
+                "password_set": password_hash is not None,
+                "organization_id": str(org.id) if org is not None else None,
+                "organization_role": request.organization_role if org is not None else None,
+                "via": "admin.create_user",
+            },
+            severity="info",
+        )
+    except Exception:
+        # Audit logging failure must not break user provisioning.
+        pass
+
+    await db.commit()
+    await db.refresh(user)
+
+    return AdminUserCreateResponse(
+        id=str(user.id),
+        email=user.email,
+        email_verified=bool(user.email_verified),
+        name=user.name,
+        status=user.status.value if user.status else UserStatus.ACTIVE.value,
+        is_admin=bool(user.is_admin),
+        organization_id=str(org.id) if org is not None else None,
+        organization_role=request.organization_role if org is not None else None,
+        set_password_token=set_password_token,
+        created_at=user.created_at,
+    )
 
 
 @router.patch("/users/{user_id}")

--- a/apps/api/app/routers/v1/auth.py
+++ b/apps/api/app/routers/v1/auth.py
@@ -33,6 +33,8 @@ from app.services.email_service import (
     send_password_reset_email_task,
     send_verification_email_task,
 )
+from app.models.system_settings import SettingKeys
+from app.services.system_settings_service import SystemSettingsService
 from app.services.webhooks import WebhookEventType, trigger_user_webhook
 
 from ...models import ActivityLog, EmailVerification, MagicLink, PasswordReset, User, UserStatus
@@ -179,6 +181,37 @@ _AUDIT_EVENT_MAP = {
 }
 
 
+async def signups_enabled(db: Session) -> bool:
+    """Resolve whether self-service signup is currently allowed.
+
+    Precedence (most specific wins):
+      1. `auth.allow_signups` system setting (DB-backed runtime switch) — lets an
+         operator flip signups on/off via the admin settings API WITHOUT a
+         redeploy. This is the live switch the `SettingKeys.AUTH_ALLOW_SIGNUPS`
+         key was always meant to be but previously was read nowhere.
+      2. `settings.ENABLE_SIGNUPS` (env/config) — the deploy-time default and the
+         fallback used whenever the DB toggle is unset.
+
+    The DB value is coerced from its stored form (SystemSettingsService persists
+    scalars as strings), so "false"/"0"/"no"/"off"/"" all read as False. A failure
+    reading the settings table must never silently harden the gate shut, so any
+    error defers to the config default rather than inventing a decision.
+    """
+    try:
+        service = SystemSettingsService(db)
+        raw = await service.get_setting(SettingKeys.AUTH_ALLOW_SIGNUPS, default=None)
+    except Exception:
+        return settings.ENABLE_SIGNUPS
+
+    if raw is None:
+        return settings.ENABLE_SIGNUPS
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, (int, float)):
+        return bool(raw)
+    return str(raw).strip().lower() not in {"false", "0", "no", "off", ""}
+
+
 async def log_audit_event(
     db: Session, user_id: str, action: str, details: Dict = None, request: Request = None
 ):
@@ -212,7 +245,9 @@ async def sign_up(
     db: Session = Depends(get_db),
 ):
     """Create a new user account"""
-    if not settings.ENABLE_SIGNUPS:
+    # Gate honours the DB-backed `auth.allow_signups` runtime switch first,
+    # falling back to the ENABLE_SIGNUPS config default. See signups_enabled().
+    if not await signups_enabled(db):
         raise HTTPException(status_code=403, detail="Sign ups are currently disabled")
 
     # Check if email already exists

--- a/apps/api/tests/unit/routers/test_admin_create_user.py
+++ b/apps/api/tests/unit/routers/test_admin_create_user.py
@@ -1,0 +1,285 @@
+"""Admin create-user endpoint (POST /api/v1/admin/users).
+
+Janua previously had no admin path to provision a user directly — creation was
+only via self-signup or invite acceptance. This adds Supabase-style
+admin.createUser parity. These tests pin the security-critical behaviours:
+
+  * happy path with a password  -> user created, usable, no token leaked
+  * password omitted            -> set_password_token minted (PasswordReset),
+                                    user has no usable password_hash
+  * the response NEVER carries the password or its hash
+  * non-admin caller            -> 403 (gate enforced)
+  * duplicate email             -> 409
+  * no-privilege-escalation     -> org role is disjoint from platform is_admin,
+                                    and an unknown org role is rejected (422)
+  * the creation is audit-logged via the tamper-evident AuditLog chain
+
+Style follows tests/unit/routers/test_signup_locale.py: call the endpoint
+coroutine directly with an AsyncMock session and intercept db.add(), rather than
+standing up a live DB/TestClient.
+"""
+
+import uuid
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+import app.routers.v1.admin as admin_mod
+from app.routers.v1.admin import AdminUserCreateRequest, create_user_admin
+from app.models import OrganizationMember, PasswordReset, User
+
+pytestmark = pytest.mark.asyncio
+
+
+def _admin_user() -> User:
+    return User(
+        id=uuid.uuid4(),
+        email="admin@madfam.io",
+        password_hash="hashed",
+        is_admin=True,
+    )
+
+
+def _non_admin_user() -> User:
+    return User(
+        id=uuid.uuid4(),
+        email="mallory@example.com",
+        password_hash="hashed",
+        is_admin=False,
+    )
+
+
+def _db(existing_user=None, existing_org=None):
+    """AsyncMock session.
+
+    db.execute is called for: optional org lookup, the duplicate-email check, and
+    (inside create_audit_log) the previous-hash lookup. We return a result whose
+    scalar_one_or_none yields, in order: [org (if org lookup happens), existing
+    user for the dup check, None for the audit previous-hash]. To keep ordering
+    robust regardless of how many selects run, we route by the queried entity is
+    impractical here; instead we hand back a small queue and default to None.
+    """
+    results = []
+    # The endpoint issues at most: org-select, user-dup-select, audit-prev-select.
+    # We only need the org-select and dup-select to return meaningful values.
+    if existing_org is not None:
+        results.append(existing_org)
+    results.append(existing_user)  # duplicate check -> None means "no dup"
+
+    call = {"i": 0}
+
+    def _make_result():
+        idx = call["i"]
+        call["i"] += 1
+        value = results[idx] if idx < len(results) else None
+        r = MagicMock()
+        r.scalar_one_or_none = MagicMock(return_value=value)
+        return r
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=lambda *a, **k: _make_result())
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+
+    async def refresh(obj, *args, **kwargs):
+        for column, default in (
+            ("id", uuid.uuid4()),
+            ("created_at", datetime.utcnow()),
+            ("updated_at", datetime.utcnow()),
+        ):
+            if getattr(obj, column, None) is None:
+                setattr(obj, column, default)
+
+    db.refresh = AsyncMock(side_effect=refresh)
+    return db
+
+
+def _added(db, cls):
+    return [c.args[0] for c in db.add.call_args_list if c.args and isinstance(c.args[0], cls)]
+
+
+async def _create(request: AdminUserCreateRequest, caller: User, db):
+    return await create_user_admin(request=request, current_user=caller, db=db)
+
+
+class TestHappyPathWithPassword:
+    async def test_creates_active_user_and_never_returns_secret(self):
+        db = _db()
+        resp = await _create(
+            AdminUserCreateRequest(
+                email="new@example.com",
+                name="New Person",
+                password="Str0ng!Passw0rd",
+                email_verified=True,
+            ),
+            _admin_user(),
+            db,
+        )
+
+        # Exactly one User created, with a hashed (not plaintext) password.
+        users = _added(db, User)
+        assert len(users) == 1
+        created = users[0]
+        assert created.email == "new@example.com"
+        assert created.password_hash is not None
+        assert created.password_hash != "Str0ng!Passw0rd"
+        assert created.email_verified is True
+
+        # Response carries no password/hash and no set-password token.
+        assert resp.email == "new@example.com"
+        assert resp.is_admin is False
+        assert resp.set_password_token is None
+        dumped = resp.model_dump()
+        assert "password" not in dumped
+        assert "password_hash" not in dumped
+        assert "Str0ng!Passw0rd" not in str(dumped)
+        assert created.password_hash not in str(dumped)
+
+    async def test_weak_password_rejected(self):
+        db = _db()
+        with pytest.raises(HTTPException) as exc:
+            await _create(
+                AdminUserCreateRequest(email="new@example.com", password="weak"),
+                _admin_user(),
+                db,
+            )
+        assert exc.value.status_code == 400
+        assert _added(db, User) == []  # nothing created on rejection
+
+
+class TestPasswordOmittedTokenPath:
+    async def test_mints_set_password_token_and_leaves_no_usable_password(self):
+        db = _db()
+        resp = await _create(
+            AdminUserCreateRequest(email="invitee@example.com", name="Invitee"),
+            _admin_user(),
+            db,
+        )
+
+        # No usable password on the created user.
+        created = _added(db, User)[0]
+        assert created.password_hash is None
+
+        # A PasswordReset token row was created, and the SAME token is returned.
+        resets = _added(db, PasswordReset)
+        assert len(resets) == 1
+        assert resp.set_password_token is not None
+        assert resp.set_password_token == resets[0].token
+        # Token is high-entropy, not a guessable default.
+        assert len(resp.set_password_token) >= 32
+        assert resp.set_password_token.lower() not in {"changeme", "password", "invitee"}
+
+
+class TestPrivilegeModel:
+    async def test_non_admin_caller_forbidden(self):
+        db = _db()
+        with pytest.raises(HTTPException) as exc:
+            await _create(
+                AdminUserCreateRequest(email="new@example.com", password="Str0ng!Passw0rd"),
+                _non_admin_user(),
+                db,
+            )
+        assert exc.value.status_code == 403
+        # Gate runs before any writes.
+        assert db.add.call_args_list == []
+
+    async def test_org_role_is_disjoint_from_platform_admin(self):
+        """Granting an org-scoped role must not touch the platform is_admin flag."""
+        org = SimpleNamespace(id=uuid.uuid4())
+        db = _db(existing_org=org)
+        resp = await _create(
+            AdminUserCreateRequest(
+                email="member@example.com",
+                password="Str0ng!Passw0rd",
+                is_admin=False,
+                organization_id=str(org.id),
+                organization_role="admin",  # org admin, NOT platform admin
+            ),
+            _admin_user(),
+            db,
+        )
+
+        created = _added(db, User)[0]
+        assert created.is_admin is False  # org role did not escalate platform admin
+        assert resp.is_admin is False
+
+        members = _added(db, OrganizationMember)
+        assert len(members) == 1
+        assert members[0].role == "admin"
+        assert members[0].organization_id == org.id
+        assert resp.organization_role == "admin"
+
+    async def test_unknown_org_role_rejected(self):
+        db = _db()
+        with pytest.raises(HTTPException) as exc:
+            await _create(
+                AdminUserCreateRequest(
+                    email="new@example.com",
+                    password="Str0ng!Passw0rd",
+                    organization_role="superadmin",  # not in the allowlist
+                ),
+                _admin_user(),
+                db,
+            )
+        assert exc.value.status_code == 422
+        assert _added(db, User) == []
+
+
+class TestDuplicateGuard:
+    async def test_duplicate_email_conflicts(self):
+        existing = User(id=uuid.uuid4(), email="dupe@example.com", password_hash="x")
+        db = _db(existing_user=existing)
+        with pytest.raises(HTTPException) as exc:
+            await _create(
+                AdminUserCreateRequest(email="dupe@example.com", password="Str0ng!Passw0rd"),
+                _admin_user(),
+                db,
+            )
+        assert exc.value.status_code == 409
+
+
+class TestAuditLogged:
+    async def test_creation_is_audit_logged(self):
+        db = _db()
+        caller = _admin_user()
+        log_mock = AsyncMock(return_value="event-id")
+        # Patch AuditLogger so its constructor returns an object whose .log is our
+        # AsyncMock — the endpoint does `AuditLogger(db).log(...)`.
+        fake_logger = MagicMock()
+        fake_logger.log = log_mock
+        with patch.object(admin_mod, "AuditLogger", return_value=fake_logger):
+            await _create(
+                AdminUserCreateRequest(email="new@example.com", password="Str0ng!Passw0rd"),
+                caller,
+                db,
+            )
+
+        log_mock.assert_awaited_once()
+        kwargs = log_mock.await_args.kwargs
+        assert kwargs["event_type"] == admin_mod.AuditEventType.USER_CREATE
+        assert kwargs["resource_type"] == "user"
+        assert kwargs["details"]["email"] == "new@example.com"
+        assert kwargs["details"]["created_by"] == str(caller.id)
+        assert kwargs["details"]["via"] == "admin.create_user"
+        # No secret ever reaches the audit trail.
+        assert "password" not in kwargs["details"]
+        assert "Str0ng!Passw0rd" not in str(kwargs["details"])
+
+    async def test_audit_failure_does_not_block_creation(self):
+        """An audit-logging error must not prevent the user from being created."""
+        db = _db()
+        fake_logger = MagicMock()
+        fake_logger.log = AsyncMock(side_effect=RuntimeError("audit sink down"))
+        with patch.object(admin_mod, "AuditLogger", return_value=fake_logger):
+            resp = await _create(
+                AdminUserCreateRequest(email="resilient@example.com", password="Str0ng!Passw0rd"),
+                _admin_user(),
+                db,
+            )
+        assert resp.email == "resilient@example.com"
+        assert len(_added(db, User)) == 1
+        db.commit.assert_awaited()

--- a/apps/api/tests/unit/routers/test_signup_allow_signups.py
+++ b/apps/api/tests/unit/routers/test_signup_allow_signups.py
@@ -1,0 +1,202 @@
+"""`auth.allow_signups` DB toggle precedence over ENABLE_SIGNUPS.
+
+The `auth.allow_signups` system setting was previously dead (defined in
+SettingKeys.AUTH_ALLOW_SIGNUPS, read nowhere). It is now a live runtime switch:
+`signups_enabled(db)` reads the DB setting first and falls back to the
+`settings.ENABLE_SIGNUPS` config default.
+
+Precedence under test:
+  1. DB `auth.allow_signups` (if set) wins — flips signups without a redeploy.
+  2. Otherwise `settings.ENABLE_SIGNUPS` (config default / fallback).
+  3. A settings-backend error falls back to the config default (never silently
+     hardens the gate shut).
+
+Plus: verify the signup handler actually honours the resolved value (a False
+resolution 403s before any user is created).
+"""
+
+import uuid
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+import app.routers.v1.auth as auth_mod
+from app.routers.v1.auth import SignUpRequest, signups_enabled, sign_up
+
+pytestmark = pytest.mark.asyncio
+
+
+def _setting_result(raw):
+    setting = None
+    if raw is not None:
+        setting = MagicMock()
+        setting.get_value = MagicMock(return_value=raw)
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=setting)
+    return result
+
+
+def _db_returning_setting(raw):
+    """AsyncMock session for signups_enabled() in isolation.
+
+    signups_enabled issues exactly one execute (the SystemSetting lookup), so a
+    single canned result is sufficient here.
+    """
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=_setting_result(raw))
+    return db
+
+
+def _db_for_signup(setting_raw):
+    """AsyncMock session for the full sign_up() path.
+
+    Execute call order in sign_up(): (1) signups_enabled -> SystemSetting lookup
+    returns `setting_raw`; (2) email-exists check -> must be None; (3) username
+    check (only if username given) -> None. We return the setting result first,
+    then None-yielding results for the user lookups.
+    """
+    call = {"i": 0}
+
+    def _make_result(*a, **k):
+        idx = call["i"]
+        call["i"] += 1
+        if idx == 0:
+            return _setting_result(setting_raw)
+        r = MagicMock()
+        r.scalar_one_or_none = MagicMock(return_value=None)
+        return r
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=_make_result)
+    return db
+
+
+class TestResolutionPrecedence:
+    async def test_db_true_overrides_config_false(self):
+        db = _db_returning_setting("true")
+        with patch.object(auth_mod.settings, "ENABLE_SIGNUPS", False):
+            assert await signups_enabled(db) is True
+
+    async def test_db_false_overrides_config_true(self):
+        db = _db_returning_setting("false")
+        with patch.object(auth_mod.settings, "ENABLE_SIGNUPS", True):
+            assert await signups_enabled(db) is False
+
+    async def test_unset_falls_back_to_config_true(self):
+        db = _db_returning_setting(None)
+        with patch.object(auth_mod.settings, "ENABLE_SIGNUPS", True):
+            assert await signups_enabled(db) is True
+
+    async def test_unset_falls_back_to_config_false(self):
+        db = _db_returning_setting(None)
+        with patch.object(auth_mod.settings, "ENABLE_SIGNUPS", False):
+            assert await signups_enabled(db) is False
+
+    async def test_settings_backend_error_falls_back_to_config(self):
+        db = AsyncMock()
+        db.execute = AsyncMock(side_effect=RuntimeError("settings table unavailable"))
+        with patch.object(auth_mod.settings, "ENABLE_SIGNUPS", True):
+            assert await signups_enabled(db) is True
+        with patch.object(auth_mod.settings, "ENABLE_SIGNUPS", False):
+            assert await signups_enabled(db) is False
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("true", True),
+            ("1", True),
+            ("yes", True),
+            ("on", True),
+            (True, True),
+            (1, True),
+            ("false", False),
+            ("0", False),
+            ("no", False),
+            ("off", False),
+            ("", False),
+            (False, False),
+            (0, False),
+        ],
+    )
+    async def test_string_and_scalar_coercion(self, raw, expected):
+        db = _db_returning_setting(raw)
+        # Config default is irrelevant when the DB value is present and coercible.
+        with patch.object(auth_mod.settings, "ENABLE_SIGNUPS", not expected):
+            assert await signups_enabled(db) is expected
+
+
+class TestSignupHandlerHonoursToggle:
+    def _request(self):
+        return Request(
+            {
+                "type": "http",
+                "method": "POST",
+                "path": "/api/v1/auth/signup",
+                "headers": [(b"user-agent", b"pytest")],
+                "client": ("198.51.100.7", 51234),
+            }
+        )
+
+    async def test_db_toggle_off_blocks_signup(self):
+        """DB says off, config says on -> 403 and no user created."""
+        db = _db_for_signup("false")
+        db.add = MagicMock()
+        db.commit = AsyncMock()
+        with patch.object(auth_mod.settings, "ENABLE_SIGNUPS", True):
+            with pytest.raises(HTTPException) as exc:
+                await sign_up(
+                    request=self._request(),
+                    signup_data=SignUpRequest(
+                        email="blocked@example.com", password="Str0ng!Passw0rd"
+                    ),
+                    background_tasks=MagicMock(),
+                    db=db,
+                )
+        assert exc.value.status_code == 403
+        # Gate short-circuits before any User is added.
+        from app.models import User
+
+        assert [c for c in db.add.call_args_list if c.args and isinstance(c.args[0], User)] == []
+
+    async def test_db_toggle_on_allows_signup_despite_config_off(self):
+        """DB says on, config says off -> signup proceeds to create a user."""
+        db = _db_for_signup("true")
+        db.add = MagicMock()
+        db.commit = AsyncMock()
+
+        async def refresh(obj, *a, **k):
+            for col, val in (
+                ("id", uuid.uuid4()),
+                ("email_verified", False),
+                ("is_admin", False),
+                ("created_at", datetime.utcnow()),
+                ("updated_at", datetime.utcnow()),
+            ):
+                if getattr(obj, col, None) is None:
+                    setattr(obj, col, val)
+
+        db.refresh = AsyncMock(side_effect=refresh)
+
+        session_stub = AsyncMock(return_value=("access", "refresh", MagicMock()))
+        with (
+            patch.object(auth_mod.settings, "ENABLE_SIGNUPS", False),
+            patch.object(auth_mod.settings, "EMAIL_ENABLED", False),
+            patch.object(auth_mod.AuthService, "create_session", session_stub),
+        ):
+            resp = await sign_up(
+                request=self._request(),
+                signup_data=SignUpRequest(
+                    email="allowed@example.com", password="Str0ng!Passw0rd"
+                ),
+                background_tasks=MagicMock(),
+                db=db,
+            )
+
+        assert resp.user.email == "allowed@example.com"
+        from app.models import User
+
+        created = [c.args[0] for c in db.add.call_args_list if c.args and isinstance(c.args[0], User)]
+        assert len(created) == 1


### PR DESCRIPTION
Parity gaps D2 + D3.

## D2 — admin create-user endpoint
`POST /api/v1/admin/users`, gated by `check_admin_permission` (platform admins only). Closes a Supabase-Auth parity gap (they have admin `createUser`; janua had only self-signup + invite).

- Body: `email`, optional `name`/`password`/`is_admin`/`email_verified`, optional `organization_id` + `organization_role`.
- **Password provided** → strength-validated + hashed via `AuthService.hash_password` (reused, not duplicated).
- **Password omitted** → user created with `password_hash=None` and a **one-time 24h `PasswordReset` token** returned as `set_password_token` (redeemed at the existing `POST /api/v1/auth/password/reset`) — **no guessable default**.
- No-privilege-escalation: platform `is_admin` and org-scoped `organization_role` are disjoint by construction; org role allowlisted (`member|admin|owner`, else 422). Duplicate email → 409. Response never returns the password/hash. Audit-logged.

## D3a — `auth.allow_signups`: wired (was dead)
The DB toggle was never read; the real gate was `settings.ENABLE_SIGNUPS`. **Wired it** with precedence **DB toggle (if set) → else `ENABLE_SIGNUPS`**; a settings-backend error falls back to config (never silently blocks). Operators can now toggle signups without a redeploy.

## D3b — SendGrid: removed from accepted set
`sendgrid` was an accepted `EMAIL_PROVIDER` value but the dep isn't installed and only the dead `enhanced_email_service` referenced it — selecting it silently did nothing. Changed validation to `^(resend|smtp)$` so it now **fails fast at config-load**.

## Tests
29 new cases (9 admin-create-user incl. password-omitted→token, no-priv-escalation, secret-never-returned, audit-resilient; 20 allow_signups precedence + end-to-end gating). Agent-validated: 29 new pass, full `tests/unit/routers/` suite 550 passed / 0 failed, `git apply --check` clean. Verified in this checkout: all modules `py_compile` clean, code matches design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)