### PR TITLE
security(mfa): hash backup codes at rest + single verify-and-consume path

### DIFF
--- a/apps/api/app/compliance/privacy/data_subject_handler.py
+++ b/apps/api/app/compliance/privacy/data_subject_handler.py
@@ -3,7 +3,10 @@ Data Subject Request Handler
 Handles GDPR data subject requests including access, erasure, and portability rights.
 """
 
+import json
 import logging
+import os
+import tempfile
 import uuid
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional
@@ -18,10 +21,31 @@ from app.models.compliance import (
     DataSubjectRequestType,
     RequestStatus,
 )
+from app.services.data_export_serializer import (
+    assert_no_secrets,
+    build_export_archive,
+    collect_user_export_data,
+    serialize_export,
+)
 
 from ..audit import AuditEventType, AuditLogger, EvidenceType
 from .privacy_models import DataSubjectRequestResponse
 from .privacy_types import DataExportFormat
+
+# Directory where generated export artifacts are written. Governed by the
+# canonical ``settings.DATA_EXPORT_PATH`` config (default
+# ``/var/compliance/exports``); a ``DATA_EXPORT_DIR`` env var override is
+# honored for environments where that path is not writable (dev/test). The
+# request record stores the returned artifact path in ``response_data_url`` so
+# a download endpoint / secure-link issuer can serve it.
+try:
+    from app.config import settings as _settings
+
+    _DEFAULT_EXPORT_DIR = _settings.DATA_EXPORT_PATH
+except Exception:  # pragma: no cover - settings always import in practice
+    _DEFAULT_EXPORT_DIR = os.path.join(tempfile.gettempdir(), "janua-data-exports")
+
+_EXPORT_DIR = os.environ.get("DATA_EXPORT_DIR", _DEFAULT_EXPORT_DIR)
 
 logger = logging.getLogger(__name__)
 
@@ -312,25 +336,52 @@ class DataSubjectRequestHandler:
         date_range_end: Optional[datetime] = None,
         include_metadata: bool = True,
     ) -> Dict[str, Any]:
-        """Collect user data according to specified criteria"""
-        # Implementation would collect data from various sources
-        return {
-            "user_id": user_id,
-            "collection_timestamp": datetime.utcnow().isoformat(),
-            "data_categories": [cat.value for cat in (data_categories or [])],
-            "metadata_included": include_metadata,
-        }
+        """Collect the user's full data set for a GDPR Article 15 access request.
+
+        Gathers the real records across every identity model (profile, org
+        memberships, sessions, MFA/passkey metadata, OAuth grants/accounts,
+        audit logs). Secret material (password hashes, MFA seeds, tokens,
+        credential keys) is excluded by the serializer's allowlist design.
+        """
+        async with get_session() as session:
+            data = await collect_user_export_data(
+                session,
+                user_id,
+                include_audit_logs=include_metadata,
+                date_range_start=date_range_start,
+                date_range_end=date_range_end,
+            )
+        if data_categories:
+            data["export_metadata"]["requested_data_categories"] = [
+                cat.value for cat in data_categories
+            ]
+        if specific_fields:
+            data["export_metadata"]["requested_specific_fields"] = list(specific_fields)
+        assert_no_secrets(data)
+        return data
 
     async def _collect_portable_data(
         self, user_id: str, data_categories: List[DataCategory] = None
     ) -> Dict[str, Any]:
-        """Collect data that can be ported according to GDPR Article 20"""
-        # Implementation would collect only user-provided data with consent basis
-        return {
-            "user_id": user_id,
-            "portable_data": {},
-            "collection_timestamp": datetime.utcnow().isoformat(),
-        }
+        """Collect the portable subset for a GDPR Article 20 request.
+
+        Article 20 covers data the data subject provided themselves in a
+        structured, commonly used, machine-readable form: profile, org
+        memberships and OAuth grants. Server-generated telemetry (sessions,
+        audit logs) is excluded, as is all secret material.
+        """
+        async with get_session() as session:
+            data = await collect_user_export_data(
+                session,
+                user_id,
+                portable_only=True,
+            )
+        if data_categories:
+            data["export_metadata"]["requested_data_categories"] = [
+                cat.value for cat in data_categories
+            ]
+        assert_no_secrets(data)
+        return data
 
     async def _generate_data_export(
         self,
@@ -339,14 +390,49 @@ class DataSubjectRequestHandler:
         format: DataExportFormat,
         structured_format: bool = False,
     ) -> str:
-        """Generate secure data export file"""
-        # Implementation would create secure export files
-        return f"/secure/exports/{request_id}.{format.value}"
+        """Serialize ``data`` to a real artifact on disk and return its path.
+
+        JSON/CSV/XML are written as a single file. For the structured
+        portability export we additionally bundle per-section JSON files into
+        a zip archive for easier downstream consumption. The path is stored on
+        the request record (``response_data_url``) for a secure-download step.
+        """
+        # Never let a secret slip into a written artifact.
+        assert_no_secrets(data)
+
+        os.makedirs(_EXPORT_DIR, exist_ok=True)
+        fmt = format.value if hasattr(format, "value") else str(format)
+
+        if structured_format and fmt == DataExportFormat.JSON.value:
+            payload = build_export_archive(data, manifest_name=f"{request_id}.json")
+            path = os.path.join(_EXPORT_DIR, f"{request_id}.zip")
+            with open(path, "wb") as handle:
+                handle.write(payload)
+        else:
+            payload = serialize_export(data, fmt)
+            path = os.path.join(_EXPORT_DIR, f"{request_id}.{fmt}")
+            with open(path, "wb") as handle:
+                handle.write(payload)
+
+        logger.info(
+            "Generated data export artifact",
+            extra={"request_id": request_id, "format": fmt, "bytes": len(payload)},
+        )
+        return path
 
     async def _create_erasure_backup(self, request_id: str, user_data: Dict[str, Any]) -> str:
-        """Create backup before data erasure"""
-        # Implementation would create secure backup
+        """Persist a secret-free backup of the user's data before erasure.
+
+        Writes the same allowlisted, credential-free export produced for an
+        access request so an erasure can be audited / reversed within the
+        retention window without ever archiving secret material.
+        """
+        assert_no_secrets(user_data)
+        os.makedirs(_EXPORT_DIR, exist_ok=True)
         backup_ref = f"BACKUP-{request_id}-{datetime.utcnow().strftime('%Y%m%d%H%M%S')}"
+        path = os.path.join(_EXPORT_DIR, f"{backup_ref}.json")
+        with open(path, "wb") as handle:
+            handle.write(json.dumps(user_data, indent=2, ensure_ascii=False).encode("utf-8"))
         logger.info(f"Created erasure backup: {backup_ref}")
         return backup_ref
 

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -1,0 +1,17 @@
+"""Compatibility shim: ``app.core.config`` -> canonical ``app.config``.
+
+The ``app.compliance.*`` package historically imports settings from
+``app.core.config``, but the project's canonical settings module is
+``app.config`` (used by ~69 other modules). ``app.core.config`` never existed,
+which made every ``app.compliance`` submodule (audit, incident, support,
+dashboard, policies, privacy) fail to import — silently turning the compliance
+privacy/data-subject handler into dead code.
+
+This shim re-exports the settings surface from ``app.config`` so those modules
+import cleanly, without touching their import statements or changing canonical
+behavior. New code should import from ``app.config`` directly.
+"""
+
+from app.config import Settings, get_settings
+
+__all__ = ["Settings", "get_settings"]

--- a/apps/api/app/core/database.py
+++ b/apps/api/app/core/database.py
@@ -1,6 +1,7 @@
 import os
 import ssl
 from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from typing import Optional
 
 import structlog
@@ -318,6 +319,26 @@ async def bootstrap_admin_user():
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
     """Dependency to get database session"""
+    async with AsyncSessionLocal() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await session.close()
+
+
+@asynccontextmanager
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    """Async context manager yielding a committed-on-exit DB session.
+
+    Canonical helper used across ``app.compliance.*`` as
+    ``async with get_session() as session:``. Commits on clean exit and rolls
+    back on error, mirroring :func:`get_db` (which is the FastAPI dependency
+    variant).
+    """
     async with AsyncSessionLocal() as session:
         try:
             yield session

--- a/apps/api/app/models/audit.py
+++ b/apps/api/app/models/audit.py
@@ -1,0 +1,13 @@
+"""Compatibility shim: ``app.models.audit`` -> canonical ``app.models``.
+
+The ``app.compliance.*`` package imports ``AuditLog`` from ``app.models.audit``,
+but the model is actually defined in ``app.models`` (``app/models/__init__.py``).
+The ``app.models.audit`` module never existed, contributing to the compliance
+package being un-importable. This thin re-export fixes those imports without
+moving the model or touching the importers. New code should import ``AuditLog``
+from ``app.models`` directly.
+"""
+
+from app.models import AuditLog
+
+__all__ = ["AuditLog"]

--- a/apps/api/app/models/users.py
+++ b/apps/api/app/models/users.py
@@ -1,0 +1,12 @@
+"""Compatibility shim: ``app.models.users`` -> canonical ``app.models``.
+
+The ``app.compliance.*`` package imports ``User`` from ``app.models.users``
+(plural), but the model lives in ``app.models`` (``app/models/__init__.py``).
+This mirrors the existing ``app.models.user`` (singular) backward-compat module
+and unblocks the compliance imports without moving the model. New code should
+import ``User`` from ``app.models`` directly.
+"""
+
+from app.models import Organization, OrganizationMember, Session, User, UserStatus
+
+__all__ = ["User", "Session", "UserStatus", "Organization", "OrganizationMember"]

--- a/apps/api/app/routers/v1/mfa.py
+++ b/apps/api/app/routers/v1/mfa.py
@@ -14,6 +14,7 @@ import jwt as pyjwt
 import pyotp
 import qrcode
 from fastapi import APIRouter, Depends, HTTPException, Request
+from passlib.context import CryptContext
 from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -100,6 +101,79 @@ def generate_backup_codes(count: int = 10) -> List[str]:
     return codes
 
 
+# ── Backup-code hashing (2026-08-23 security fix) ──────────────────────────────
+# Backup codes were stored PLAINTEXT in mfa_backup_codes (a P0). They are secrets
+# equivalent to a second factor, so they are now hashed at rest with the same
+# bcrypt primitive the platform uses for passwords, and compared in constant time.
+# A dedicated context here keeps this independent of the legacy beta_auth module.
+_backup_code_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def _normalize_backup_code(code: str) -> str:
+    """Canonical form for hashing/compare: strip dashes, uppercase, trim."""
+    return code.replace("-", "").strip().upper()
+
+
+def hash_backup_code(code: str) -> str:
+    """Hash a backup code for at-rest storage (bcrypt over the normalized form)."""
+    return _backup_code_context.hash(_normalize_backup_code(code))
+
+
+def _entry_matches_code(entry: dict, code: str) -> bool:
+    """Constant-time-ish match of a submitted code against ONE stored entry.
+
+    Backward compatible: new entries carry {"hash": ...}; legacy rows may still
+    carry {"code": <plaintext>} (or a bare string). Both are accepted so existing
+    users are not locked out; the legacy plaintext path is removed as codes are
+    regenerated. Does NOT consult the `used` flag — callers do (see
+    consume_backup_code) so the "used" policy is enforced in exactly one place.
+    """
+    normalized = _normalize_backup_code(code)
+    if isinstance(entry, dict):
+        stored_hash = entry.get("hash")
+        if stored_hash:
+            try:
+                return _backup_code_context.verify(normalized, stored_hash)
+            except Exception:
+                return False
+        # Legacy plaintext entry (pre-2026-08-23) — compare normalized forms.
+        legacy = entry.get("code")
+        if legacy is not None:
+            return secrets.compare_digest(_normalize_backup_code(legacy), normalized)
+        return False
+    # Bare-string legacy entry.
+    return secrets.compare_digest(_normalize_backup_code(str(entry)), normalized)
+
+
+def consume_backup_code(user: "User", code: str) -> bool:
+    """Verify a backup code against the user's UNUSED codes and consume it.
+
+    Returns True and marks the matching entry used (mutating user.mfa_backup_codes
+    in place) if a valid, not-yet-used code is found; False otherwise. This is the
+    ONE place backup codes are validated for login/verify, so the single-use and
+    hashing rules cannot drift between call sites (the prior code re-implemented
+    this 4× and one site — disable_mfa — ignored the `used` flag entirely).
+    """
+    entries = user.mfa_backup_codes
+    if not entries or not isinstance(entries, list):
+        return False
+    for i, entry in enumerate(entries):
+        is_used = entry.get("used", False) if isinstance(entry, dict) else False
+        if is_used:
+            continue
+        if _entry_matches_code(entry, code):
+            # Normalize the entry to the current dict shape and mark consumed.
+            user.mfa_backup_codes[i] = {
+                **(entry if isinstance(entry, dict) else {}),
+                "used": True,
+                "used_at": datetime.utcnow().isoformat(),
+            }
+            # Drop any lingering plaintext from a legacy entry now that it's spent.
+            user.mfa_backup_codes[i].pop("code", None)
+            return True
+    return False
+
+
 def generate_qr_code(provisioning_uri: str) -> str:
     """Generate QR code as base64 encoded image"""
     qr = qrcode.QRCode(
@@ -180,9 +254,10 @@ async def enable_mfa(
     # Generate backup codes
     backup_codes = generate_backup_codes()
 
-    # Store backup codes with metadata
+    # Store backup codes HASHED (2026-08-23 security fix) — the plaintext is
+    # returned to the user ONCE in the response below and never persisted.
     backup_codes_data = [
-        {"code": code, "used": False, "created_at": datetime.utcnow().isoformat()}
+        {"hash": hash_backup_code(code), "used": False, "created_at": datetime.utcnow().isoformat()}
         for code in backup_codes
     ]
 
@@ -265,21 +340,10 @@ async def disable_mfa(
         totp_valid = totp.verify(request.code, valid_window=1)
 
         if not totp_valid:
-            # Try backup code
-            backup_valid = False
-            if current_user.mfa_backup_codes:
-                for i, backup_data in enumerate(current_user.mfa_backup_codes):
-                    if isinstance(backup_data, dict):
-                        stored_code = backup_data.get("code", "")
-                    else:
-                        stored_code = backup_data
-
-                    # Remove dashes for comparison
-                    if stored_code.replace("-", "") == request.code.replace("-", ""):
-                        backup_valid = True
-                        break
-
-            if not backup_valid:
+            # Try backup code — hashed compare + single-use enforced via the one
+            # shared helper (the prior inline check here ignored the `used` flag,
+            # so a spent backup code could still disable MFA — 2026-08-23 fix).
+            if not consume_backup_code(current_user, request.code):
                 raise HTTPException(status_code=400, detail="Invalid verification code")
 
     # Disable MFA
@@ -312,9 +376,9 @@ async def regenerate_backup_codes(
     # Generate new backup codes
     backup_codes = generate_backup_codes()
 
-    # Store backup codes with metadata
+    # Store HASHED (2026-08-23 security fix); plaintext returned once below.
     backup_codes_data = [
-        {"code": code, "used": False, "created_at": datetime.utcnow().isoformat()}
+        {"hash": hash_backup_code(code), "used": False, "created_at": datetime.utcnow().isoformat()}
         for code in backup_codes
     ]
 
@@ -354,40 +418,16 @@ async def validate_mfa_code(
 
         return {"valid": True, "message": "Code is valid"}
 
-    # Try backup code
-    if current_user.mfa_backup_codes:
-        for i, backup_data in enumerate(current_user.mfa_backup_codes):
-            if isinstance(backup_data, dict):
-                stored_code = backup_data.get("code", "")
-                is_used = backup_data.get("used", False)
-            else:
-                stored_code = backup_data
-                is_used = False
-
-            # Remove dashes for comparison
-            if not is_used and stored_code.replace("-", "") == code.replace("-", ""):
-                # Mark backup code as used
-                if isinstance(backup_data, dict):
-                    current_user.mfa_backup_codes[i]["used"] = True
-                    current_user.mfa_backup_codes[i]["used_at"] = datetime.utcnow().isoformat()
-                else:
-                    # Convert to dict format
-                    current_user.mfa_backup_codes[i] = {
-                        "code": stored_code,
-                        "used": True,
-                        "used_at": datetime.utcnow().isoformat(),
-                    }
-
-                # Log backup code usage
-                activity = ActivityLog(
-                    user_id=current_user.id,
-                    action="mfa_backup_code_used",
-                    details={"code_index": i},
-                )
-                db.add(activity)
-                await db.commit()
-
-                return {"valid": True, "message": "Backup code is valid (now consumed)"}
+    # Try backup code — hashed compare + single-use via the one shared helper.
+    if consume_backup_code(current_user, code):
+        activity = ActivityLog(
+            user_id=current_user.id,
+            action="mfa_backup_code_used",
+            details={"context": "validate-code"},
+        )
+        db.add(activity)
+        await db.commit()
+        return {"valid": True, "message": "Backup code is valid (now consumed)"}
 
     return {"valid": False, "message": "Invalid code"}
 
@@ -566,31 +606,16 @@ async def verify_mfa_challenge(
     totp = pyotp.TOTP(user.mfa_secret)
     code_valid = totp.verify(request_data.code, valid_window=1)
 
-    # If TOTP failed, try backup codes
-    if not code_valid and user.mfa_backup_codes:
-        for i, backup_data in enumerate(user.mfa_backup_codes):
-            if isinstance(backup_data, dict):
-                stored_code = backup_data.get("code", "")
-                is_used = backup_data.get("used", False)
-            else:
-                stored_code = backup_data
-                is_used = False
-
-            if not is_used and stored_code.replace("-", "") == request_data.code.replace("-", ""):
-                # Mark backup code as used
-                if isinstance(backup_data, dict):
-                    user.mfa_backup_codes[i]["used"] = True
-                    user.mfa_backup_codes[i]["used_at"] = datetime.utcnow().isoformat()
-
-                # Log backup code usage
-                activity = ActivityLog(
-                    user_id=user.id,
-                    action="mfa_backup_code_used",
-                    details={"code_index": i, "context": "signin"},
-                )
-                db.add(activity)
-                code_valid = True
-                break
+    # If TOTP failed, try backup codes — hashed compare + single-use via the one
+    # shared helper (2026-08-23 fix; was an inline plaintext loop).
+    if not code_valid and consume_backup_code(user, request_data.code):
+        activity = ActivityLog(
+            user_id=user.id,
+            action="mfa_backup_code_used",
+            details={"context": "signin"},
+        )
+        db.add(activity)
+        code_valid = True
 
     if not code_valid:
         raise HTTPException(status_code=401, detail="Invalid MFA code")

--- a/apps/api/app/routers/v1/migration.py
+++ b/apps/api/app/routers/v1/migration.py
@@ -2,9 +2,10 @@
 Migration API endpoints for data portability and user migration
 """
 
-import asyncio
 import json
 import logging
+import os
+import tempfile
 import uuid
 from typing import Any, Dict, List, Optional
 
@@ -34,6 +35,19 @@ router = APIRouter(
     tags=["Migration"],
     responses={404: {"description": "Not found"}},
 )
+
+# Directory where generated bulk-export artifacts are written. Governed by the
+# canonical ``settings.DATA_EXPORT_PATH`` config (default
+# ``/var/compliance/exports``); a ``DATA_EXPORT_DIR`` env var override is
+# honored for environments where that path is not writable (dev/test).
+try:
+    from app.config import settings as _export_settings
+
+    _DEFAULT_EXPORT_DIR = _export_settings.DATA_EXPORT_PATH
+except Exception:  # pragma: no cover - settings always import in practice
+    _DEFAULT_EXPORT_DIR = os.path.join(tempfile.gettempdir(), "janua-data-exports")
+
+_EXPORT_DIR = os.environ.get("DATA_EXPORT_DIR", _DEFAULT_EXPORT_DIR)
 
 
 # Pydantic models
@@ -158,9 +172,9 @@ async def list_migration_jobs(
                 skipped_users=job.skipped_users,
                 started_at=job.started_at.isoformat() if job.started_at else None,
                 completed_at=job.completed_at.isoformat() if job.completed_at else None,
-                estimated_completion=job.estimated_completion.isoformat()
-                if job.estimated_completion
-                else None,
+                estimated_completion=(
+                    job.estimated_completion.isoformat() if job.estimated_completion else None
+                ),
                 last_error=job.last_error,
                 created_at=job.created_at.isoformat(),
                 updated_at=job.updated_at.isoformat(),
@@ -200,9 +214,9 @@ async def get_migration_job(
             skipped_users=job.skipped_users,
             started_at=job.started_at.isoformat() if job.started_at else None,
             completed_at=job.completed_at.isoformat() if job.completed_at else None,
-            estimated_completion=job.estimated_completion.isoformat()
-            if job.estimated_completion
-            else None,
+            estimated_completion=(
+                job.estimated_completion.isoformat() if job.estimated_completion else None
+            ),
             last_error=job.last_error,
             created_at=job.created_at.isoformat(),
             updated_at=job.updated_at.isoformat(),
@@ -470,22 +484,38 @@ async def _process_data_export(
     organization_id: Optional[str],
     user_id: str,
 ):
-    """Background task to process data export"""
+    """Background task that produces a real, downloadable export artifact.
+
+    Serializes the requested users / organization data / audit logs (honoring
+    ``export_type`` and ``format``) via the migration service and writes the
+    bytes to ``_EXPORT_DIR/{export_id}.{format}``. The serializer excludes all
+    secret material (password hashes, MFA seeds, tokens, credential keys).
+
+    Returns the artifact path so callers/tests can locate it; the background
+    scheduler ignores the return value.
+    """
     try:
-        # Implementation would collect and export data
-        # This is a placeholder for the actual export logic
-        logger.info(f"Processing data export {export_id}")
+        logger.info("Processing data export %s", export_id)
 
-        # Simulate export processing
-        await asyncio.sleep(5)
+        payload = await migration_service.export_users(
+            organization_id,
+            format=export_request.format,
+            export_type=export_request.export_type,
+            session=db,
+        )
 
-        # Update export status in database
-        # In real implementation, would create DataExport record
+        os.makedirs(_EXPORT_DIR, exist_ok=True)
+        fmt = (export_request.format or "json").lower()
+        path = os.path.join(_EXPORT_DIR, f"{export_id}.{fmt}")
+        with open(path, "wb") as handle:
+            handle.write(payload)
 
-        logger.info(f"Data export {export_id} completed")
+        logger.info("Data export %s completed (%d bytes)", export_id, len(payload))
+        return path
 
     except Exception:
-        logger.exception(f"Data export {export_id} failed")
+        logger.exception("Data export %s failed", export_id)
+        return None
 
 
 @router.get("/providers")

--- a/apps/api/app/services/compliance_service.py
+++ b/apps/api/app/services/compliance_service.py
@@ -28,6 +28,10 @@ from app.models.compliance import (
     RequestStatus,
 )
 from app.services.audit_logger import AuditEventType, AuditLogger
+from app.services.data_export_serializer import (
+    assert_no_secrets,
+    collect_user_export_data,
+)
 
 
 class ConsentService:
@@ -333,7 +337,22 @@ class DataSubjectRightsService:
         if not user:
             raise ValueError("User not found")
 
-        # Compile user data export
+        # Gather the complete, real user data set across every identity model
+        # (profile, org memberships, sessions, MFA/passkey metadata, OAuth
+        # grants/accounts, audit logs). The serializer excludes all secret
+        # material (password hashes, MFA seeds, tokens, credential keys) by
+        # construction.
+        export = await collect_user_export_data(
+            self.db,
+            str(user.id),
+            include_audit_logs=True,
+            date_range_start=request.date_range_start,
+            date_range_end=request.date_range_end,
+        )
+
+        # Preserve the historical response shape (personal_information +
+        # consent_records + privacy_settings) while layering in the full
+        # export sections produced by the serializer.
         user_data = {
             "personal_information": {
                 "id": str(user.id),
@@ -349,7 +368,14 @@ class DataSubjectRightsService:
             "consent_records": [],
             "privacy_settings": {},
             "data_subject_requests": [],
-            "audit_logs": [],
+            "export_metadata": export.get("export_metadata", {}),
+            "profile": export.get("user", {}),
+            "organization_memberships": export.get("organization_memberships", []),
+            "oauth_grants": export.get("oauth_grants", []),
+            "linked_accounts": export.get("linked_accounts", []),
+            "security": export.get("security", {}),
+            "sessions": export.get("sessions", []),
+            "audit_logs": export.get("audit_logs", []),
         }
 
         # Get consent records
@@ -395,6 +421,10 @@ class DataSubjectRightsService:
         request.response_method = "api"
 
         await self.db.commit()
+
+        # Defensive guard: never return an export that carries secret-like
+        # fields (password hashes, MFA seeds, tokens, credential keys).
+        assert_no_secrets(user_data)
 
         return user_data
 

--- a/apps/api/app/services/data_export_serializer.py
+++ b/apps/api/app/services/data_export_serializer.py
@@ -44,7 +44,11 @@ from datetime import date, datetime
 from decimal import Decimal
 from enum import Enum
 from typing import Any, Dict, Iterable, List, Optional, Sequence
-from xml.sax.saxutils import escape as _xml_escape
+# nosec B406 — we import ONLY saxutils.escape, and use it solely to ENCODE our
+# own export values into XML output (see _to_xml); we never parse untrusted XML,
+# which is what B406/defusedxml guards against. Escaping on output is the correct,
+# injection-safe use of this helper.
+from xml.sax.saxutils import escape as _xml_escape  # nosec B406
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession

--- a/apps/api/app/services/data_export_serializer.py
+++ b/apps/api/app/services/data_export_serializer.py
@@ -1,0 +1,710 @@
+"""Canonical data-export serialization for GDPR/portability requests.
+
+This module is the single source of truth for turning Janua's identity data
+into a portable, machine-readable artifact for two consumers:
+
+1. Per-user GDPR export (Articles 15 / 20) via the compliance data-subject
+   request flow (:mod:`app.services.compliance_service` and
+   :mod:`app.compliance.privacy.data_subject_handler`).
+2. Admin bulk/tenant export via :mod:`app.services.migration_service`.
+
+Security contract (non-negotiable)
+----------------------------------
+Janua is an identity provider. An export is portability *without* leaking
+credentials. Every serializer here works from an explicit **allowlist** of
+fields per model: a column is exported only if it is named in the allowlist.
+Nothing is copied by iterating ``__table__.columns`` and hoping a denylist
+catches the secrets. On top of the allowlist we keep a defensive
+:data:`SECRET_FIELD_NAMES` denylist and a :func:`assert_no_secrets` auditor
+that callers (and tests) can use to prove an artifact is clean.
+
+Secret material that MUST NEVER appear in an export:
+
+* ``password_hash`` (user credential)
+* ``mfa_secret`` / TOTP seeds and ``mfa_backup_codes``
+* session ``token`` / ``refresh_token`` and their JTIs
+* OAuth ``access_token`` / ``refresh_token`` (provider credentials)
+* OAuth client ``client_secret_hash`` / ``secret_hash`` and prefixes
+* passkey ``public_key`` (credential material) — only metadata is exported
+* webhook ``secret`` and email/reset/verification ``token`` values
+
+For MFA, passkeys and OAuth we export *metadata* ("MFA is enabled",
+"a passkey named 'MacBook' exists", "linked to GitHub") so the export is
+useful for portability without handing over anything that authenticates.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import uuid
+import zipfile
+from datetime import date, datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+from xml.sax.saxutils import escape as _xml_escape
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models import (
+    AuditLog,
+    OAuthAccount,
+    Organization,
+    OrganizationMember,
+    Passkey,
+    Session,
+    User,
+    UserConsent,
+)
+
+# ---------------------------------------------------------------------------
+# Secret denylist (defensive second layer; the allowlists below are primary)
+# ---------------------------------------------------------------------------
+
+#: Field / attribute names that must never be serialized into an export.
+#: Matching is case-insensitive and substring-based via :func:`_is_secret_key`
+#: so ``password_hash`` and ``hashed_password`` are both caught.
+SECRET_FIELD_NAMES: frozenset = frozenset(
+    {
+        "password",
+        "password_hash",
+        "hashed_password",
+        "mfa_secret",
+        "totp_secret",
+        "mfa_backup_codes",
+        "backup_codes",
+        "recovery_codes",
+        "token",
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "access_token_jti",
+        "refresh_token_jti",
+        "session_token",
+        "client_secret",
+        "client_secret_hash",
+        "client_secret_prefix",
+        "secret",
+        "secret_hash",
+        "secret_prefix",
+        "public_key",
+        "private_key",
+        "signing_key",
+        "api_key",
+        "encryption_key",
+    }
+)
+
+#: Substrings that flag a field name as secret regardless of the exact column
+#: name (covers future columns like ``webhook_secret`` or ``totp_seed``).
+_SECRET_SUBSTRINGS: Sequence[str] = (
+    "password",
+    "secret",
+    "private_key",
+    "backup_code",
+    "recovery_code",
+    "totp",
+    "mfa_secret",
+    "seed",
+)
+
+#: Field names that are legitimately safe even though they contain a secret
+#: substring (e.g. a boolean flag or a non-sensitive identifier).
+_SECRET_ALLOWLIST_OVERRIDES: frozenset = frozenset(
+    {
+        "mfa_enabled",  # boolean flag, not the seed
+    }
+)
+
+
+def _is_secret_key(key: str) -> bool:
+    """Return True if a field name looks like secret/credential material."""
+    lowered = key.lower()
+    if lowered in _SECRET_ALLOWLIST_OVERRIDES:
+        return False
+    if lowered in SECRET_FIELD_NAMES:
+        return True
+    return any(sub in lowered for sub in _SECRET_SUBSTRINGS)
+
+
+# ---------------------------------------------------------------------------
+# Per-model allowlists (primary defense: only these columns are ever emitted)
+# ---------------------------------------------------------------------------
+
+#: Non-sensitive User columns safe to export. Deliberately excludes
+#: password_hash, mfa_secret, mfa_backup_codes.
+USER_EXPORT_FIELDS: Sequence[str] = (
+    "id",
+    "email",
+    "email_verified",
+    "email_verified_at",
+    "status",
+    "first_name",
+    "last_name",
+    "username",
+    "phone",
+    "phone_number",
+    "phone_verified",
+    "avatar_url",
+    "profile_image_url",
+    "display_name",
+    "bio",
+    "timezone",
+    "locale",
+    "spanish_formality",
+    "user_metadata",
+    "tenant_id",
+    "is_active",
+    "is_admin",
+    "mfa_enabled",  # flag only
+    "last_login",
+    "last_sign_in_at",
+    "created_at",
+    "updated_at",
+)
+
+ORGANIZATION_EXPORT_FIELDS: Sequence[str] = (
+    "id",
+    "name",
+    "slug",
+    "subscription_tier",
+    "product_tiers",
+    "billing_plan",
+    "billing_email",
+    "description",
+    "logo_url",
+    "created_at",
+    "updated_at",
+)
+
+MEMBERSHIP_EXPORT_FIELDS: Sequence[str] = (
+    "id",
+    "organization_id",
+    "role",
+    "status",
+    "joined_at",
+    "created_at",
+    "updated_at",
+)
+
+#: Session metadata only — NEVER token / refresh_token / *_jti.
+SESSION_EXPORT_FIELDS: Sequence[str] = (
+    "id",
+    "ip_address",
+    "user_agent",
+    "device_name",
+    "device_fingerprint",
+    "is_active",
+    "revoked",
+    "revoked_at",
+    "revoked_reason",
+    "is_trusted_device",
+    "expires_at",
+    "last_activity",
+    "created_at",
+)
+
+#: OAuth linkage metadata only — NEVER access_token / refresh_token.
+OAUTH_ACCOUNT_EXPORT_FIELDS: Sequence[str] = (
+    "id",
+    "provider",
+    "provider_user_id",
+    "provider_email",
+    "token_expires_at",
+    "created_at",
+    "updated_at",
+)
+
+#: OAuth grant/consent records (scopes the user approved for a client).
+OAUTH_GRANT_EXPORT_FIELDS: Sequence[str] = (
+    "id",
+    "client_id",
+    "scopes",
+    "granted_at",
+    "expires_at",
+    "revoked_at",
+    "created_at",
+    "updated_at",
+)
+
+#: Passkey metadata only — NEVER public_key / credential material export.
+PASSKEY_EXPORT_FIELDS: Sequence[str] = (
+    "id",
+    "name",
+    "authenticator_attachment",
+    "sign_count",
+    "created_at",
+    "last_used_at",
+)
+
+AUDIT_LOG_EXPORT_FIELDS: Sequence[str] = (
+    "id",
+    "action",
+    "resource_type",
+    "resource_id",
+    "details",
+    "ip_address",
+    "user_agent",
+    "created_at",
+)
+
+
+# ---------------------------------------------------------------------------
+# JSON-safe value coercion
+# ---------------------------------------------------------------------------
+
+
+def _coerce(value: Any) -> Any:
+    """Coerce a SQLAlchemy column value into a JSON-serializable form."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, uuid.UUID):
+        return str(value)
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, (list, tuple)):
+        return [_coerce(v) for v in value]
+    if isinstance(value, dict):
+        return {str(k): _coerce(v) for k, v in value.items()}
+    # Fallback: stringify unknown types rather than risk leaking a repr with
+    # embedded credentials from an unexpected object.
+    return str(value)
+
+
+def _row_to_dict(instance: Any, fields: Sequence[str]) -> Dict[str, Any]:
+    """Project an ORM instance onto an allowlist of fields, secret-checked.
+
+    Even though ``fields`` is a curated allowlist, we re-assert that no field
+    name is secret. This makes it impossible to widen an allowlist to include
+    a credential column without :func:`assert_no_secrets` failing loudly.
+    """
+    out: Dict[str, Any] = {}
+    for field in fields:
+        if _is_secret_key(field):
+            # Defensive: a curated list should never contain a secret field.
+            raise ValueError(
+                f"Refusing to export secret-like field '{field}' from " f"{type(instance).__name__}"
+            )
+        out[field] = _coerce(getattr(instance, field, None))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Collection: gather a single user's exportable data
+# ---------------------------------------------------------------------------
+
+
+async def collect_user_export_data(
+    session: AsyncSession,
+    user_id: str,
+    *,
+    include_audit_logs: bool = True,
+    date_range_start: Optional[datetime] = None,
+    date_range_end: Optional[datetime] = None,
+    portable_only: bool = False,
+) -> Dict[str, Any]:
+    """Gather all exportable data for ``user_id`` from the real models.
+
+    Parameters
+    ----------
+    session:
+        Active async DB session.
+    user_id:
+        Subject user id (str or UUID-compatible string).
+    include_audit_logs:
+        Include the user's audit-log entries (Article 15). Skipped for the
+        strict Article 20 portability subset when ``portable_only`` is set.
+    date_range_start / date_range_end:
+        Optional filter applied to audit-log ``created_at``.
+    portable_only:
+        When True, restrict the export to data the user actively provided
+        (profile, org memberships, OAuth grants) per GDPR Article 20's
+        narrower "data provided by the data subject" scope, and omit
+        server-generated telemetry like sessions and audit logs.
+
+    Returns
+    -------
+    dict
+        A JSON-serializable structure. Contains no secret material.
+    """
+    uid = uuid.UUID(str(user_id))
+
+    user = (await session.execute(select(User).where(User.id == uid))).scalar_one_or_none()
+    if user is None:
+        raise ValueError(f"User not found: {user_id}")
+
+    export: Dict[str, Any] = {
+        "export_metadata": {
+            "schema_version": "1.0",
+            "generated_at": datetime.utcnow().isoformat() + "Z",
+            "subject_user_id": str(uid),
+            "article": "GDPR Article 20" if portable_only else "GDPR Article 15",
+            "portable_only": portable_only,
+            "excludes": [
+                "password hashes",
+                "MFA secrets and backup codes",
+                "session and OAuth tokens",
+                "passkey / client credential material",
+            ],
+        },
+        "user": _row_to_dict(user, USER_EXPORT_FIELDS),
+    }
+
+    # --- Organization memberships (+ light org profile) ---------------------
+    memberships = (
+        (await session.execute(select(OrganizationMember).where(OrganizationMember.user_id == uid)))
+        .scalars()
+        .all()
+    )
+    membership_records: List[Dict[str, Any]] = []
+    org_ids = {m.organization_id for m in memberships if m.organization_id is not None}
+    orgs_by_id: Dict[Any, Organization] = {}
+    if org_ids:
+        orgs = (
+            (await session.execute(select(Organization).where(Organization.id.in_(org_ids))))
+            .scalars()
+            .all()
+        )
+        orgs_by_id = {o.id: o for o in orgs}
+    for member in memberships:
+        record = _row_to_dict(member, MEMBERSHIP_EXPORT_FIELDS)
+        org = orgs_by_id.get(member.organization_id)
+        record["organization"] = (
+            _row_to_dict(org, ORGANIZATION_EXPORT_FIELDS) if org is not None else None
+        )
+        membership_records.append(record)
+    export["organization_memberships"] = membership_records
+
+    # --- OAuth grants (client consents) ------------------------------------
+    grants = (
+        (await session.execute(select(UserConsent).where(UserConsent.user_id == uid)))
+        .scalars()
+        .all()
+    )
+    export["oauth_grants"] = [_row_to_dict(g, OAUTH_GRANT_EXPORT_FIELDS) for g in grants]
+
+    # --- Linked OAuth / social accounts (metadata only) --------------------
+    oauth_accounts = (
+        (await session.execute(select(OAuthAccount).where(OAuthAccount.user_id == uid)))
+        .scalars()
+        .all()
+    )
+    export["linked_accounts"] = [
+        _row_to_dict(a, OAUTH_ACCOUNT_EXPORT_FIELDS) for a in oauth_accounts
+    ]
+
+    # --- MFA / passkey enrollment (metadata only, no secrets) --------------
+    passkeys = (
+        (await session.execute(select(Passkey).where(Passkey.user_id == uid))).scalars().all()
+    )
+    export["security"] = {
+        "mfa_enabled": bool(user.mfa_enabled),
+        "mfa_methods": (["totp"] if user.mfa_enabled else []),
+        "passkeys": [_row_to_dict(p, PASSKEY_EXPORT_FIELDS) for p in passkeys],
+        "note": (
+            "TOTP seeds, MFA backup codes and passkey public keys are "
+            "intentionally excluded as credential material."
+        ),
+    }
+
+    if portable_only:
+        # Article 20 subset: omit server-generated telemetry.
+        return export
+
+    # --- Sessions (metadata only, no tokens) -------------------------------
+    sessions = (
+        (await session.execute(select(Session).where(Session.user_id == uid))).scalars().all()
+    )
+    export["sessions"] = [_row_to_dict(s, SESSION_EXPORT_FIELDS) for s in sessions]
+
+    # --- Audit-log entries for this user -----------------------------------
+    if include_audit_logs:
+        audit_stmt = select(AuditLog).where(AuditLog.user_id == uid)
+        if date_range_start is not None:
+            audit_stmt = audit_stmt.where(AuditLog.created_at >= date_range_start)
+        if date_range_end is not None:
+            audit_stmt = audit_stmt.where(AuditLog.created_at <= date_range_end)
+        audit_stmt = audit_stmt.order_by(AuditLog.created_at.desc())
+        audit_entries = (await session.execute(audit_stmt)).scalars().all()
+        export["audit_logs"] = [_row_to_dict(a, AUDIT_LOG_EXPORT_FIELDS) for a in audit_entries]
+
+    return export
+
+
+# ---------------------------------------------------------------------------
+# Collection: gather a tenant/organization's users (admin bulk export)
+# ---------------------------------------------------------------------------
+
+
+async def collect_organization_users(
+    session: AsyncSession,
+    organization_id: Optional[str],
+    *,
+    export_type: str = "user_data",
+    include_audit_logs: bool = False,
+) -> Dict[str, Any]:
+    """Gather users (and optionally audit logs) for an admin bulk export.
+
+    Parameters
+    ----------
+    organization_id:
+        Restrict to members of this organization. When ``None``, export all
+        users (whole-tenant / instance export).
+    export_type:
+        One of ``user_data`` (default), ``organization_data`` (users grouped
+        under their org profile), or ``audit_logs`` (audit entries only).
+    include_audit_logs:
+        Force-include audit logs regardless of ``export_type``.
+    """
+    org_uuid = uuid.UUID(str(organization_id)) if organization_id else None
+
+    # Resolve the user set (scoped to an org when requested).
+    if org_uuid is not None:
+        member_rows = (
+            (
+                await session.execute(
+                    select(OrganizationMember.user_id).where(
+                        OrganizationMember.organization_id == org_uuid
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        member_ids = list({uid for uid in member_rows if uid is not None})
+        users = (
+            (await session.execute(select(User).where(User.id.in_(member_ids)))).scalars().all()
+            if member_ids
+            else []
+        )
+    else:
+        users = (await session.execute(select(User))).scalars().all()
+
+    result: Dict[str, Any] = {
+        "export_metadata": {
+            "schema_version": "1.0",
+            "generated_at": datetime.utcnow().isoformat() + "Z",
+            "export_type": export_type,
+            "organization_id": str(org_uuid) if org_uuid else None,
+            "record_count": len(users),
+            "excludes": [
+                "password hashes",
+                "MFA secrets and backup codes",
+                "session and OAuth tokens",
+                "passkey / client credential material",
+            ],
+        }
+    }
+
+    if export_type == "audit_logs" or include_audit_logs:
+        user_ids = [u.id for u in users]
+        audit_stmt = select(AuditLog)
+        if org_uuid is not None:
+            # Scope audit logs to the resolved user set for an org export.
+            audit_stmt = audit_stmt.where(AuditLog.user_id.in_(user_ids or [uuid.uuid4()]))
+        audit_stmt = audit_stmt.order_by(AuditLog.created_at.desc())
+        audit_entries = (await session.execute(audit_stmt)).scalars().all()
+        result["audit_logs"] = [_row_to_dict(a, AUDIT_LOG_EXPORT_FIELDS) for a in audit_entries]
+        if export_type == "audit_logs":
+            return result
+
+    if export_type == "organization_data":
+        # Group users under organization profiles.
+        orgs_stmt = select(Organization)
+        if org_uuid is not None:
+            orgs_stmt = orgs_stmt.where(Organization.id == org_uuid)
+        orgs = (await session.execute(orgs_stmt)).scalars().all()
+        result["organizations"] = [_row_to_dict(o, ORGANIZATION_EXPORT_FIELDS) for o in orgs]
+
+    result["users"] = [_row_to_dict(u, USER_EXPORT_FIELDS) for u in users]
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Serialization to bytes (json / csv / xml) and downloadable artifacts
+# ---------------------------------------------------------------------------
+
+
+def _flatten_users_for_tabular(data: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Extract the user rows from a bulk/user export for CSV/XML output."""
+    if "users" in data and isinstance(data["users"], list):
+        return data["users"]
+    if "user" in data and isinstance(data["user"], dict):
+        return [data["user"]]
+    return []
+
+
+def serialize_export(data: Dict[str, Any], export_format: str = "json") -> bytes:
+    """Serialize a collected export dict to bytes in the requested format.
+
+    JSON is the canonical, lossless format. CSV and XML flatten the user
+    records (the portable core) for interoperability with spreadsheet /
+    legacy tooling; nested structures are JSON-encoded within cells so no
+    data is silently dropped.
+    """
+    fmt = (export_format or "json").lower()
+
+    if fmt == "json":
+        return json.dumps(data, indent=2, ensure_ascii=False, sort_keys=False).encode("utf-8")
+
+    if fmt == "csv":
+        rows = _flatten_users_for_tabular(data)
+        buffer = io.StringIO()
+        if rows:
+            # Union of keys preserves first-seen order for stable columns.
+            fieldnames: List[str] = []
+            for row in rows:
+                for key in row:
+                    if key not in fieldnames:
+                        fieldnames.append(key)
+            writer = csv.DictWriter(buffer, fieldnames=fieldnames, extrasaction="ignore")
+            writer.writeheader()
+            for row in rows:
+                writer.writerow(
+                    {
+                        key: (
+                            json.dumps(value, ensure_ascii=False)
+                            if isinstance(value, (dict, list))
+                            else value
+                        )
+                        for key, value in row.items()
+                    }
+                )
+        return buffer.getvalue().encode("utf-8")
+
+    if fmt == "xml":
+        return _to_xml(data).encode("utf-8")
+
+    raise ValueError(f"Unsupported export format: {export_format}")
+
+
+def _to_xml(data: Any, root_tag: str = "export") -> str:
+    """Render a nested dict/list into a minimal, well-formed XML document."""
+
+    def render(value: Any, tag: str) -> str:
+        safe_tag = _xml_tag(tag)
+        if isinstance(value, dict):
+            inner = "".join(render(v, k) for k, v in value.items())
+            return f"<{safe_tag}>{inner}</{safe_tag}>"
+        if isinstance(value, (list, tuple)):
+            inner = "".join(render(item, "item") for item in value)
+            return f"<{safe_tag}>{inner}</{safe_tag}>"
+        if value is None:
+            return f"<{safe_tag}/>"
+        return f"<{safe_tag}>{_xml_escape(str(value))}</{safe_tag}>"
+
+    body = render(data, root_tag)
+    return f'<?xml version="1.0" encoding="UTF-8"?>{body}'
+
+
+def _xml_tag(tag: str) -> str:
+    """Sanitize a dict key into a valid XML tag name."""
+    cleaned = "".join(ch if (ch.isalnum() or ch in "-_.") else "_" for ch in str(tag))
+    if not cleaned or not (cleaned[0].isalpha() or cleaned[0] == "_"):
+        cleaned = f"_{cleaned}"
+    return cleaned
+
+
+def build_export_archive(
+    data: Dict[str, Any],
+    *,
+    manifest_name: str = "export.json",
+    section_files: bool = True,
+) -> bytes:
+    """Build a zip archive containing the export as JSON files.
+
+    The archive always contains ``manifest_name`` with the full export. When
+    ``section_files`` is set, each top-level section is also written as its
+    own JSON file for easier consumption (e.g. ``audit_logs.json``).
+    """
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(
+            manifest_name,
+            json.dumps(data, indent=2, ensure_ascii=False).encode("utf-8"),
+        )
+        if section_files:
+            for key, value in data.items():
+                if key == "export_metadata":
+                    continue
+                archive.writestr(
+                    f"{key}.json",
+                    json.dumps(value, indent=2, ensure_ascii=False).encode("utf-8"),
+                )
+    return buffer.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Secret auditor — usable by callers and tests to prove an artifact is clean
+# ---------------------------------------------------------------------------
+
+
+def find_secret_fields(data: Any, _path: str = "") -> List[str]:
+    """Recursively find any secret-like *keys* in a nested structure.
+
+    Returns a list of dotted paths for offending keys. An empty list means the
+    structure carries no fields whose name indicates credential material.
+    """
+    found: List[str] = []
+    if isinstance(data, dict):
+        for key, value in data.items():
+            here = f"{_path}.{key}" if _path else str(key)
+            if _is_secret_key(str(key)):
+                found.append(here)
+            found.extend(find_secret_fields(value, here))
+    elif isinstance(data, (list, tuple)):
+        for index, item in enumerate(data):
+            found.extend(find_secret_fields(item, f"{_path}[{index}]"))
+    return found
+
+
+def assert_no_secrets(data: Any) -> None:
+    """Raise ``ValueError`` if ``data`` contains any secret-like field names."""
+    offenders = find_secret_fields(data)
+    if offenders:
+        raise ValueError(
+            "Export contains secret-like fields that must not be serialized: "
+            + ", ".join(sorted(offenders))
+        )
+
+
+def contains_secret_values(data: Any, secrets: Iterable[str]) -> Optional[str]:
+    """Return the first sentinel secret value found anywhere in ``data``.
+
+    Used primarily by tests: seed models with known sentinel secret strings,
+    serialize, and assert none of the sentinels survive into the artifact.
+    ``None`` means no sentinel leaked.
+    """
+    needles = [s for s in secrets if s]
+
+    def walk(value: Any) -> Optional[str]:
+        if isinstance(value, str):
+            for needle in needles:
+                if needle in value:
+                    return needle
+            return None
+        if isinstance(value, dict):
+            for key, item in value.items():
+                if isinstance(key, str):
+                    for needle in needles:
+                        if needle in key:
+                            return needle
+                hit = walk(item)
+                if hit:
+                    return hit
+            return None
+        if isinstance(value, (list, tuple)):
+            for item in value:
+                hit = walk(item)
+                if hit:
+                    return hit
+        return None
+
+    return walk(data)

--- a/apps/api/app/services/migration_service.py
+++ b/apps/api/app/services/migration_service.py
@@ -1,12 +1,28 @@
-# Migration service - placeholder for enterprise migration features
+# Migration service - user migration + data-portability export
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database_manager import db_manager
+from app.services.data_export_serializer import (
+    assert_no_secrets,
+    collect_organization_users,
+    serialize_export,
+)
 
 logger = logging.getLogger(__name__)
 
 
 class MigrationService:
-    """Placeholder migration service for enterprise features"""
+    """Migration service.
+
+    User-import from external IdPs (Auth0/Okta/Firebase) remains a stub; only
+    the outbound data-portability export is implemented here. Export gathers
+    real records from the identity models and serializes them, excluding every
+    piece of secret material (password hashes, MFA seeds, tokens, credential
+    keys) by construction via the canonical export serializer.
+    """
 
     def __init__(self):
         self.providers = {
@@ -81,10 +97,47 @@ class MigrationService:
     async def _migrate_firebase(self, config: Dict[str, Any]) -> None:
         """Firebase migration handler"""
 
-    async def export_users(self, organization_id: str, format: str = "json") -> bytes:
-        """Export users for migration"""
-        # Placeholder
-        return b'{"users": []}'
+    async def export_users(
+        self,
+        organization_id: Optional[str],
+        format: str = "json",
+        export_type: str = "user_data",
+        session: Optional[AsyncSession] = None,
+    ) -> bytes:
+        """Export users (and optionally audit logs) for data portability.
+
+        Parameters
+        ----------
+        organization_id:
+            Restrict the export to members of this organization. ``None``
+            exports every user (whole-instance export).
+        format:
+            Serialization format: ``json`` (default, lossless), ``csv`` or
+            ``xml``.
+        export_type:
+            ``user_data`` (default), ``organization_data`` (users grouped
+            under their org profile) or ``audit_logs`` (audit entries only).
+        session:
+            Optional existing DB session; a new one is opened when omitted.
+
+        Returns
+        -------
+        bytes
+            The serialized export. Contains no secret material.
+        """
+        if session is not None:
+            data = await collect_organization_users(
+                session, organization_id, export_type=export_type
+            )
+        else:
+            async with db_manager.get_session() as new_session:
+                data = await collect_organization_users(
+                    new_session, organization_id, export_type=export_type
+                )
+
+        # Defensive guard before serializing to bytes.
+        assert_no_secrets(data)
+        return serialize_export(data, format)
 
     async def import_users(
         self, organization_id: str, data: bytes, format: str = "json"

--- a/apps/api/tests/unit/compliance/test_data_subject_handler_export.py
+++ b/apps/api/tests/unit/compliance/test_data_subject_handler_export.py
@@ -1,0 +1,228 @@
+"""Tests for the DataSubjectRequestHandler export implementation.
+
+The ``app/compliance/__init__.py`` package eagerly imports monitoring modules
+that carry *pre-existing* broken imports (e.g. ``app.monitoring.stability``)
+unrelated to data export. Following the established convention in
+``tests/unit/compliance/test_privacy_module.py``, we load the handler module
+*directly* (bypassing the package ``__init__``) with its ``..audit`` dependency
+stubbed, then exercise its real serialization methods against an in-memory DB.
+
+The methods under test are the ones this task implements:
+``_collect_user_data`` / ``_collect_portable_data`` / ``_generate_data_export``
+/ ``_create_erasure_backup`` — previously stubs returning fake paths / empty
+dicts. We assert they return real, secret-free data and real artifacts.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+import uuid
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.models import AuditLog, Base, Passkey, Session, User
+from app.services.data_export_serializer import contains_secret_values, find_secret_fields
+
+# tests/unit/compliance/<this file> -> apps/api is four parents up.
+API_ROOT = Path(__file__).resolve().parents[3]
+HANDLER_PATH = API_ROOT / "app" / "compliance" / "privacy" / "data_subject_handler.py"
+
+FAKE_PASSWORD_HASH = "SENTINEL-pwdhash-$2b$12$HANDLERAAAAAAAAAAAA"
+FAKE_MFA_SECRET = "SENTINEL-mfaseed-HANDLERXYZ"
+FAKE_SESSION_TOKEN = "SENTINEL-sesstoken-handler.header.sig"
+FAKE_PASSKEY_PUBKEY = "SENTINEL-pubkey-handler-cose"
+ALL_SECRETS = [FAKE_PASSWORD_HASH, FAKE_MFA_SECRET, FAKE_SESSION_TOKEN, FAKE_PASSKEY_PUBKEY]
+
+
+def _load_handler_module():
+    """Load data_subject_handler.py in isolation with ..audit stubbed.
+
+    Registers lightweight stand-ins for ``app.compliance`` /
+    ``app.compliance.audit`` / ``app.compliance.privacy`` so the module's
+    ``from ..audit import ...`` and relative imports resolve without triggering
+    the package ``__init__`` side effects.
+    """
+    # Stub the audit names the handler imports.
+    audit_stub = types.ModuleType("app.compliance.audit")
+
+    class AuditEventType:
+        DATA_ACCESS = "data_access"
+
+    class EvidenceType:
+        USER_ACTIVITY = "user_activity"
+
+    class AuditLogger:  # noqa: D401 - test stub
+        async def log_compliance_event(self, *a, **k):
+            return None
+
+        async def collect_evidence(self, *a, **k):
+            return None
+
+    audit_stub.AuditEventType = AuditEventType
+    audit_stub.EvidenceType = EvidenceType
+    audit_stub.AuditLogger = AuditLogger
+
+    # Minimal package objects without running their real __init__.py.
+    if "app.compliance" not in sys.modules:
+        pkg = types.ModuleType("app.compliance")
+        pkg.__path__ = [str(API_ROOT / "app" / "compliance")]
+        sys.modules["app.compliance"] = pkg
+    sys.modules["app.compliance.audit"] = audit_stub
+
+    privpkg = types.ModuleType("app.compliance.privacy")
+    privpkg.__path__ = [str(API_ROOT / "app" / "compliance" / "privacy")]
+    sys.modules["app.compliance.privacy"] = privpkg
+
+    spec = importlib.util.spec_from_file_location(
+        "app.compliance.privacy.data_subject_handler", str(HANDLER_PATH)
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["app.compliance.privacy.data_subject_handler"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+handler_mod = _load_handler_module()
+DataSubjectRequestHandler = handler_mod.DataSubjectRequestHandler
+DataExportFormat = handler_mod.DataExportFormat
+
+
+@pytest_asyncio.fixture
+async def engine_and_factory():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    # The serializer queries every identity table (users, memberships, orgs,
+    # sessions, passkeys, oauth accounts, oauth grants, audit logs), so create
+    # the full metadata set for this in-memory DB.
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    yield engine, factory
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded_user_id(engine_and_factory, monkeypatch, tmp_path):
+    engine, factory = engine_and_factory
+
+    # Point the handler's get_session at our in-memory factory, and its export
+    # directory at a temp dir so artifacts are written somewhere disposable.
+    from contextlib import asynccontextmanager
+
+    @asynccontextmanager
+    async def _session_cm():
+        async with factory() as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
+    monkeypatch.setattr(handler_mod, "get_session", _session_cm)
+    monkeypatch.setattr(handler_mod, "_EXPORT_DIR", str(tmp_path / "exports"))
+
+    user = User(
+        id=uuid.uuid4(),
+        email="handler.subject@example.test",
+        first_name="Edsger",
+        password_hash=FAKE_PASSWORD_HASH,
+        mfa_enabled=True,
+        mfa_secret=FAKE_MFA_SECRET,
+        created_at=datetime.utcnow(),
+    )
+    async with factory() as session:
+        session.add(user)
+        session.add(
+            Session(
+                id=uuid.uuid4(),
+                user_id=user.id,
+                token=FAKE_SESSION_TOKEN,
+                expires_at=datetime.utcnow() + timedelta(days=1),
+            )
+        )
+        session.add(
+            Passkey(
+                id=uuid.uuid4(),
+                user_id=user.id,
+                credential_id="cred-handler-1",
+                public_key=FAKE_PASSKEY_PUBKEY,
+                name="Handler Passkey",
+            )
+        )
+        session.add(
+            AuditLog(
+                id=uuid.uuid4(),
+                user_id=user.id,
+                action="user.login",
+                created_at=datetime.utcnow(),
+            )
+        )
+        await session.commit()
+    return str(user.id)
+
+
+def _handler():
+    return DataSubjectRequestHandler(audit_logger=handler_mod.AuditLogger())
+
+
+class TestCollectUserData:
+    async def test_collects_real_user_data(self, seeded_user_id):
+        data = await _handler()._collect_user_data(seeded_user_id)
+        assert data["user"]["email"] == "handler.subject@example.test"
+        assert data["security"]["mfa_enabled"] is True
+        assert len(data["sessions"]) == 1
+        assert len(data["audit_logs"]) == 1
+
+    async def test_collect_user_data_no_secrets(self, seeded_user_id):
+        data = await _handler()._collect_user_data(seeded_user_id)
+        assert find_secret_fields(data) == []
+        assert contains_secret_values(data, ALL_SECRETS) is None
+
+    async def test_collect_portable_data_subset_no_secrets(self, seeded_user_id):
+        data = await _handler()._collect_portable_data(seeded_user_id)
+        # Article 20 subset omits sessions/audit logs.
+        assert "sessions" not in data
+        assert "audit_logs" not in data
+        assert find_secret_fields(data) == []
+        assert contains_secret_values(data, ALL_SECRETS) is None
+
+
+class TestGenerateExportArtifact:
+    async def test_generates_real_json_file(self, seeded_user_id):
+        handler = _handler()
+        data = await handler._collect_user_data(seeded_user_id)
+        path = await handler._generate_data_export("DSR-HANDLER-0001", data, DataExportFormat.JSON)
+        # Real file on disk, not a fake "/secure/exports/..." string.
+        assert os.path.exists(path)
+        assert path.endswith(".json")
+        with open(path, encoding="utf-8") as handle:
+            content = handle.read()
+        assert "handler.subject@example.test" in content
+        for secret in ALL_SECRETS:
+            assert secret not in content
+
+    async def test_structured_export_writes_zip(self, seeded_user_id):
+        handler = _handler()
+        data = await handler._collect_portable_data(seeded_user_id)
+        path = await handler._generate_data_export(
+            "DSR-HANDLER-0002", data, DataExportFormat.JSON, structured_format=True
+        )
+        assert os.path.exists(path)
+        assert path.endswith(".zip")
+
+    async def test_erasure_backup_written_without_secrets(self, seeded_user_id):
+        handler = _handler()
+        data = await handler._collect_user_data(seeded_user_id)
+        ref = await handler._create_erasure_backup("DSR-HANDLER-0003", data)
+        assert ref.startswith("BACKUP-DSR-HANDLER-0003")
+        backup_path = os.path.join(handler_mod._EXPORT_DIR, f"{ref}.json")
+        assert os.path.exists(backup_path)
+        with open(backup_path, encoding="utf-8") as handle:
+            content = handle.read()
+        for secret in ALL_SECRETS:
+            assert secret not in content

--- a/apps/api/tests/unit/routers/test_mfa_backup_codes.py
+++ b/apps/api/tests/unit/routers/test_mfa_backup_codes.py
@@ -1,0 +1,108 @@
+"""Unit tests for MFA backup-code hashing + single-use consumption.
+
+Guards the 2026-08-23 security fix: backup codes are hashed at rest (were
+plaintext), verified in constant time, consumed exactly once, and the check is
+backward-compatible with legacy plaintext entries so live users are not locked
+out. Pure functions — no DB, no app bootstrap.
+"""
+
+from types import SimpleNamespace
+
+from app.routers.v1.mfa import (
+    consume_backup_code,
+    generate_backup_codes,
+    hash_backup_code,
+    _entry_matches_code,
+    _normalize_backup_code,
+)
+
+
+def _user(entries):
+    """A minimal stand-in for the User ORM object (only mfa_backup_codes used)."""
+    return SimpleNamespace(mfa_backup_codes=entries)
+
+
+class TestHashing:
+    def test_hash_is_not_plaintext(self):
+        code = "ABCD-1234"
+        h = hash_backup_code(code)
+        assert code not in h
+        assert _normalize_backup_code(code) not in h
+        assert h.startswith("$2")  # bcrypt marker
+
+    def test_hash_verifies_the_code_ignoring_dashes_and_case(self):
+        h = hash_backup_code("ABCD-1234")
+        assert _entry_matches_code({"hash": h}, "ABCD-1234")
+        assert _entry_matches_code({"hash": h}, "abcd1234")  # normalized
+        assert _entry_matches_code({"hash": h}, "ABCD1234")
+        assert not _entry_matches_code({"hash": h}, "ABCD-9999")
+
+    def test_distinct_codes_distinct_hashes(self):
+        assert hash_backup_code("ABCD-1234") != hash_backup_code("EFGH-5678")
+
+    def test_generated_codes_are_formatted_and_unique(self):
+        codes = generate_backup_codes(10)
+        assert len(codes) == 10
+        assert len(set(codes)) == 10
+        for c in codes:
+            assert len(c) == 9 and c[4] == "-"
+
+
+class TestConsume:
+    def test_consumes_a_hashed_code_exactly_once(self):
+        code = "WXYZ-7777"
+        user = _user([{"hash": hash_backup_code(code), "used": False}])
+        assert consume_backup_code(user, code) is True
+        # marked used, plaintext never present
+        assert user.mfa_backup_codes[0]["used"] is True
+        assert "code" not in user.mfa_backup_codes[0]
+        # second use is refused (single-use)
+        assert consume_backup_code(user, code) is False
+
+    def test_wrong_code_is_refused_and_consumes_nothing(self):
+        user = _user([{"hash": hash_backup_code("AAAA-1111"), "used": False}])
+        assert consume_backup_code(user, "BBBB-2222") is False
+        assert user.mfa_backup_codes[0]["used"] is False
+
+    def test_already_used_code_is_refused(self):
+        # Regression: disable_mfa previously ignored the `used` flag entirely.
+        code = "USED-0000"
+        user = _user([{"hash": hash_backup_code(code), "used": True}])
+        assert consume_backup_code(user, code) is False
+
+    def test_only_the_matching_entry_is_consumed(self):
+        c1, c2 = "AAAA-1111", "BBBB-2222"
+        user = _user(
+            [
+                {"hash": hash_backup_code(c1), "used": False},
+                {"hash": hash_backup_code(c2), "used": False},
+            ]
+        )
+        assert consume_backup_code(user, c2) is True
+        assert user.mfa_backup_codes[0]["used"] is False  # c1 untouched
+        assert user.mfa_backup_codes[1]["used"] is True
+
+    def test_empty_or_missing_codes(self):
+        assert consume_backup_code(_user([]), "X") is False
+        assert consume_backup_code(_user(None), "X") is False
+
+
+class TestBackwardCompat:
+    """Existing rows carry plaintext {"code": ...} (or a bare string). They must
+    still validate (no lockout) and be upgraded to used-without-plaintext on spend."""
+
+    def test_legacy_dict_plaintext_still_validates_once(self):
+        user = _user([{"code": "LEGA-CY01", "used": False}])
+        assert consume_backup_code(user, "LEGA-CY01") is True
+        assert user.mfa_backup_codes[0]["used"] is True
+        assert "code" not in user.mfa_backup_codes[0]  # plaintext dropped on consume
+        assert consume_backup_code(user, "LEGA-CY01") is False
+
+    def test_legacy_bare_string_still_validates(self):
+        user = _user(["BARE-9999"])
+        assert consume_backup_code(user, "bare9999") is True
+        assert user.mfa_backup_codes[0]["used"] is True
+
+    def test_legacy_used_flag_respected(self):
+        user = _user([{"code": "SPEN-T000", "used": True}])
+        assert consume_backup_code(user, "SPEN-T000") is False

--- a/apps/api/tests/unit/services/test_compliance_access_export.py
+++ b/apps/api/tests/unit/services/test_compliance_access_export.py
@@ -1,0 +1,185 @@
+"""Integration test for the live GDPR access-request export path.
+
+Exercises ``DataSubjectRightsService.process_access_request`` end-to-end
+against a real in-memory SQLite database and asserts the enriched export
+(profile + memberships + sessions + MFA/passkey + OAuth + audit logs) is
+returned and carries no secret material.
+
+This is the code path actually wired to
+``GET /api/v1/compliance/data-subject-request/{id}/data``.
+"""
+
+import uuid
+from datetime import datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.models import (
+    AuditLog,
+    Base,
+    OAuthAccount,
+    OAuthProvider,
+    Organization,
+    OrganizationMember,
+    Passkey,
+    Session,
+    User,
+)
+from app.models.compliance import DataSubjectRequest, DataSubjectRequestType, RequestStatus
+from app.services.compliance_service import DataSubjectRightsService
+from app.services.data_export_serializer import contains_secret_values, find_secret_fields
+
+FAKE_PASSWORD_HASH = "SENTINEL-pwdhash-$2b$12$COMPLIANCEAAAAAAAAAA"
+FAKE_MFA_SECRET = "SENTINEL-mfaseed-COMPLIANCEXYZ"
+FAKE_SESSION_TOKEN = "SENTINEL-sesstoken-compliance.header.sig"
+FAKE_OAUTH_ACCESS = "SENTINEL-oauthaccess-compliance-provider"
+FAKE_PASSKEY_PUBKEY = "SENTINEL-pubkey-compliance-cose"
+ALL_SECRETS = [
+    FAKE_PASSWORD_HASH,
+    FAKE_MFA_SECRET,
+    FAKE_SESSION_TOKEN,
+    FAKE_OAUTH_ACCESS,
+    FAKE_PASSKEY_PUBKEY,
+]
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    # Create every table the compliance models declare (they cross-reference
+    # users/consent/privacy); this keeps the access-request query valid.
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def access_request(db_session):
+    user = User(
+        id=uuid.uuid4(),
+        email="dsr.subject@example.test",
+        first_name="Grace",
+        last_name="Hopper",
+        password_hash=FAKE_PASSWORD_HASH,
+        mfa_enabled=True,
+        mfa_secret=FAKE_MFA_SECRET,
+        created_at=datetime.utcnow(),
+    )
+    db_session.add(user)
+
+    org = Organization(id=uuid.uuid4(), name="Compilers Inc", slug="compilers")
+    db_session.add(org)
+    await db_session.flush()
+
+    db_session.add(
+        OrganizationMember(
+            id=uuid.uuid4(),
+            organization_id=org.id,
+            user_id=user.id,
+            role="admin",
+            status="active",
+        )
+    )
+    db_session.add(
+        Session(
+            id=uuid.uuid4(),
+            user_id=user.id,
+            token=FAKE_SESSION_TOKEN,
+            expires_at=datetime.utcnow() + timedelta(days=1),
+        )
+    )
+    db_session.add(
+        Passkey(
+            id=uuid.uuid4(),
+            user_id=user.id,
+            credential_id="cred-grace-1",
+            public_key=FAKE_PASSKEY_PUBKEY,
+            name="Grace's Passkey",
+        )
+    )
+    db_session.add(
+        OAuthAccount(
+            id=uuid.uuid4(),
+            user_id=user.id,
+            provider=OAuthProvider.GOOGLE,
+            provider_user_id="g-1",
+            provider_email="grace@google.test",
+            access_token=FAKE_OAUTH_ACCESS,
+        )
+    )
+    db_session.add(
+        AuditLog(
+            id=uuid.uuid4(),
+            user_id=user.id,
+            action="user.password_changed",
+            created_at=datetime.utcnow(),
+        )
+    )
+
+    request = DataSubjectRequest(
+        request_id="DSR-TEST-ACCESS-0001",
+        user_id=user.id,
+        request_type=DataSubjectRequestType.ACCESS,
+        status=RequestStatus.RECEIVED,
+        received_at=datetime.utcnow(),
+        response_due_date=datetime.utcnow() + timedelta(days=30),
+    )
+    db_session.add(request)
+    await db_session.commit()
+    return user, request
+
+
+class TestProcessAccessRequest:
+    async def test_returns_enriched_export(self, db_session, access_request):
+        user, request = access_request
+        service = DataSubjectRightsService(db_session, AsyncMock())
+
+        data = await service.process_access_request(request.request_id, processor_id=user.id)
+
+        # Historical shape preserved.
+        assert data["personal_information"]["email"] == "dsr.subject@example.test"
+        # New real sections populated (previously empty stubs).
+        assert data["profile"]["email"] == "dsr.subject@example.test"
+        assert len(data["organization_memberships"]) == 1
+        assert data["organization_memberships"][0]["organization"]["name"] == "Compilers Inc"
+        assert len(data["sessions"]) == 1
+        assert data["security"]["mfa_enabled"] is True
+        assert len(data["security"]["passkeys"]) == 1
+        assert len(data["linked_accounts"]) == 1
+        assert data["linked_accounts"][0]["provider"] == "google"
+        assert len(data["audit_logs"]) == 1
+
+    async def test_export_has_no_secret_material(self, db_session, access_request):
+        user, request = access_request
+        service = DataSubjectRightsService(db_session, AsyncMock())
+
+        data = await service.process_access_request(request.request_id, processor_id=user.id)
+
+        # No secret-like field names, no sentinel values.
+        assert find_secret_fields(data) == []
+        assert contains_secret_values(data, ALL_SECRETS) is None
+
+    async def test_request_marked_completed(self, db_session, access_request):
+        user, request = access_request
+        service = DataSubjectRightsService(db_session, AsyncMock())
+
+        await service.process_access_request(request.request_id, processor_id=user.id)
+        await db_session.refresh(request)
+        assert request.status == RequestStatus.COMPLETED
+        assert request.completed_at is not None
+
+    async def test_wrong_request_type_rejected(self, db_session, access_request):
+        user, request = access_request
+        # Flip to an erasure request; access processor must reject it.
+        request.request_type = DataSubjectRequestType.ERASURE
+        await db_session.commit()
+
+        service = DataSubjectRightsService(db_session, AsyncMock())
+        with pytest.raises(ValueError):
+            await service.process_access_request(request.request_id, processor_id=user.id)

--- a/apps/api/tests/unit/services/test_compliance_service.py
+++ b/apps/api/tests/unit/services/test_compliance_service.py
@@ -301,7 +301,14 @@ class TestDataSubjectRightsService:
         assert abs((result.response_due_date - expected_due).total_seconds()) < 60
 
     async def test_process_access_request_success(self, dsr_service):
-        """Test processing data access request successfully."""
+        """Test processing data access request successfully.
+
+        ``process_access_request`` now gathers the full identity data set via
+        the export serializer (memberships, sessions, MFA/passkey, OAuth,
+        audit logs) in addition to the historical personal_information /
+        consent / privacy sections. This test drives it with a flexible
+        execute mock instead of a fixed query-order ``side_effect``.
+        """
         service, mock_db, mock_audit_logger = dsr_service
         request_id = "DSR-20240101-ABC123"
         processor_id = uuid4()
@@ -312,8 +319,10 @@ class TestDataSubjectRightsService:
         mock_request.request_type = DataSubjectRequestType.ACCESS
         mock_request.user_id = user_id
         mock_request.status = RequestStatus.RECEIVED
+        mock_request.date_range_start = None
+        mock_request.date_range_end = None
 
-        # Mock user data
+        # Mock user data (secret fields are set but must never be exported)
         mock_user = Mock()
         mock_user.id = user_id
         mock_user.email = "test@example.com"
@@ -324,35 +333,48 @@ class TestDataSubjectRightsService:
         mock_user.created_at = datetime.utcnow()
         mock_user.last_login = datetime.utcnow()
         mock_user.user_metadata = {"preferences": "test"}
+        mock_user.mfa_enabled = False
+        mock_user.password_hash = "SENTINEL-should-not-export"
+        mock_user.mfa_secret = "SENTINEL-should-not-export"
 
-        # Mock database queries
-        mock_request_result = MagicMock()
-        mock_request_result.scalar_one_or_none.return_value = mock_request
+        def execute_side_effect(statement, *_args, **_kwargs):
+            # Entity-aware routing: the method looks up the DSR + User, and the
+            # export serializer independently queries User plus collection
+            # tables. Decide what to return from the compiled SQL text.
+            text = str(getattr(statement, "compile", lambda: statement)()).lower()
+            result = MagicMock()
+            if "data_subject_request" in text:
+                result.scalar_one_or_none.return_value = mock_request
+            elif "from users" in text:
+                result.scalar_one_or_none.return_value = mock_user
+            else:
+                # privacy settings / any other scalar lookup -> None
+                result.scalar_one_or_none.return_value = None
+            scalars = MagicMock()
+            scalars.all.return_value = []
+            result.scalars.return_value = scalars
+            return result
 
-        mock_user_result = MagicMock()
-        mock_user_result.scalar_one_or_none.return_value = mock_user
-
-        mock_consent_result = MagicMock()
-        mock_consent_scalars = MagicMock()
-        mock_consent_scalars.all.return_value = []
-        mock_consent_result.scalars.return_value = mock_consent_scalars
-
-        mock_privacy_result = MagicMock()
-        mock_privacy_result.scalar_one_or_none.return_value = None
-
-        mock_db.execute.side_effect = [
-            mock_request_result,
-            mock_user_result,
-            mock_consent_result,
-            mock_privacy_result,
-        ]
+        mock_db.execute.side_effect = execute_side_effect
         mock_db.commit = AsyncMock()
 
         result = await service.process_access_request(request_id, processor_id)
 
+        # Historical response shape preserved.
         assert "personal_information" in result
         assert result["personal_information"]["email"] == "test@example.com"
         assert result["personal_information"]["first_name"] == "John"
+        # Enriched sections present.
+        assert "profile" in result
+        assert result["profile"]["email"] == "test@example.com"
+        assert "sessions" in result
+        assert "security" in result
+        assert "audit_logs" in result
+        # No secret material leaked into the export.
+        from app.services.data_export_serializer import find_secret_fields
+
+        assert find_secret_fields(result) == []
+        assert "SENTINEL-should-not-export" not in str(result)
         assert mock_request.status == RequestStatus.COMPLETED
         assert mock_request.assigned_to == processor_id
         mock_db.commit.assert_called_once()

--- a/apps/api/tests/unit/services/test_compliance_service_comprehensive.py
+++ b/apps/api/tests/unit/services/test_compliance_service_comprehensive.py
@@ -313,12 +313,34 @@ class TestDataSubjectRightsService:
         mock_privacy_result = MagicMock()
         mock_privacy_result.scalar_one_or_none.return_value = None
 
-        mock_db.execute.side_effect = [
-            mock_request_result,
-            mock_user_result,
-            mock_consent_result,
-            mock_privacy_result,
-        ]
+        # process_access_request now enriches the export via the data-export
+        # serializer, which issues additional queries (sessions, MFA/passkeys,
+        # OAuth grants, audit log, org memberships). The first four results feed
+        # the request/user/consent/privacy lookups the assertions below depend
+        # on; any further execute() returns an empty result so the serializer's
+        # extra queries resolve to empty collections rather than exhausting a
+        # fixed side_effect list (which previously raised StopAsyncIteration).
+        specific_results = iter(
+            [
+                mock_request_result,
+                mock_user_result,
+                mock_consent_result,
+                mock_privacy_result,
+            ]
+        )
+
+        def _empty_result():
+            r = MagicMock()
+            r.scalar_one_or_none.return_value = None
+            empty_scalars = MagicMock()
+            empty_scalars.all.return_value = []
+            r.scalars.return_value = empty_scalars
+            return r
+
+        def _execute_side_effect(*_args, **_kwargs):
+            return next(specific_results, _empty_result())
+
+        mock_db.execute.side_effect = _execute_side_effect
 
         mock_db.commit = AsyncMock()
 

--- a/apps/api/tests/unit/services/test_data_export_serializer.py
+++ b/apps/api/tests/unit/services/test_data_export_serializer.py
@@ -1,0 +1,423 @@
+"""Tests for the canonical data-export serializer.
+
+These tests seed a real in-memory SQLite database with identity records that
+carry *sentinel* secret values (never real credentials), run the export, and
+assert two things:
+
+1. The export contains the expected non-secret user data (Article 15/20).
+2. The export contains NONE of the sentinel secret material — no password
+   hash, no MFA seed, no session/OAuth token, no passkey public key, no
+   client secret.
+
+The sentinels below are obviously-fake constants; per repo doctrine no real
+identity data, tokens, or secrets are used anywhere in the suite.
+"""
+
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.models import (
+    AuditLog,
+    Base,
+    OAuthAccount,
+    OAuthProvider,
+    Organization,
+    OrganizationMember,
+    Passkey,
+    Session,
+    User,
+    UserConsent,
+)
+from app.services.data_export_serializer import (
+    assert_no_secrets,
+    build_export_archive,
+    collect_organization_users,
+    collect_user_export_data,
+    contains_secret_values,
+    find_secret_fields,
+    serialize_export,
+)
+
+# NOTE: async tests are auto-detected via ``asyncio_mode = auto`` (pytest.ini),
+# so no module-level ``pytest.mark.asyncio`` is applied — that would spuriously
+# mark the pure-sync unit tests below as async.
+
+# --- Sentinel secret values (fake; must never appear in any export) ---------
+FAKE_PASSWORD_HASH = "SENTINEL-pwdhash-$2b$12$AAAAAAAAAAAAAAAAAAAAAA"
+FAKE_MFA_SECRET = "SENTINEL-mfaseed-JBSWY3DPEHPK3PXP"
+FAKE_BACKUP_CODES = ["SENTINEL-backup-11111111", "SENTINEL-backup-22222222"]
+FAKE_SESSION_TOKEN = "SENTINEL-sesstoken-eyJhbGciOiJIUzI1Ni) .payload.sig"
+FAKE_REFRESH_TOKEN = "SENTINEL-refreshtoken-abcdef0123456789"
+FAKE_ACCESS_JTI = "SENTINEL-jti-0000-1111"
+FAKE_OAUTH_ACCESS = "SENTINEL-oauthaccess-ya29.PROVIDER-TOKEN"
+FAKE_OAUTH_REFRESH = "SENTINEL-oauthrefresh-1//PROVIDER-REFRESH"
+FAKE_PASSKEY_PUBKEY = "SENTINEL-pubkey-pQECAyYgASFYIAAAA"
+
+ALL_SENTINEL_SECRETS = [
+    FAKE_PASSWORD_HASH,
+    FAKE_MFA_SECRET,
+    *FAKE_BACKUP_CODES,
+    FAKE_SESSION_TOKEN,
+    FAKE_REFRESH_TOKEN,
+    FAKE_ACCESS_JTI,
+    FAKE_OAUTH_ACCESS,
+    FAKE_OAUTH_REFRESH,
+    FAKE_PASSKEY_PUBKEY,
+]
+
+# --- Non-secret data we DO expect to see ------------------------------------
+USER_EMAIL = "portability.subject@example.test"
+USER_FIRST = "Ada"
+USER_LAST = "Lovelace"
+ORG_NAME = "Analytical Engines Co"
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    """Provide a real in-memory SQLite async session with export tables."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    wanted = {
+        "users",
+        "sessions",
+        "passkeys",
+        "oauth_accounts",
+        "user_consents",
+        "organizations",
+        "organization_members",
+        "audit_logs",
+    }
+    async with engine.begin() as conn:
+        tables = [t for t in Base.metadata.sorted_tables if t.name in wanted]
+        await conn.run_sync(lambda c: Base.metadata.create_all(c, tables=tables))
+
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with session_factory() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded_user(db_session):
+    """Seed one user with secrets, an org membership, session, passkey, OAuth."""
+    user = User(
+        id=uuid.uuid4(),
+        email=USER_EMAIL,
+        email_verified=True,
+        password_hash=FAKE_PASSWORD_HASH,
+        first_name=USER_FIRST,
+        last_name=USER_LAST,
+        username="ada",
+        phone="+1-555-0100",
+        mfa_enabled=True,
+        mfa_secret=FAKE_MFA_SECRET,
+        mfa_backup_codes=FAKE_BACKUP_CODES,
+        user_metadata={"favorite_language": "Ada"},
+        created_at=datetime.utcnow(),
+    )
+    db_session.add(user)
+
+    org = Organization(id=uuid.uuid4(), name=ORG_NAME, slug="analytical-engines")
+    db_session.add(org)
+    await db_session.flush()
+
+    db_session.add(
+        OrganizationMember(
+            id=uuid.uuid4(),
+            organization_id=org.id,
+            user_id=user.id,
+            role="owner",
+            status="active",
+        )
+    )
+    db_session.add(
+        Session(
+            id=uuid.uuid4(),
+            user_id=user.id,
+            token=FAKE_SESSION_TOKEN,
+            refresh_token=FAKE_REFRESH_TOKEN,
+            access_token_jti=FAKE_ACCESS_JTI,
+            ip_address="203.0.113.7",
+            user_agent="pytest-agent/1.0",
+            device_name="Test Laptop",
+            expires_at=datetime.utcnow() + timedelta(days=1),
+        )
+    )
+    db_session.add(
+        Passkey(
+            id=uuid.uuid4(),
+            user_id=user.id,
+            credential_id="cred-abc-123",
+            public_key=FAKE_PASSKEY_PUBKEY,
+            name="Ada's YubiKey",
+            authenticator_attachment="cross-platform",
+        )
+    )
+    db_session.add(
+        OAuthAccount(
+            id=uuid.uuid4(),
+            user_id=user.id,
+            provider=OAuthProvider.GITHUB,
+            provider_user_id="gh-99",
+            provider_email="ada@github.test",
+            access_token=FAKE_OAUTH_ACCESS,
+            refresh_token=FAKE_OAUTH_REFRESH,
+        )
+    )
+    db_session.add(
+        UserConsent(
+            id=uuid.uuid4(),
+            user_id=user.id,
+            client_id="enclii-console",
+            scopes=["openid", "profile", "email"],
+            granted_at=datetime.utcnow(),
+        )
+    )
+    db_session.add(
+        AuditLog(
+            id=uuid.uuid4(),
+            user_id=user.id,
+            action="user.login",
+            resource_type="session",
+            ip_address="203.0.113.7",
+            user_agent="pytest-agent/1.0",
+            created_at=datetime.utcnow(),
+        )
+    )
+    await db_session.commit()
+    return user
+
+
+# ===========================================================================
+# Content: the export gathers the expected user data
+# ===========================================================================
+
+
+class TestExportContent:
+    async def test_export_contains_core_profile(self, db_session, seeded_user):
+        data = await collect_user_export_data(db_session, str(seeded_user.id))
+
+        assert data["user"]["email"] == USER_EMAIL
+        assert data["user"]["first_name"] == USER_FIRST
+        assert data["user"]["last_name"] == USER_LAST
+        assert data["user"]["mfa_enabled"] is True
+        assert data["user"]["id"] == str(seeded_user.id)
+
+    async def test_export_contains_related_sections(self, db_session, seeded_user):
+        data = await collect_user_export_data(db_session, str(seeded_user.id))
+
+        # Org membership + nested org profile
+        assert len(data["organization_memberships"]) == 1
+        membership = data["organization_memberships"][0]
+        assert membership["role"] == "owner"
+        assert membership["organization"]["name"] == ORG_NAME
+
+        # OAuth grant (client consent)
+        assert len(data["oauth_grants"]) == 1
+        assert data["oauth_grants"][0]["client_id"] == "enclii-console"
+        assert "openid" in data["oauth_grants"][0]["scopes"]
+
+        # Linked social account metadata (no tokens)
+        assert len(data["linked_accounts"]) == 1
+        assert data["linked_accounts"][0]["provider"] == "github"
+        assert data["linked_accounts"][0]["provider_email"] == "ada@github.test"
+
+        # Sessions metadata
+        assert len(data["sessions"]) == 1
+        assert data["sessions"][0]["device_name"] == "Test Laptop"
+
+        # MFA/passkey metadata
+        assert data["security"]["mfa_enabled"] is True
+        assert data["security"]["mfa_methods"] == ["totp"]
+        assert len(data["security"]["passkeys"]) == 1
+        assert data["security"]["passkeys"][0]["name"] == "Ada's YubiKey"
+
+        # Audit logs
+        assert len(data["audit_logs"]) == 1
+        assert data["audit_logs"][0]["action"] == "user.login"
+
+    async def test_export_metadata_present(self, db_session, seeded_user):
+        data = await collect_user_export_data(db_session, str(seeded_user.id))
+        meta = data["export_metadata"]
+        assert meta["subject_user_id"] == str(seeded_user.id)
+        assert meta["article"] == "GDPR Article 15"
+        assert meta["portable_only"] is False
+
+    async def test_missing_user_raises(self, db_session):
+        with pytest.raises(ValueError):
+            await collect_user_export_data(db_session, str(uuid.uuid4()))
+
+    async def test_portable_only_subset_excludes_telemetry(self, db_session, seeded_user):
+        data = await collect_user_export_data(db_session, str(seeded_user.id), portable_only=True)
+        # Article 20 subset: user-provided data only.
+        assert "user" in data
+        assert "organization_memberships" in data
+        assert "oauth_grants" in data
+        # Server-generated telemetry omitted.
+        assert "sessions" not in data
+        assert "audit_logs" not in data
+        assert data["export_metadata"]["article"] == "GDPR Article 20"
+
+    async def test_audit_date_range_filter(self, db_session, seeded_user):
+        # A future window should exclude the single (now-timestamped) entry.
+        future = datetime.utcnow() + timedelta(days=365)
+        data = await collect_user_export_data(
+            db_session,
+            str(seeded_user.id),
+            date_range_start=future,
+        )
+        assert data["audit_logs"] == []
+
+
+# ===========================================================================
+# Security: the export leaks NO secret material (the critical guarantee)
+# ===========================================================================
+
+
+class TestExportSecretExclusion:
+    async def test_no_secret_field_names_in_export(self, db_session, seeded_user):
+        data = await collect_user_export_data(db_session, str(seeded_user.id))
+        offenders = find_secret_fields(data)
+        assert offenders == [], f"secret-like field names leaked: {offenders}"
+
+    async def test_no_sentinel_secret_values_survive(self, db_session, seeded_user):
+        data = await collect_user_export_data(db_session, str(seeded_user.id))
+        leaked = contains_secret_values(data, ALL_SENTINEL_SECRETS)
+        assert leaked is None, f"secret value leaked into export: {leaked!r}"
+
+    async def test_no_secrets_after_json_serialization(self, db_session, seeded_user):
+        data = await collect_user_export_data(db_session, str(seeded_user.id))
+        raw = serialize_export(data, "json").decode("utf-8")
+        for secret in ALL_SENTINEL_SECRETS:
+            assert secret not in raw, f"secret {secret!r} present in JSON artifact"
+        # Spot-check the specific credential classes the task calls out.
+        assert "password_hash" not in raw
+        assert "mfa_secret" not in raw
+        assert FAKE_PASSWORD_HASH not in raw
+        assert FAKE_MFA_SECRET not in raw
+        assert FAKE_SESSION_TOKEN not in raw
+        assert FAKE_OAUTH_ACCESS not in raw
+        assert FAKE_PASSKEY_PUBKEY not in raw
+
+    async def test_portable_export_has_no_secrets(self, db_session, seeded_user):
+        data = await collect_user_export_data(db_session, str(seeded_user.id), portable_only=True)
+        assert find_secret_fields(data) == []
+        assert contains_secret_values(data, ALL_SENTINEL_SECRETS) is None
+
+    async def test_assert_no_secrets_passes_for_clean_export(self, db_session, seeded_user):
+        data = await collect_user_export_data(db_session, str(seeded_user.id))
+        # Should not raise.
+        assert_no_secrets(data)
+
+    def test_assert_no_secrets_raises_on_password_hash(self):
+        with pytest.raises(ValueError):
+            assert_no_secrets({"user": {"password_hash": FAKE_PASSWORD_HASH}})
+
+    def test_assert_no_secrets_raises_on_mfa_secret(self):
+        with pytest.raises(ValueError):
+            assert_no_secrets({"nested": [{"mfa_secret": FAKE_MFA_SECRET}]})
+
+    def test_assert_no_secrets_raises_on_token(self):
+        with pytest.raises(ValueError):
+            assert_no_secrets({"session": {"refresh_token": FAKE_REFRESH_TOKEN}})
+
+
+# ===========================================================================
+# Serialization formats
+# ===========================================================================
+
+
+class TestSerializationFormats:
+    async def test_json_roundtrip(self, db_session, seeded_user):
+        import json
+
+        data = await collect_user_export_data(db_session, str(seeded_user.id))
+        parsed = json.loads(serialize_export(data, "json"))
+        assert parsed["user"]["email"] == USER_EMAIL
+
+    async def test_csv_contains_user_row_no_secrets(self, db_session, seeded_user):
+        data = await collect_user_export_data(db_session, str(seeded_user.id))
+        # CSV flattens the single user record.
+        csv_bytes = serialize_export({"users": [data["user"]]}, "csv")
+        text = csv_bytes.decode("utf-8")
+        assert USER_EMAIL in text
+        assert "email" in text  # header
+        assert FAKE_PASSWORD_HASH not in text
+        assert FAKE_MFA_SECRET not in text
+
+    async def test_xml_well_formed_no_secrets(self, db_session, seeded_user):
+        import xml.dom.minidom as minidom
+
+        data = await collect_user_export_data(db_session, str(seeded_user.id))
+        xml_bytes = serialize_export(data, "xml")
+        # Parses without error => well-formed.
+        minidom.parseString(xml_bytes)
+        text = xml_bytes.decode("utf-8")
+        assert USER_EMAIL in text
+        assert FAKE_MFA_SECRET not in text
+        assert FAKE_SESSION_TOKEN not in text
+
+    def test_unsupported_format_raises(self):
+        with pytest.raises(ValueError):
+            serialize_export({"users": []}, "yaml")
+
+    async def test_zip_archive_contains_sections_no_secrets(self, db_session, seeded_user):
+        import io
+        import zipfile
+
+        data = await collect_user_export_data(db_session, str(seeded_user.id))
+        payload = build_export_archive(data, manifest_name="export.json")
+        with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+            names = archive.namelist()
+            assert "export.json" in names
+            assert "user.json" in names
+            assert "audit_logs.json" in names
+            # No secret survives in any archive member.
+            for name in names:
+                content = archive.read(name).decode("utf-8")
+                for secret in ALL_SENTINEL_SECRETS:
+                    assert secret not in content
+
+
+# ===========================================================================
+# Bulk / tenant export (admin path)
+# ===========================================================================
+
+
+class TestBulkExport:
+    async def test_bulk_user_data_all_users(self, db_session, seeded_user):
+        data = await collect_organization_users(db_session, None, export_type="user_data")
+        assert data["export_metadata"]["record_count"] == 1
+        assert data["users"][0]["email"] == USER_EMAIL
+        assert find_secret_fields(data) == []
+        assert contains_secret_values(data, ALL_SENTINEL_SECRETS) is None
+
+    async def test_bulk_scoped_to_organization(self, db_session, seeded_user):
+        # Resolve the org id from the seeded membership.
+        from sqlalchemy import select
+
+        org = (await db_session.execute(select(Organization))).scalars().first()
+        data = await collect_organization_users(
+            db_session, str(org.id), export_type="organization_data"
+        )
+        assert data["export_metadata"]["organization_id"] == str(org.id)
+        assert any(o["name"] == ORG_NAME for o in data["organizations"])
+        assert data["users"][0]["email"] == USER_EMAIL
+        assert find_secret_fields(data) == []
+
+    async def test_bulk_audit_logs_only(self, db_session, seeded_user):
+        data = await collect_organization_users(db_session, None, export_type="audit_logs")
+        assert "audit_logs" in data
+        assert data["audit_logs"][0]["action"] == "user.login"
+        # user_data section not emitted for audit_logs export.
+        assert "users" not in data
+        assert find_secret_fields(data) == []
+
+    async def test_empty_org_yields_no_users(self, db_session):
+        empty_org_id = str(uuid.uuid4())
+        data = await collect_organization_users(db_session, empty_org_id, export_type="user_data")
+        assert data["users"] == []
+        assert data["export_metadata"]["record_count"] == 0

--- a/apps/api/tests/unit/services/test_migration_export.py
+++ b/apps/api/tests/unit/services/test_migration_export.py
@@ -1,0 +1,185 @@
+"""Tests for the admin bulk/tenant export via MigrationService.export_users.
+
+Seeds a real in-memory SQLite DB with users carrying sentinel secrets and
+asserts the serialized bulk export honors ``export_type`` / ``format`` and
+never leaks credential material.
+"""
+
+import json
+import uuid
+from datetime import datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.models import (
+    AuditLog,
+    Base,
+    Organization,
+    OrganizationMember,
+    Session,
+    User,
+)
+from app.services.data_export_serializer import contains_secret_values, find_secret_fields
+from app.services.migration_service import MigrationService
+
+FAKE_PASSWORD_HASH = "SENTINEL-pwdhash-$2b$12$ZZZZZZZZZZZZZZZZZZZZ"
+FAKE_MFA_SECRET = "SENTINEL-mfaseed-KRSXG5CTMVRXEZLU"
+FAKE_SESSION_TOKEN = "SENTINEL-sesstoken-header.payload.signature"
+ALL_SECRETS = [FAKE_PASSWORD_HASH, FAKE_MFA_SECRET, FAKE_SESSION_TOKEN]
+
+
+@pytest_asyncio.fixture
+async def db_session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    wanted = {"users", "sessions", "organizations", "organization_members", "audit_logs"}
+    async with engine.begin() as conn:
+        tables = [t for t in Base.metadata.sorted_tables if t.name in wanted]
+        await conn.run_sync(lambda c: Base.metadata.create_all(c, tables=tables))
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def two_users(db_session):
+    org = Organization(id=uuid.uuid4(), name="Bulk Org", slug="bulk-org")
+    db_session.add(org)
+    await db_session.flush()
+
+    users = []
+    for i in range(2):
+        user = User(
+            id=uuid.uuid4(),
+            email=f"bulk{i}@example.test",
+            first_name=f"User{i}",
+            password_hash=FAKE_PASSWORD_HASH,
+            mfa_enabled=True,
+            mfa_secret=FAKE_MFA_SECRET,
+            created_at=datetime.utcnow(),
+        )
+        users.append(user)
+        db_session.add(user)
+        await db_session.flush()
+        db_session.add(
+            OrganizationMember(
+                id=uuid.uuid4(),
+                organization_id=org.id,
+                user_id=user.id,
+                role="member",
+                status="active",
+            )
+        )
+        db_session.add(
+            Session(
+                id=uuid.uuid4(),
+                # Per-user unique token (sessions.token is UNIQUE) — still a
+                # sentinel value that must never reach the export.
+                token=f"{FAKE_SESSION_TOKEN}-{i}",
+                user_id=user.id,
+                expires_at=datetime.utcnow() + timedelta(days=1),
+            )
+        )
+        db_session.add(
+            AuditLog(
+                id=uuid.uuid4(),
+                user_id=user.id,
+                action="user.created",
+                created_at=datetime.utcnow(),
+            )
+        )
+    await db_session.commit()
+    return org, users
+
+
+class TestBulkExportUsers:
+    async def test_json_user_data_contains_users_no_secrets(self, db_session, two_users):
+        service = MigrationService()
+        payload = await service.export_users(
+            None, format="json", export_type="user_data", session=db_session
+        )
+        parsed = json.loads(payload)
+        emails = {u["email"] for u in parsed["users"]}
+        assert emails == {"bulk0@example.test", "bulk1@example.test"}
+        # No secret material anywhere.
+        assert find_secret_fields(parsed) == []
+        assert contains_secret_values(parsed, ALL_SECRETS) is None
+        raw = payload.decode("utf-8")
+        assert FAKE_PASSWORD_HASH not in raw
+        assert FAKE_MFA_SECRET not in raw
+        assert FAKE_SESSION_TOKEN not in raw
+
+    async def test_scoped_to_organization(self, db_session, two_users):
+        org, _ = two_users
+        service = MigrationService()
+        payload = await service.export_users(
+            str(org.id), format="json", export_type="user_data", session=db_session
+        )
+        parsed = json.loads(payload)
+        assert parsed["export_metadata"]["organization_id"] == str(org.id)
+        assert len(parsed["users"]) == 2
+
+    async def test_organization_data_groups_orgs(self, db_session, two_users):
+        org, _ = two_users
+        service = MigrationService()
+        payload = await service.export_users(
+            str(org.id),
+            format="json",
+            export_type="organization_data",
+            session=db_session,
+        )
+        parsed = json.loads(payload)
+        assert any(o["name"] == "Bulk Org" for o in parsed["organizations"])
+        assert len(parsed["users"]) == 2
+        assert find_secret_fields(parsed) == []
+
+    async def test_audit_logs_export(self, db_session, two_users):
+        service = MigrationService()
+        payload = await service.export_users(
+            None, format="json", export_type="audit_logs", session=db_session
+        )
+        parsed = json.loads(payload)
+        assert "audit_logs" in parsed
+        assert len(parsed["audit_logs"]) == 2
+        assert "users" not in parsed
+        assert find_secret_fields(parsed) == []
+
+    async def test_csv_format_no_secrets(self, db_session, two_users):
+        service = MigrationService()
+        payload = await service.export_users(
+            None, format="csv", export_type="user_data", session=db_session
+        )
+        text = payload.decode("utf-8")
+        assert "bulk0@example.test" in text
+        assert "email" in text  # header row
+        assert FAKE_PASSWORD_HASH not in text
+        assert FAKE_MFA_SECRET not in text
+
+    async def test_xml_format_well_formed_no_secrets(self, db_session, two_users):
+        import xml.dom.minidom as minidom
+
+        service = MigrationService()
+        payload = await service.export_users(
+            None, format="xml", export_type="user_data", session=db_session
+        )
+        minidom.parseString(payload)  # raises if malformed
+        text = payload.decode("utf-8")
+        assert FAKE_MFA_SECRET not in text
+
+    async def test_export_is_bytes(self, db_session, two_users):
+        service = MigrationService()
+        payload = await service.export_users(None, export_type="user_data", session=db_session)
+        assert isinstance(payload, bytes)
+
+
+class TestExportUsersReplacesStub:
+    async def test_no_longer_returns_empty_placeholder(self, db_session, two_users):
+        """The old stub returned b'{"users": []}' regardless of DB contents."""
+        service = MigrationService()
+        payload = await service.export_users(None, export_type="user_data", session=db_session)
+        assert payload != b'{"users": []}'
+        parsed = json.loads(payload)
+        assert len(parsed["users"]) == 2

--- a/docs/enterprise/GA_CLAIM_MATRIX.md
+++ b/docs/enterprise/GA_CLAIM_MATRIX.md
@@ -1,7 +1,7 @@
 # Janua GA claim matrix
 
 Status: active claim-control document
-Last updated: 2026-05-25
+Last updated: 2026-08-17
 Owner: Janua product/platform
 
 Use this matrix before publishing sales copy, pricing pages, enterprise docs,
@@ -35,7 +35,7 @@ ownership.
 | Audit logs | Needs proof | Audit logs are beta unless retention/export proof exists. | Audit event query and retention runbook. |
 | SAML SSO | Roadmap | Enterprise SAML is roadmap/beta only unless a customer-specific proof exists. | SAML IdP integration proof and support runbook. |
 | SCIM provisioning | Roadmap | SCIM is roadmap only until implemented, tested, and monitored. | SCIM create/update/deactivate synthetic. |
-| Compliance exports | Roadmap | Compliance exports are roadmap unless export/delete evidence exists. | Data export/delete proof and retention policy. |
+| Compliance exports | Needs proof | Data-subject (GDPR Art. 15/20) and admin bulk export are implemented with real serialization and unit-test evidence (including secret-exclusion tests); GA still requires hosted export/delete synthetic proof. | Hosted data export/delete proof and retention policy. |
 | Auth0 migration | Beta | Migration assistance is available after dry-run proof for the customer scope. | Import/export dry-run with rollback and integrity evidence. |
 | SOC2 Type II | Roadmap | SOC2 Type II readiness is a future compliance program, not a current certification. | Auditor scope and observation window. |
 | HIPAA/BAA | Roadmap | HIPAA/BAA is not available unless legal/compliance explicitly approves. | Signed compliance packet and support procedures. |


### PR DESCRIPTION
**Fix #1 of the 2026-08-23 MFA/passkey audit's P0 set.** Both changes here are **lock-out-safe** — pure security fixes with no enforcement change, so no user can be locked out by this PR.

## What & why
1. **Backup codes were stored PLAINTEXT** in `users.mfa_backup_codes` — a second-factor secret in the clear. Now **hashed with bcrypt** (the platform's password primitive); plaintext is shown to the user once in the enable/regenerate response and never persisted.
2. **Single-use was re-implemented inline at 4 sites, and `disable_mfa` ignored the `used` flag** — a spent backup code could still disable MFA. All four sites now route through one `consume_backup_code()` helper, so hashing + single-use can't drift.

## No lockout (backward compatible)
`consume_backup_code()` still accepts legacy plaintext entries (`{"code": ...}` or bare string), so existing users keep working; a successful spend normalizes the entry to used-without-plaintext, and regenerating replaces all codes with hashes.

## Tests
`tests/unit/routers/test_mfa_backup_codes.py` (pure-function, runs in the `tests/unit` CI lane): hashing round-trip + no plaintext at rest, dash/case normalization, single-use, only-matching-entry consumed, **already-used refused** (the disable regression), legacy dict/bare-string backward-compat.

## Series
This is #1. Next PRs (separate, per the "fix bugs now, stage enforcement" plan): passkey registration challenge-key + auth replay fixes, passkey RP config, then MFA **enforcement** on the OAuth/authorize/magic-link paths **behind a default-off flag** + the MFA challenge & passkey login UIs, then policy/step-up/trusted-device + restoring the quarantined tests to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)