### PR TITLE
security(mfa): enforce MFA on all login paths (staged behind default-off flag)

### DIFF
--- a/apps/api/app/auth/mfa_enforcement.py
+++ b/apps/api/app/auth/mfa_enforcement.py
@@ -1,0 +1,66 @@
+"""Shared MFA-enforcement gate for the login paths.
+
+2026-08-23 security fix. The completeness audit found MFA was enforced on exactly
+ONE path (the JSON `/signin` endpoint) while the OAuth browser login, the OAuth
+`/authorize` flow, and magic-link login all issued full sessions WITHOUT checking
+`mfa_enabled` — so a user who "enabled 2FA" was unprotected on every path a real
+product uses through Janua. This module centralizes the decision so every login
+path enforces MFA identically, and gates it behind a DEFAULT-OFF flag so shipping
+the enforcement cannot lock anyone out before the MFA-challenge UI is live.
+
+Usage in a login path, immediately before it would create a session:
+
+    if mfa_required_for(user):
+        return mfa_challenge_response(user)   # JSON callers
+        # or: redirect back to the login UI with ?mfa_required=1 (browser flow)
+
+The challenge token this mints is consumed by POST /api/v1/mfa/challenge/verify,
+which already exists and issues the real session once the second factor checks.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import jwt as pyjwt
+
+from app.config import settings
+
+MFA_CHALLENGE_TYPE = "mfa_challenge"
+_CHALLENGE_TTL_MINUTES = 5
+
+
+def mfa_required_for(user) -> bool:
+    """True iff this login should be interrupted for a second factor.
+
+    Requires BOTH the global enforcement flag (default OFF — see
+    settings.MFA_ENFORCE_ON_LOGIN) and the user actually having MFA configured.
+    When the flag is off, this always returns False and every login path behaves
+    exactly as it did before this change. A per-org "require MFA" policy can be
+    layered on top later (it would make this return True even for a user who has
+    not yet enrolled — a separate, enrollment-forcing flow).
+    """
+    if not getattr(settings, "MFA_ENFORCE_ON_LOGIN", False):
+        return False
+    return bool(getattr(user, "mfa_enabled", False) and getattr(user, "mfa_secret", None))
+
+
+def mint_mfa_challenge_token(user) -> str:
+    """Mint a short-lived challenge token (NOT a session token).
+
+    Identical shape to the one the JSON /signin path already issues, so
+    /mfa/challenge/verify accepts it unchanged: {sub, type:"mfa_challenge", exp,
+    iat, iss}, HS256 over JWT_SECRET_KEY.
+    """
+    payload = {
+        "sub": str(user.id),
+        "type": MFA_CHALLENGE_TYPE,
+        "exp": datetime.utcnow() + timedelta(minutes=_CHALLENGE_TTL_MINUTES),
+        "iat": datetime.utcnow(),
+        "iss": settings.JWT_ISSUER,
+    }
+    return pyjwt.encode(
+        payload,
+        settings.JWT_SECRET_KEY or "development-secret-key",
+        algorithm="HS256",
+    )

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -350,6 +350,13 @@ class Settings(BaseSettings):
     ENABLE_MAGIC_LINKS: bool = Field(default=True)
     ENABLE_OAUTH: bool = Field(default=True)
     ENABLE_MFA: bool = Field(default=True)
+    # Enforce MFA at the login paths (OAuth browser login, /authorize, magic-link)
+    # for users who have it enabled. Kept DEFAULT-OFF (2026-08-23): the audit found
+    # MFA was bypassed on every path except JSON /signin, and turning enforcement
+    # on before the MFA-challenge UI ships would lock users out. Flip to true
+    # (globally or per-deploy) once the challenge UI is live. When false, behavior
+    # is exactly as today. Per-org policy can layer on top later.
+    MFA_ENFORCE_ON_LOGIN: bool = Field(default=False)
     ENABLE_ORGANIZATIONS: bool = Field(default=True)
     ENABLE_GUEST_ACCESS: bool = Field(
         default=True, description="Enable guest access token endpoint"

--- a/apps/api/app/routers/v1/auth.py
+++ b/apps/api/app/routers/v1/auth.py
@@ -1064,6 +1064,22 @@ async def login_form(
     # Reset failed attempts on successful login
     await AccountLockoutService.reset_failed_attempts(db, user)
 
+    # SECURITY (2026-08-23): enforce MFA on the OAuth browser-login path. This was
+    # the primary bypass — a user with MFA enabled was issued a full session here
+    # with no second factor. Gated behind MFA_ENFORCE_ON_LOGIN (default OFF), so
+    # this is inert until the challenge UI ships and the flag is flipped; when off,
+    # mfa_required_for() returns False and behavior is unchanged.
+    from app.auth.mfa_enforcement import mfa_required_for
+
+    if mfa_required_for(user):
+        await log_activity(
+            db, str(user.id), "signin", {"method": "oauth_form", "mfa_required": True}, request
+        )
+        return make_error_page(
+            "This account requires a second factor to sign in. Complete the "
+            "additional verification step to continue.",
+        )
+
     # Create session and tokens
     access_token, refresh_token, session = await AuthService.create_session(
         db, user, ip_address=request.client.host, user_agent=request.headers.get("user-agent")
@@ -1944,6 +1960,27 @@ async def magic_link_callback(
     if not user:
         return _expired_page()
 
+    # SECURITY (2026-08-23): a magic link proves mailbox control but is not the
+    # user's second factor. If MFA is enforced and enabled, do NOT mint a session
+    # here — and do NOT burn the link, so the user can complete verification.
+    # Gated behind MFA_ENFORCE_ON_LOGIN (default OFF): inert until the challenge UI
+    # ships. When off, behavior is unchanged.
+    from app.auth.mfa_enforcement import mfa_required_for
+
+    if mfa_required_for(user):
+        await log_activity(
+            db, str(user.id), "signin", {"method": "magic_link", "mfa_required": True}, req
+        )
+        return HTMLResponse(
+            content=_recovery_page_html(
+                "<h1>Additional verification required</h1>"
+                '<p class="lede">This account has two-factor authentication enabled. '
+                "Signing in by link is not sufficient on its own.</p>"
+                "<p>Return to the sign-in page and complete the second-factor step.</p>"
+            ),
+            status_code=401,
+        )
+
     # Burn the token before minting anything: a link that has produced a
     # session must never produce a second one.
     magic_link.used_at = datetime.utcnow()
@@ -2005,6 +2042,36 @@ async def verify_magic_link(
 
     if not user:
         raise HTTPException(status_code=400, detail="User not found")
+
+    # SECURITY (2026-08-23): enforce MFA on the JSON magic-link path too. A JSON
+    # caller receives the same mfa_required + mfa_token contract the /signin path
+    # uses, and completes at /mfa/challenge/verify. The link is NOT burned on an
+    # MFA interrupt, so the user isn't stranded. Gated behind MFA_ENFORCE_ON_LOGIN
+    # (default OFF): inert until the challenge UI ships; when off, unchanged.
+    from app.auth.mfa_enforcement import mfa_required_for, mint_mfa_challenge_token
+
+    if mfa_required_for(user):
+        await log_activity(
+            db, str(user.id), "signin", {"method": "magic_link", "mfa_required": True}, req
+        )
+        return SignInResponse(
+            user=UserResponse(
+                id=str(user.id),
+                email=user.email,
+                email_verified=user.email_verified,
+                username=user.username,
+                first_name=user.first_name,
+                last_name=user.last_name,
+                profile_image_url=user.profile_image_url,
+                is_admin=getattr(user, "is_admin", False),
+                created_at=user.created_at,
+                updated_at=user.updated_at,
+                last_sign_in_at=user.last_sign_in_at,
+            ),
+            tokens=None,
+            mfa_required=True,
+            mfa_token=mint_mfa_challenge_token(user),
+        )
 
     # Mark magic link as used
     magic_link.used_at = datetime.utcnow()

--- a/apps/api/app/routers/v1/oauth_provider.py
+++ b/apps/api/app/routers/v1/oauth_provider.py
@@ -873,6 +873,30 @@ async def authorize_get(
                     detail="Email verification required. Please verify your email before authorizing third-party applications.",
                 )
 
+    # SECURITY (2026-08-23): enforce MFA at /authorize. The docstring long claimed
+    # "MFA required → respect it; never bypass" but no check existed. Even with the
+    # login form now gating MFA, a PRE-EXISTING non-MFA session cookie could sail
+    # through here, so /authorize refuses to issue a code for an MFA-enforced user
+    # and sends them back through login to complete the second factor. Gated behind
+    # MFA_ENFORCE_ON_LOGIN (default OFF): inert until the challenge UI ships; when
+    # off, behavior is unchanged. Mirrors the email-verification handling above:
+    # silent auth → login_required error redirect; interactive → back to login.
+    from app.auth.mfa_enforcement import mfa_required_for
+
+    if mfa_required_for(current_user):
+        if silent_auth:
+            return _redirect_with_oauth_error(
+                redirect_uri,
+                error="login_required",
+                error_description="mfa_required",
+                state=state,
+                client_validated=True,
+            )
+        login_params = urlencode(
+            {"client_id": client_id, "client_name": client.name, "mfa_required": "1"}
+        )
+        return RedirectResponse(url=f"/api/v1/auth/login?{login_params}", status_code=302)
+
     # Check if user has already consented to all requested scopes
     requested_scopes = ConsentService.parse_scopes(scope)
     has_consent = await ConsentService.has_consent(db, current_user.id, client_id, requested_scopes)

--- a/apps/api/tests/unit/auth/test_mfa_enforcement.py
+++ b/apps/api/tests/unit/auth/test_mfa_enforcement.py
@@ -1,0 +1,54 @@
+"""Unit tests for the shared MFA-enforcement gate (2026-08-23).
+
+Guards the decision that fixes the audit's #1 P0 — MFA was bypassed on every
+login path except JSON /signin. The gate must be OFF by default (so shipping it
+cannot lock anyone out) and only True when BOTH the flag is on AND the user has
+MFA configured. Pure functions — no DB, no app bootstrap.
+"""
+
+from types import SimpleNamespace
+
+import jwt as pyjwt
+
+from app.auth.mfa_enforcement import (
+    MFA_CHALLENGE_TYPE,
+    mfa_required_for,
+    mint_mfa_challenge_token,
+)
+from app.config import settings
+
+
+def _user(mfa_enabled=True, mfa_secret="SECRET"):
+    return SimpleNamespace(id="u-1", mfa_enabled=mfa_enabled, mfa_secret=mfa_secret)
+
+
+class TestGateDefaultOff:
+    def test_off_by_default_even_with_mfa_enabled(self, monkeypatch):
+        # The flag defaults False; with it off, NO login path is interrupted —
+        # this is the property that makes shipping enforcement lock-out-safe.
+        monkeypatch.setattr(settings, "MFA_ENFORCE_ON_LOGIN", False, raising=False)
+        assert mfa_required_for(_user(mfa_enabled=True)) is False
+
+    def test_on_and_enabled_requires_mfa(self, monkeypatch):
+        monkeypatch.setattr(settings, "MFA_ENFORCE_ON_LOGIN", True, raising=False)
+        assert mfa_required_for(_user(mfa_enabled=True, mfa_secret="S")) is True
+
+    def test_on_but_user_has_no_mfa_does_not_require(self, monkeypatch):
+        monkeypatch.setattr(settings, "MFA_ENFORCE_ON_LOGIN", True, raising=False)
+        assert mfa_required_for(_user(mfa_enabled=False, mfa_secret=None)) is False
+        assert mfa_required_for(_user(mfa_enabled=True, mfa_secret=None)) is False
+
+
+class TestChallengeToken:
+    def test_token_is_a_challenge_not_a_session(self, monkeypatch):
+        monkeypatch.setattr(settings, "MFA_ENFORCE_ON_LOGIN", True, raising=False)
+        token = mint_mfa_challenge_token(_user())
+        decoded = pyjwt.decode(
+            token,
+            settings.JWT_SECRET_KEY or "development-secret-key",
+            algorithms=["HS256"],
+            options={"verify_iss": False},
+        )
+        assert decoded["type"] == MFA_CHALLENGE_TYPE
+        assert decoded["sub"] == "u-1"
+        assert "exp" in decoded and "iat" in decoded


### PR DESCRIPTION
**Fix #3 — the central one — of the 2026-08-23 MFA/passkey audit.** The audit's most dangerous finding: MFA was enforced on exactly ONE path (JSON `/signin`) while **OAuth browser login, OAuth `/authorize`, and both magic-link paths issued full sessions with no MFA check**. A user who "enabled 2FA" was unprotected on every path a product actually uses through Janua — 2FA protected almost nothing.

## Lock-out-safe by construction
New flag **`MFA_ENFORCE_ON_LOGIN`, default FALSE**. Per the "fix bugs now, stage enforcement" plan: while off, `mfa_required_for()` always returns False and **every login path behaves exactly as today** — merging cannot lock anyone out. Flip it on once the MFA-challenge UI ships (next PR).

## One shared gate, four bypasses closed
- `app/auth/mfa_enforcement.py`: `mfa_required_for(user)` (True only if flag on **and** user has MFA) + `mint_mfa_challenge_token(user)` (same shape `/signin` issues, consumed by the existing `/mfa/challenge/verify`).
- **login_form** (OAuth browser login) → interstitial.
- **magic_link_callback** (browser) → verification-required page, link **not** burned.
- **verify_magic_link** (JSON) → `mfa_required` + `mfa_token`, link **not** burned.
- **oauth_provider.authorize** → silent-auth: `login_required(mfa_required)` error redirect; interactive: back to login. Catches a **pre-existing non-MFA cookie**.

## Tests
`tests/unit/auth/test_mfa_enforcement.py` — off-by-default (the lock-out-safety property), on+enabled requires, on+no-MFA doesn't, challenge-token-is-a-challenge.

## Series
Next: **MFA-challenge UI + passkey login UI** (which make it safe to flip the flag), then per-org require-MFA policy / trusted-device / step-up, and restoring the quarantined MFA tests to CI. Companions: #556 (backup-code hashing), #557 (passkey ceremonies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)