### PR TITLE
feat(auth): MFA-challenge + passkey login UI/SDK (P1) + fix 2 pre-existing 500-on-success bugs

### DIFF
--- a/apps/api/app/routers/v1/auth.py
+++ b/apps/api/app/routers/v1/auth.py
@@ -627,6 +627,226 @@ async def _recover_authorize_url_from_client(client_id: str, db) -> Optional[str
     return f"{parsed.scheme}://{parsed.netloc}/"
 
 
+def _render_mfa_challenge_page(
+    *,
+    mfa_token: str,
+    app_name: str,
+    auth_request_id: Optional[str],
+    client_id: Optional[str],
+    client_name: Optional[str],
+    next_url: Optional[str],
+    error_message: Optional[str] = None,
+    status_code: int = 200,
+):
+    """Render the hosted second-factor screen for the OAuth browser-login flow.
+
+    This replaces the previous dead-end interstitial (a static "you need a second
+    factor" message with no way to enter a code — auth's P1 #3). It POSTs the code
+    plus the short-lived `mfa_token` to `/api/v1/auth/login-form/mfa`, which
+    verifies the factor, sets the session cookies, and resumes the OAuth redirect.
+
+    The OAuth context (`auth_request_id`/`client_id`/`client_name`/`next`) is
+    carried as hidden fields so the verify step can rebuild the same authorize
+    URL — the `oauth:pre_login:<auth_request_id>` Redis key is NOT consumed on the
+    MFA branch (login_form only deletes it after a session is actually created),
+    so it is still available when the second factor completes.
+    """
+    import html
+
+    from fastapi.responses import HTMLResponse
+
+    safe_app_name = html.escape(app_name or "Application")
+    hidden_fields = _oauth_context_hidden_fields_html(
+        auth_request_id=auth_request_id,
+        client_id=client_id,
+        client_name=client_name,
+        next_url=next_url,
+    )
+    error_html = (
+        f'<div class="error">{html.escape(error_message)}</div>' if error_message else ""
+    )
+
+    html_content = f"""
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Two-factor authentication - Janua</title>
+    <style>
+        * {{ box-sizing: border-box; margin: 0; padding: 0; }}
+        body {{
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 20px;
+        }}
+        .login-container {{
+            background: white;
+            border-radius: 16px;
+            box-shadow: 0 20px 60px rgba(0,0,0,0.3);
+            padding: 40px;
+            width: 100%;
+            max-width: 400px;
+        }}
+        .logo {{ text-align: center; margin-bottom: 24px; }}
+        .logo h1 {{ font-size: 28px; color: #333; margin-bottom: 8px; }}
+        .logo p {{ color: #666; font-size: 14px; }}
+        .app-info {{
+            background: #f8f9fa;
+            border-radius: 8px;
+            padding: 12px 16px;
+            margin-bottom: 24px;
+            text-align: center;
+        }}
+        .app-info span {{ color: #666; font-size: 13px; }}
+        .app-info strong {{ color: #333; }}
+        .form-group {{ margin-bottom: 20px; }}
+        label {{ display: block; margin-bottom: 6px; color: #333; font-weight: 500; font-size: 14px; }}
+        input[type="text"] {{
+            width: 100%;
+            padding: 12px 16px;
+            border: 2px solid #e1e5eb;
+            border-radius: 8px;
+            font-size: 20px;
+            letter-spacing: 4px;
+            text-align: center;
+        }}
+        input:focus {{
+            outline: none;
+            border-color: #667eea;
+            box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
+        }}
+        button {{
+            width: 100%;
+            padding: 14px;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            color: white;
+            border: none;
+            border-radius: 8px;
+            font-size: 16px;
+            font-weight: 600;
+            cursor: pointer;
+        }}
+        .hint {{ color: #666; font-size: 13px; text-align: center; margin-top: 12px; }}
+        .error {{
+            background: #fee;
+            color: #c00;
+            padding: 12px 16px;
+            border-radius: 8px;
+            margin-bottom: 20px;
+            font-size: 14px;
+        }}
+        .footer {{ text-align: center; margin-top: 24px; color: #666; font-size: 12px; }}
+    </style>
+</head>
+<body>
+    <div class="login-container">
+        <div class="logo">
+            <h1>&#128274; Janua</h1>
+            <p>Two-factor authentication</p>
+        </div>
+
+        <div class="app-info">
+            <span>Signing in to <strong>{safe_app_name}</strong></span>
+        </div>
+
+        {error_html}
+
+        <form method="POST" action="/api/v1/auth/login-form/mfa">
+            <input type="hidden" name="mfa_token" value="{html.escape(mfa_token)}">
+            {hidden_fields}
+            <div class="form-group">
+                <label for="code">Verification code</label>
+                <input type="text" id="code" name="code" inputmode="text"
+                       autocomplete="one-time-code" placeholder="123456"
+                       required autofocus>
+            </div>
+            <button type="submit">Verify</button>
+            <div class="hint">Enter the 6-digit code from your authenticator app, or a backup code.</div>
+        </form>
+
+        <div class="footer">Powered by Janua &bull; Secure Authentication</div>
+    </div>
+</body>
+</html>
+"""
+    return HTMLResponse(content=html_content, status_code=status_code)
+
+
+def _set_session_cookies(response, access_token: str, refresh_token: str) -> None:
+    """Set the hosted-flow session cookies on a response.
+
+    Extracted so the password path (login_form) and the second-factor path
+    (login_form_mfa) set identical cookies — same names, flags, TTLs, and
+    optional cross-subdomain domain — instead of drifting between two copies.
+    The access cookie is intentionally non-HttpOnly (the browser SDK reads it for
+    API calls); the refresh cookie is HttpOnly.
+    """
+    access_cookie_kwargs: dict = {
+        "httponly": False,
+        "samesite": "lax",
+        "secure": True,
+        "max_age": 3600,  # 1 hour
+    }
+    refresh_cookie_kwargs: dict = {
+        "httponly": True,
+        "samesite": "lax",
+        "secure": True,
+        "max_age": 604800,  # 7 days
+    }
+    if settings.COOKIE_DOMAIN:
+        access_cookie_kwargs["domain"] = settings.COOKIE_DOMAIN
+        refresh_cookie_kwargs["domain"] = settings.COOKIE_DOMAIN
+
+    response.set_cookie(key="janua_access_token", value=access_token, **access_cookie_kwargs)
+    response.set_cookie(key="janua_refresh_token", value=refresh_token, **refresh_cookie_kwargs)
+
+
+async def _resolve_oauth_redirect_target(
+    *,
+    auth_request_id: Optional[str],
+    client_id: Optional[str],
+    next_url: str,
+    redis: ResilientRedisClient,
+    db,
+) -> str:
+    """Resolve where to send the browser after a hosted login completes.
+
+    Mirrors login_form's redirect logic for the second-factor path: prefer the
+    OAuth authorize URL rebuilt from the Redis-stored params (keyed by
+    auth_request_id), fall back to the client's registered origin, and otherwise
+    use the validated `next` URL. Does NOT delete the Redis key (the caller does,
+    after a session is created), matching login_form's single-use semantics.
+    """
+    if auth_request_id:
+        stored_data = await redis.get(f"oauth:pre_login:{auth_request_id}")
+        if stored_data:
+            try:
+                auth_params = json.loads(stored_data)
+                query_params = {}
+                for key in [
+                    "response_type", "client_id", "redirect_uri", "scope",
+                    "state", "nonce", "code_challenge", "code_challenge_method",
+                ]:
+                    if auth_params.get(key) is not None:
+                        query_params[key] = auth_params[key]
+                return f"/api/v1/oauth/authorize?{urlencode(query_params)}"
+            except (json.JSONDecodeError, KeyError):
+                pass
+        # Redis lost the params — try the client's registered origin.
+        if client_id:
+            recovered = await _recover_authorize_url_from_client(client_id, db)
+            if recovered:
+                return recovered
+        return "/"
+    # Non-OAuth login: validate the caller-supplied next URL (CWE-601).
+    return validate_redirect_url(next_url, default_url="/")
+
+
 # GET /login - Render login form for OAuth flows
 @router.get("/login")
 async def login_page(
@@ -1110,9 +1330,23 @@ async def login_form(
         await log_activity(
             db, str(user.id), "signin", {"method": "oauth_form", "mfa_required": True}, request
         )
-        return make_error_page(
-            "This account requires a second factor to sign in. Complete the "
-            "additional verification step to continue.",
+        # Render the real second-factor screen (P1 #3). We mint a short-lived
+        # challenge token here and hand the user a code-entry form that POSTs to
+        # /login-form/mfa; that endpoint verifies the factor, sets the session
+        # cookies, and completes the OAuth redirect. The OAuth context is carried
+        # in hidden fields so the redirect can be rebuilt after verification.
+        from app.auth.mfa_enforcement import mint_mfa_challenge_token
+
+        return _render_mfa_challenge_page(
+            mfa_token=mint_mfa_challenge_token(user),
+            app_name=client_name or "Application",
+            auth_request_id=auth_request_id,
+            client_id=client_id,
+            client_name=client_name,
+            # For non-OAuth logins the redirect target is `next`; for OAuth it is
+            # rebuilt from auth_request_id, so only pass next when there is no
+            # auth_request_id (matches _oauth_context_hidden_fields_html's rule).
+            next_url=safe_next if not auth_request_id else None,
         )
 
     # Create session and tokens
@@ -1181,28 +1415,132 @@ async def login_form(
         # For non-OAuth flows, safe_next was validated against the redirect allowlist.
         response = RedirectResponse(url=safe_next, status_code=302)
 
-    # Build cookie kwargs — include domain for cross-subdomain SSO when configured
-    access_cookie_kwargs: dict = {
-        "httponly": False,  # Allow JS access for API calls
-        "samesite": "lax",
-        "secure": True,  # HTTPS only
-        "max_age": 3600,  # 1 hour
-    }
-    if settings.COOKIE_DOMAIN:
-        access_cookie_kwargs["domain"] = settings.COOKIE_DOMAIN
+    # Set session cookies (shared with the second-factor path — see helper).
+    _set_session_cookies(response, access_token, refresh_token)
 
-    refresh_cookie_kwargs: dict = {
-        "httponly": True,  # HttpOnly for security
-        "samesite": "lax",
-        "secure": True,
-        "max_age": 604800,  # 7 days
-    }
-    if settings.COOKIE_DOMAIN:
-        refresh_cookie_kwargs["domain"] = settings.COOKIE_DOMAIN
+    return response
 
-    response.set_cookie(key="janua_access_token", value=access_token, **access_cookie_kwargs)
-    response.set_cookie(key="janua_refresh_token", value=refresh_token, **refresh_cookie_kwargs)
 
+@router.post("/login-form/mfa")
+@limiter.limit("5/minute")
+async def login_form_mfa(
+    request: Request,
+    mfa_token: str = Form(...),
+    code: str = Form(...),
+    next: str = Form("/"),
+    auth_request_id: Optional[str] = Form(None),
+    client_id: Optional[str] = Form(None),
+    client_name: Optional[str] = Form(None),
+    db: Session = Depends(get_db),
+    redis: ResilientRedisClient = Depends(get_redis),
+):
+    """Complete the second factor for the hosted OAuth browser-login flow (P1 #3).
+
+    The GET /login → POST /login-form path renders the MFA challenge screen (via
+    _render_mfa_challenge_page) when MFA is required; that screen POSTs here with
+    the short-lived `mfa_token` and the user's code, plus the OAuth context. This
+    endpoint verifies the factor, establishes the session cookies, and resumes
+    the OAuth redirect — the browser equivalent of POST /mfa/challenge/verify
+    (which returns JSON tokens and cannot set cookies or redirect).
+
+    On an invalid code it re-renders the challenge screen (401) with a freshly
+    minted challenge token so the user can retry without restarting sign-in.
+    """
+    from uuid import UUID
+
+    import jwt as pyjwt
+
+    # Decode + validate the challenge token (same contract as
+    # /mfa/challenge/verify: HS256 over JWT_SECRET_KEY, type == "mfa_challenge").
+    def _reject(msg: str, *, remint_for=None):
+        token_for_retry = mfa_token
+        if remint_for is not None:
+            from app.auth.mfa_enforcement import mint_mfa_challenge_token
+
+            token_for_retry = mint_mfa_challenge_token(remint_for)
+        return _render_mfa_challenge_page(
+            mfa_token=token_for_retry,
+            app_name=client_name or "Application",
+            auth_request_id=auth_request_id,
+            client_id=client_id,
+            client_name=client_name,
+            next_url=next if not auth_request_id else None,
+            error_message=msg,
+            status_code=401,
+        )
+
+    try:
+        payload = pyjwt.decode(
+            mfa_token,
+            settings.JWT_SECRET_KEY or "development-secret-key",
+            algorithms=["HS256"],
+            options={"require": ["sub", "type", "exp"]},
+        )
+    except pyjwt.ExpiredSignatureError:
+        # Can't re-mint (no user yet) — the challenge is stale, restart sign-in.
+        return _reject("Your verification session expired. Please sign in again.")
+    except pyjwt.InvalidTokenError:
+        return _reject("Invalid verification session. Please sign in again.")
+
+    if payload.get("type") != "mfa_challenge":
+        return _reject("Invalid verification session. Please sign in again.")
+
+    result = await db.execute(
+        select(User).where(User.id == UUID(payload.get("sub")), User.status == UserStatus.ACTIVE)
+    )
+    user = result.scalar_one_or_none()
+    if not user or not user.mfa_enabled or not user.mfa_secret:
+        return _reject("Invalid verification session. Please sign in again.")
+
+    # Verify TOTP, then fall back to a single-use backup code (shared helper).
+    import pyotp
+
+    from app.routers.v1.mfa import consume_backup_code
+
+    code_valid = pyotp.TOTP(user.mfa_secret).verify(code, valid_window=1)
+    if not code_valid and consume_backup_code(user, code):
+        db.add(
+            ActivityLog(
+                user_id=user.id,
+                action="mfa_backup_code_used",
+                activity_metadata={"context": "oauth_form"},
+            )
+        )
+        code_valid = True
+
+    if not code_valid:
+        # Wrong code — re-render with a fresh challenge token so retry works even
+        # if the original is close to expiry.
+        return _reject("Invalid verification code. Please try again.", remint_for=user)
+
+    # Second factor cleared — create the session and resume the OAuth redirect.
+    access_token, refresh_token, _session = await AuthService.create_session(
+        db, user, ip_address=request.client.host, user_agent=request.headers.get("user-agent")
+    )
+    await log_activity(
+        db, str(user.id), "signin", {"method": "oauth_form", "mfa": "totp"}, request
+    )
+
+    safe_next = await _resolve_oauth_redirect_target(
+        auth_request_id=auth_request_id,
+        client_id=client_id,
+        next_url=next,
+        redis=redis,
+        db=db,
+    )
+
+    # Single-use: drop the pre-login Redis key now that the session exists
+    # (matches login_form). Best-effort — the key also has a TTL.
+    if auth_request_id:
+        try:
+            await redis.delete(f"oauth:pre_login:{auth_request_id}")
+        except Exception:
+            pass
+
+    from fastapi.responses import RedirectResponse
+
+    response = RedirectResponse(url=safe_next, status_code=302)
+    _set_session_cookies(response, access_token, refresh_token)
     return response
 
 

--- a/apps/api/app/routers/v1/mfa.py
+++ b/apps/api/app/routers/v1/mfa.py
@@ -33,7 +33,11 @@ class MFAChallengeVerifyRequest(BaseModel):
     """MFA challenge verification request (during sign-in)"""
 
     mfa_token: str
-    code: str = Field(..., min_length=6, max_length=8)  # TOTP (6) or backup code (9 with dash)
+    # TOTP is 6 digits; a formatted backup code is XXXX-XXXX (9 chars). max_length
+    # was 8, which rejected every formatted backup code at validation before it
+    # reached consume_backup_code — so backup codes could never complete a sign-in
+    # challenge. Allow up to 9 (the normalizer strips the dash on compare).
+    code: str = Field(..., min_length=6, max_length=9)
 
 
 class MFAEnableRequest(BaseModel):
@@ -277,7 +281,7 @@ async def enable_mfa(
 
     # Log activity
     activity = ActivityLog(
-        user_id=current_user.id, action="mfa_setup_initiated", details={"method": "totp"}
+        user_id=current_user.id, action="mfa_setup_initiated", activity_metadata={"method": "totp"}
     )
     db.add(activity)
 
@@ -309,7 +313,7 @@ async def verify_mfa(
 
     # Log activity
     activity = ActivityLog(
-        user_id=current_user.id, action="mfa_enabled", details={"method": "totp"}
+        user_id=current_user.id, action="mfa_enabled", activity_metadata={"method": "totp"}
     )
     db.add(activity)
 
@@ -352,7 +356,7 @@ async def disable_mfa(
     current_user.mfa_backup_codes = []
 
     # Log activity
-    activity = ActivityLog(user_id=current_user.id, action="mfa_disabled", details={})
+    activity = ActivityLog(user_id=current_user.id, action="mfa_disabled", activity_metadata={})
     db.add(activity)
 
     await db.commit()
@@ -388,7 +392,7 @@ async def regenerate_backup_codes(
     activity = ActivityLog(
         user_id=current_user.id,
         action="mfa_backup_codes_regenerated",
-        details={"count": len(backup_codes)},
+        activity_metadata={"count": len(backup_codes)},
     )
     db.add(activity)
 
@@ -411,7 +415,7 @@ async def validate_mfa_code(
     if totp.verify(code, valid_window=1):
         # Log successful validation
         activity = ActivityLog(
-            user_id=current_user.id, action="mfa_verify", details={"method": "totp"}
+            user_id=current_user.id, action="mfa_verify", activity_metadata={"method": "totp"}
         )
         db.add(activity)
         await db.commit()
@@ -423,7 +427,7 @@ async def validate_mfa_code(
         activity = ActivityLog(
             user_id=current_user.id,
             action="mfa_backup_code_used",
-            details={"context": "validate-code"},
+            activity_metadata={"context": "validate-code"},
         )
         db.add(activity)
         await db.commit()
@@ -518,7 +522,7 @@ async def initiate_mfa_recovery(email: str, db: Session = Depends(get_db)):
 
     # Log recovery attempt
     activity = ActivityLog(
-        user_id=user.id, action="mfa_recovery_initiated", details={"method": "email"}
+        user_id=user.id, action="mfa_recovery_initiated", activity_metadata={"method": "email"}
     )
     db.add(activity)
     await db.commit()
@@ -612,7 +616,7 @@ async def verify_mfa_challenge(
         activity = ActivityLog(
             user_id=user.id,
             action="mfa_backup_code_used",
-            details={"context": "signin"},
+            activity_metadata={"context": "signin"},
         )
         db.add(activity)
         code_valid = True
@@ -627,7 +631,9 @@ async def verify_mfa_challenge(
 
     # Log successful MFA sign-in
     activity = ActivityLog(
-        user_id=user.id, action="mfa_verify", details={"method": "totp", "context": "signin"}
+        user_id=user.id,
+        action="mfa_verify",
+        activity_metadata={"method": "totp", "context": "signin"},
     )
     db.add(activity)
     await db.commit()

--- a/apps/api/app/routers/v1/passkeys.py
+++ b/apps/api/app/routers/v1/passkeys.py
@@ -275,7 +275,7 @@ async def verify_registration(
     activity = ActivityLog(
         user_id=current_user.id,
         action="passkey_registered",
-        details={"passkey_id": str(passkey.id), "name": passkey.name},
+        activity_metadata={"passkey_id": str(passkey.id), "name": passkey.name},
     )
     db.add(activity)
 
@@ -419,7 +419,7 @@ async def verify_authentication(
                 ActivityLog(
                     user_id=user.id,
                     action="passkey_clone_suspected",
-                    details={
+                    activity_metadata={
                         "passkey_id": str(passkey.id),
                         "stored_sign_count": passkey.sign_count,
                         "presented_sign_count": verification.new_sign_count,
@@ -463,7 +463,7 @@ async def verify_authentication(
     activity = ActivityLog(
         user_id=user.id,
         action="passkey_authentication",
-        details={"passkey_id": str(passkey.id), "session_id": str(user_session.id)},
+        activity_metadata={"passkey_id": str(passkey.id), "session_id": str(user_session.id)},
     )
     db.add(activity)
 
@@ -571,7 +571,9 @@ async def delete_passkey(
 
     # Log activity
     activity = ActivityLog(
-        user_id=current_user.id, action="passkey_deleted", details={"passkey_name": passkey.name}
+        user_id=current_user.id,
+        action="passkey_deleted",
+        activity_metadata={"passkey_name": passkey.name},
     )
     db.add(activity)
 

--- a/apps/api/tests/unit/routers/test_login_form_mfa.py
+++ b/apps/api/tests/unit/routers/test_login_form_mfa.py
@@ -1,0 +1,133 @@
+"""Unit tests for POST /api/v1/auth/login-form/mfa (hosted OAuth MFA screen).
+
+This is the browser/OAuth equivalent of /mfa/challenge/verify (P1 #3): the hosted
+login form (GET /login → POST /login-form) renders a real second-factor screen on
+MFA-required, and that screen POSTs here. On a valid code this sets the session
+cookies and 302-redirects to resume the OAuth flow; on an invalid code it
+re-renders the challenge screen (401) with a fresh challenge token.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta
+
+import jwt as pyjwt
+import pyotp
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.config import settings
+from app.core.redis import get_redis
+from app.database import get_db
+from app.main import app
+from app.models import Base, User, UserStatus
+
+MFA_FORM_URL = "/api/v1/auth/login-form/mfa"
+TEST_SECRET = pyotp.random_base32()
+
+
+def _mint_challenge(user_id: str) -> str:
+    payload = {
+        "sub": str(user_id),
+        "type": "mfa_challenge",
+        "exp": datetime.utcnow() + timedelta(minutes=5),
+        "iat": datetime.utcnow(),
+        "iss": settings.JWT_ISSUER,
+    }
+    return pyjwt.encode(
+        payload, settings.JWT_SECRET_KEY or "development-secret-key", algorithm="HS256"
+    )
+
+
+@pytest_asyncio.fixture
+async def mfa_form_client():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with session_factory() as session:
+            yield session
+
+    import fakeredis.aioredis
+
+    import app.services.auth_service as auth_service_module
+
+    fake_redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+    async def _fake_get_redis():
+        return fake_redis
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_redis] = _fake_get_redis
+    _orig_get_redis = auth_service_module.get_redis
+    auth_service_module.get_redis = _fake_get_redis
+
+    user_id = uuid.uuid4()
+    user = User(
+        id=user_id,
+        email="mfa-form-user@janua.test",
+        email_verified=True,
+        status=UserStatus.ACTIVE,
+        is_active=True,
+        mfa_enabled=True,
+        mfa_secret=TEST_SECRET,
+        mfa_backup_codes=[],
+    )
+    async with session_factory() as session:
+        session.add(user)
+        await session.commit()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        client.__dict__["_seeded_user_id"] = str(user_id)
+        yield client
+
+    app.dependency_overrides.clear()
+    auth_service_module.get_redis = _orig_get_redis
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_valid_code_sets_cookies_and_redirects(mfa_form_client):
+    user_id = mfa_form_client.__dict__["_seeded_user_id"]
+    code = pyotp.TOTP(TEST_SECRET).now()
+
+    resp = await mfa_form_client.post(
+        MFA_FORM_URL,
+        data={"mfa_token": _mint_challenge(user_id), "code": code, "next": "/dashboard"},
+    )
+
+    # 302 redirect to the (validated) next target, with session cookies set.
+    assert resp.status_code == 302, resp.text
+    assert resp.headers["location"] == "/dashboard"
+    set_cookie = resp.headers.get_list("set-cookie")
+    joined = " ".join(set_cookie)
+    assert "janua_access_token=" in joined
+    assert "janua_refresh_token=" in joined
+
+
+@pytest.mark.asyncio
+async def test_invalid_code_rerenders_challenge(mfa_form_client):
+    user_id = mfa_form_client.__dict__["_seeded_user_id"]
+
+    resp = await mfa_form_client.post(
+        MFA_FORM_URL,
+        data={"mfa_token": _mint_challenge(user_id), "code": "000000"},
+    )
+
+    # Re-renders the challenge screen (not a redirect, no session cookies).
+    assert resp.status_code == 401
+    assert "Verification code" in resp.text
+    assert "Invalid verification code" in resp.text
+    assert "janua_access_token=" not in " ".join(resp.headers.get_list("set-cookie"))

--- a/apps/api/tests/unit/routers/test_mfa_challenge_verify.py
+++ b/apps/api/tests/unit/routers/test_mfa_challenge_verify.py
@@ -1,0 +1,187 @@
+"""Unit tests for POST /api/v1/mfa/challenge/verify (the sign-in second factor).
+
+This is the endpoint the TypeScript SDK's verifyMfaChallenge(), the dashboard
+MFA step, and the hosted-login MFA screen all depend on to exchange a password
+challenge for real session tokens.
+
+Two things are guarded here:
+
+1. The happy path returns the SignInResponse contract ({user, tokens}) for both
+   a valid TOTP code and a valid backup code.
+
+2. Regression: every ActivityLog these paths write must use the model's
+   `activity_metadata` column, NOT a `details=` kwarg (which is not a mapped
+   attribute and raises TypeError → 500). The success path always writes an
+   ActivityLog, so if that kwarg ever regresses these tests turn the resulting
+   500 red. This bug shipped undetected precisely because the comprehensive MFA
+   tests were quarantined out of the CI lane.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta
+
+import jwt as pyjwt
+import pyotp
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.config import settings
+from app.core.redis import get_redis
+from app.database import get_db
+from app.main import app
+from app.models import Base, User, UserStatus
+from app.routers.v1.mfa import hash_backup_code
+
+CHALLENGE_URL = "/api/v1/mfa/challenge/verify"
+TEST_SECRET = pyotp.random_base32()
+
+
+def _mint_challenge(user_id: str, *, expired: bool = False, wrong_type: bool = False) -> str:
+    """Mint an MFA challenge token matching what the login paths issue."""
+    exp = datetime.utcnow() + (timedelta(minutes=-1) if expired else timedelta(minutes=5))
+    payload = {
+        "sub": str(user_id),
+        "type": "session" if wrong_type else "mfa_challenge",
+        "exp": exp,
+        "iat": datetime.utcnow(),
+        "iss": settings.JWT_ISSUER,
+    }
+    return pyjwt.encode(
+        payload, settings.JWT_SECRET_KEY or "development-secret-key", algorithm="HS256"
+    )
+
+
+@pytest_asyncio.fixture
+async def mfa_client():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with session_factory() as session:
+            yield session
+
+    # AuthService.create_session talks to Redis directly (session store + token
+    # blacklist), via its own module-level `get_redis` binding — not the FastAPI
+    # dependency. Point that binding (and the mfa router's) at an in-memory
+    # fakeredis so the token-issuing path actually completes.
+    import fakeredis.aioredis
+
+    import app.services.auth_service as auth_service_module
+
+    fake_redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+
+    async def _fake_get_redis():
+        return fake_redis
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_redis] = _fake_get_redis
+    _orig_get_redis = auth_service_module.get_redis
+    auth_service_module.get_redis = _fake_get_redis
+
+    # Seed an MFA-enabled user. mfa_secret is an EncryptedString; with no
+    # FIELD_ENCRYPTION_KEY in the test env it stores plaintext, so TOTP verifies
+    # against the same value on read-back.
+    user_id = uuid.uuid4()
+    user = User(
+        id=user_id,
+        email="mfa-user@janua.test",
+        email_verified=True,
+        status=UserStatus.ACTIVE,
+        is_active=True,
+        mfa_enabled=True,
+        mfa_secret=TEST_SECRET,
+        mfa_backup_codes=[{"hash": hash_backup_code("ABCD-1234"), "used": False}],
+    )
+    async with session_factory() as session:
+        session.add(user)
+        await session.commit()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        client.__dict__["_seeded_user_id"] = str(user_id)
+        yield client
+
+    app.dependency_overrides.clear()
+    auth_service_module.get_redis = _orig_get_redis
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_valid_totp_returns_tokens(mfa_client):
+    user_id = mfa_client.__dict__["_seeded_user_id"]
+    code = pyotp.TOTP(TEST_SECRET).now()
+
+    resp = await mfa_client.post(
+        CHALLENGE_URL, json={"mfa_token": _mint_challenge(user_id), "code": code}
+    )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # SignInResponse contract the SDK relies on.
+    assert body["user"]["email"] == "mfa-user@janua.test"
+    assert body["tokens"]["access_token"]
+    assert body["tokens"]["refresh_token"]
+
+
+@pytest.mark.asyncio
+async def test_valid_backup_code_returns_tokens(mfa_client):
+    """The backup-code branch writes an extra ActivityLog — this would 500 under
+    the old `details=` kwarg. Proves that branch works end-to-end."""
+    user_id = mfa_client.__dict__["_seeded_user_id"]
+
+    resp = await mfa_client.post(
+        CHALLENGE_URL, json={"mfa_token": _mint_challenge(user_id), "code": "ABCD-1234"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["tokens"]["access_token"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_code_is_rejected(mfa_client):
+    user_id = mfa_client.__dict__["_seeded_user_id"]
+
+    resp = await mfa_client.post(
+        CHALLENGE_URL, json={"mfa_token": _mint_challenge(user_id), "code": "000000"}
+    )
+
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_expired_challenge_is_rejected(mfa_client):
+    user_id = mfa_client.__dict__["_seeded_user_id"]
+    code = pyotp.TOTP(TEST_SECRET).now()
+
+    resp = await mfa_client.post(
+        CHALLENGE_URL,
+        json={"mfa_token": _mint_challenge(user_id, expired=True), "code": code},
+    )
+
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_non_challenge_token_is_rejected(mfa_client):
+    """A real session token must not be accepted as a challenge token."""
+    user_id = mfa_client.__dict__["_seeded_user_id"]
+    code = pyotp.TOTP(TEST_SECRET).now()
+
+    resp = await mfa_client.post(
+        CHALLENGE_URL,
+        json={"mfa_token": _mint_challenge(user_id, wrong_type=True), "code": code},
+    )
+
+    assert resp.status_code == 401

--- a/apps/dashboard/app/login/page.tsx
+++ b/apps/dashboard/app/login/page.tsx
@@ -97,6 +97,12 @@ function LoginForm() {
         redirectUrl={redirectTo}
         socialProviders={{ google: true, github: true, microsoft: true, apple: true }}
         showRememberMe={false}
+        // Renders the "Sign in with Passkey" button (WebAuthn login) and, on an
+        // MFA-enabled account, the built-in two-factor code step. Both are driven
+        // by januaClient (signInWithPasskey / verifyMfaChallenge) and persist
+        // tokens the same way password sign-in does, so handleAfterSignIn works
+        // unchanged for all three paths.
+        enablePasskey
       />
 
       <div className="text-muted-foreground text-center text-sm mt-4">

--- a/apps/dashboard/lib/auth.tsx
+++ b/apps/dashboard/lib/auth.tsx
@@ -37,12 +37,33 @@ function syncTokenCookie(token: string | null): void {
 
 // ── Auth context with dashboard-specific additions ──
 
+/**
+ * Result of {@link AuthContextType.login}. When the account has a second factor,
+ * `mfaRequired` is true and `login` does NOT complete the session — the caller
+ * must collect a code and call {@link AuthContextType.verifyMfa} with the
+ * returned `mfaToken`.
+ */
+interface LoginResult {
+  mfaRequired: boolean
+  mfaToken?: string
+}
+
 interface AuthContextType {
   user: User | null
   isAuthenticated: boolean
   isLoading: boolean
   error: string | null
-  login: (email: string, password: string) => Promise<void>
+  /**
+   * Sign in with email + password. Resolves to `{ mfaRequired: true, mfaToken }`
+   * when a second factor is needed (no session is established yet); resolves to
+   * `{ mfaRequired: false }` on a completed sign-in.
+   */
+  login: (email: string, password: string) => Promise<LoginResult>
+  /**
+   * Complete an MFA challenge raised by {@link login}. Pass the `mfaToken` from
+   * the login result plus the user's TOTP or backup code.
+   */
+  verifyMfa: (mfaToken: string, code: string) => Promise<void>
   logout: () => Promise<void>
   refreshUser: () => Promise<void>
   clearError: () => void
@@ -71,13 +92,34 @@ function DashboardAuthBridge({ children }: { children: ReactNode }) {
     syncCookie()
   }, [client, isAuthenticated, isLoading])
 
-  const login = useCallback(async (email: string, password: string) => {
+  const login = useCallback(async (email: string, password: string): Promise<LoginResult> => {
     setError(null)
     try {
-      await client.auth.signIn({ email, password })
-      // Cookie sync happens via the useEffect above
+      const result = await client.auth.signIn({ email, password })
+      // A second factor is required: surface the challenge instead of treating
+      // the (token-less) response as a completed sign-in. Previously this method
+      // ignored the MFA fields entirely, so an MFA-enabled user's login appeared
+      // to "succeed" with no session — the dashboard's user-visible instance of
+      // the audit's P1 #1.
+      if (result.mfa_required) {
+        return { mfaRequired: true, mfaToken: result.mfa_token }
+      }
+      // Cookie sync happens via the useEffect above.
+      return { mfaRequired: false }
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : 'Login failed'
+      setError(errorMessage)
+      throw err
+    }
+  }, [client])
+
+  const verifyMfa = useCallback(async (mfaToken: string, code: string): Promise<void> => {
+    setError(null)
+    try {
+      await client.auth.verifyMfaChallenge(mfaToken, code)
+      // Tokens are now persisted by the SDK; the useEffect above syncs the cookie.
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Verification failed'
       setError(errorMessage)
       throw err
     }
@@ -116,6 +158,7 @@ function DashboardAuthBridge({ children }: { children: ReactNode }) {
         isLoading,
         error,
         login,
+        verifyMfa,
         logout,
         refreshUser,
         clearError,

--- a/packages/nextjs-sdk/src/app/server.ts
+++ b/packages/nextjs-sdk/src/app/server.ts
@@ -2,7 +2,31 @@ import { cookies } from 'next/headers';
 import { NextRequest } from 'next/server';
 import { SignJWT, jwtVerify } from 'jose';
 import { JanuaClient } from '@janua/typescript-sdk';
-import type { User, Session } from '@janua/typescript-sdk';
+import type { AuthResponse, TokenResponse, User, Session } from '@janua/typescript-sdk';
+
+/**
+ * Narrow an AuthResponse to its tokens, or throw with a clear reason.
+ *
+ * `AuthResponse.tokens` is optional because sign-in can return an MFA challenge
+ * (`mfa_required: true`) with NO tokens. This server-side helper establishes a
+ * session cookie in one shot and cannot run the interactive second-factor
+ * round-trip, so it fails loudly instead of dereferencing undefined tokens.
+ * MFA-enabled accounts must use the client-side flow (client.auth.signIn →
+ * verifyMfaChallenge) which owns the code-entry UI.
+ */
+function requireTokens(response: AuthResponse): TokenResponse {
+  if (response.mfa_required) {
+    throw new Error(
+      'This account requires multi-factor authentication, which the server-side ' +
+        'signIn helper does not support. Complete sign-in on the client with ' +
+        'client.auth.signIn() followed by client.auth.verifyMfaChallenge().'
+    );
+  }
+  if (!response.tokens) {
+    throw new Error('Sign-in did not return session tokens.');
+  }
+  return response.tokens;
+}
 
 const COOKIE_NAME = 'janua-session';
 const COOKIE_OPTIONS = {
@@ -83,7 +107,8 @@ export class JanuaServerClient {
 
   async signIn(email: string, password: string): Promise<{ user: User; session: Session }> {
     const response = await this.client.auth.signIn({ email, password });
-    
+    const tokens = requireTokens(response);
+
     const sessionData: SessionData = {
       user: response.user,
       session: {
@@ -95,8 +120,8 @@ export class JanuaServerClient {
         expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
         last_activity: new Date().toISOString()
       } as any,
-      accessToken: response.tokens.access_token,
-      refreshToken: response.tokens.refresh_token,
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
     };
 
     const encryptedSession = await this.encryptSession(sessionData);
@@ -124,7 +149,8 @@ export class JanuaServerClient {
     lastName?: string;
   }): Promise<{ user: User; session: Session }> {
     const response = await this.client.auth.signUp(data);
-    
+    const tokens = requireTokens(response);
+
     const sessionData: SessionData = {
       user: response.user,
       session: {
@@ -136,8 +162,8 @@ export class JanuaServerClient {
         expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
         last_activity: new Date().toISOString()
       } as any,
-      accessToken: response.tokens.access_token,
-      refreshToken: response.tokens.refresh_token,
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
     };
 
     const encryptedSession = await this.encryptSession(sessionData);
@@ -160,6 +186,7 @@ export class JanuaServerClient {
 
   async handleOAuthCallback(code: string, codeVerifier?: string): Promise<{ user: User; session: Session }> {
     const response = await this.client.auth.handleOAuthCallback(code, codeVerifier || '');
+    const tokens = requireTokens(response as unknown as AuthResponse);
 
     const sessionData: SessionData = {
       user: response.user,
@@ -172,8 +199,8 @@ export class JanuaServerClient {
         expires_at: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
         last_activity: new Date().toISOString()
       } as any,
-      accessToken: response.tokens.access_token,
-      refreshToken: response.tokens.refresh_token,
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
     };
 
     const encryptedSession = await this.encryptSession(sessionData);

--- a/packages/react-sdk/src/hooks/use-mfa.ts
+++ b/packages/react-sdk/src/hooks/use-mfa.ts
@@ -2,11 +2,15 @@ import { useState, useCallback } from 'react'
 import { useJanua } from '../provider'
 
 export interface UseMFAReturn {
-  /** Enable MFA for the current user. Returns the secret, QR code URI, and backup codes. */
-  enable: (type?: string) => Promise<{ secret: string; qr_code: string; backup_codes: string[]; provisioning_uri: string }>
-  /** Verify an MFA code */
+  /**
+   * Begin MFA enrollment for the current user. Requires the account password
+   * (the /mfa/enable endpoint verifies it before issuing a secret). Returns the
+   * TOTP secret, provisioning URI, QR code, and one-time backup codes.
+   */
+  enable: (password: string) => Promise<{ secret: string; qr_code: string; backup_codes: string[]; provisioning_uri: string }>
+  /** Confirm MFA enrollment with a TOTP code from the authenticator app. */
   verify: (code: string) => Promise<void>
-  /** Disable MFA for the current user */
+  /** Disable MFA for the current user (requires the account password). */
   disable: (password: string) => Promise<void>
   /** Whether an MFA operation is in progress */
   isLoading: boolean
@@ -26,7 +30,7 @@ export interface UseMFAReturn {
  *   const { enable, verify, disable, isLoading, error } = useMFA();
  *
  *   const handleEnable = async () => {
- *     const { secret, qrCode } = await enable('totp');
+ *     const { secret, qr_code } = await enable(userPassword);
  *     // Display QR code for user to scan
  *   };
  *
@@ -45,11 +49,11 @@ export function useMFA(): UseMFAReturn {
   const [error, setError] = useState<Error | null>(null)
 
   const enable = useCallback(
-    async (type: string = 'totp') => {
+    async (password: string) => {
       setIsLoading(true)
       setError(null)
       try {
-        const response = await client.auth.enableMFA(type)
+        const response = await client.auth.enableMFA(password)
         return response
       } catch (err) {
         const mfaError = err instanceof Error ? err : new Error('Failed to enable MFA')

--- a/packages/react-sdk/src/provider.tsx
+++ b/packages/react-sdk/src/provider.tsx
@@ -25,7 +25,7 @@ import {
   validateState,
   buildAuthorizationUrl,
 } from './utils/pkce';
-import { mapErrorToState, ReactJanuaError } from './utils/errors';
+import { createErrorState, mapErrorToState, ReactJanuaError } from './utils/errors';
 
 /**
  * Context value interface with full authentication capabilities
@@ -352,6 +352,27 @@ export function JanuaProvider({ children, config, appearance }: JanuaProviderPro
       try {
         const response = await client.signIn({ email, password });
 
+        // A second factor is required: sign-in returned mfa_required + mfa_token
+        // and NO tokens. Surface it as an MFA_REQUIRED error carrying the
+        // mfa_token so the caller can complete it (e.g. with the MFAChallenge
+        // component + client.auth.verifyMfaChallenge). Previously this method
+        // dereferenced response.tokens unconditionally, which is now typed as
+        // possibly-undefined precisely because of this case.
+        if (response.mfa_required) {
+          const mfaState = createErrorState(
+            'MFA_REQUIRED',
+            'Multi-factor authentication is required.',
+            undefined,
+            { mfa_token: response.mfa_token }
+          );
+          setError(mfaState);
+          throw ReactJanuaError.fromState(mfaState);
+        }
+
+        if (!response.tokens) {
+          throw new ReactJanuaError('UNKNOWN_ERROR', 'Sign-in did not return session tokens.');
+        }
+
         storeTokens(response.tokens.access_token, response.tokens.refresh_token);
 
         // Set user from token immediately so isAuthenticated becomes true
@@ -398,6 +419,9 @@ export function JanuaProvider({ children, config, appearance }: JanuaProviderPro
           username: options?.username,
         });
 
+        if (!response.tokens) {
+          throw new ReactJanuaError('UNKNOWN_ERROR', 'Sign-up did not return session tokens.');
+        }
         storeTokens(response.tokens.access_token, response.tokens.refresh_token);
 
         // Security: User data stored in React state only, not localStorage (CWE-312)

--- a/packages/typescript-sdk/src/__tests__/auth.test.ts
+++ b/packages/typescript-sdk/src/__tests__/auth.test.ts
@@ -7,7 +7,7 @@ import { HttpClient } from '../http-client';
 import { TokenManager } from '../utils';
 import { AuthenticationError, ValidationError } from '../errors';
 import { OAuthProvider, UserStatus } from '../types';
-import type { SignUpParams, SignInParams, MFAParams, OAuthParams } from '../types';
+import type { SignUpParams, SignInParams, OAuthParams } from '../types';
 
 // Inline fixtures to replace missing imports
 const userFixtures = {
@@ -194,16 +194,20 @@ describe('Auth', () => {
       expect(mockOnSignIn).not.toHaveBeenCalled();
     });
 
-    it('should handle MFA requirement', async () => {
+    it('should surface an MFA challenge (mfa_required + mfa_token)', async () => {
       const signInParams: SignInParams = {
         email: 'test@example.com',
         password: 'Test123!@#'
       };
 
+      // Real API contract (apps/api/app/routers/v1/auth.py:451-452): on a second
+      // factor, sign-in returns the user, mfa_required=true, an mfa_token, and NO
+      // tokens.
       const mockResponse = {
-        requires_mfa: true,
-        mfa_challenge_id: 'challenge-123',
-        mfa_methods: ['totp', 'sms']
+        user: userFixtures.validUser,
+        tokens: null,
+        mfa_required: true,
+        mfa_token: 'mfa-token-abc'
       };
 
       mockHttpClient.post.mockResolvedValue({ data: mockResponse });
@@ -211,10 +215,11 @@ describe('Auth', () => {
       const result = await auth.signIn(signInParams);
 
       expect(result).toEqual({
-        requires_mfa: true,
-        mfa_challenge_id: 'challenge-123',
-        mfa_methods: ['totp', 'sms']
+        user: userFixtures.validUser,
+        mfa_required: true,
+        mfa_token: 'mfa-token-abc'
       });
+      // No tokens are issued until verifyMfaChallenge completes the second factor.
       expect(mockTokenManager.setTokens).not.toHaveBeenCalled();
       expect(mockOnSignIn).not.toHaveBeenCalled();
     });
@@ -381,60 +386,70 @@ describe('Auth', () => {
   });
 
   describe('MFA operations', () => {
-    describe('verifyMFA', () => {
-      it('should verify MFA code successfully', async () => {
-        const mfaParams: MFAParams = {
-          challenge_id: 'challenge-123',
-          code: '123456',
-          method: 'totp'
-        };
+    describe('verifyMFA (enrollment)', () => {
+      it('should confirm enrollment and return a message', async () => {
+        const mockResponse = { message: 'MFA successfully enabled' };
 
+        mockHttpClient.post.mockResolvedValue({ data: mockResponse });
+
+        const result = await auth.verifyMFA({ code: '123456' });
+
+        expect(mockHttpClient.post).toHaveBeenCalledWith('/api/v1/mfa/verify', { code: '123456' });
+        expect(result).toEqual(mockResponse);
+      });
+    });
+
+    describe('verifyMfaChallenge (sign-in)', () => {
+      it('should complete the challenge and issue tokens', async () => {
         const mockResponse = {
           user: userFixtures.verifiedUser,
-          access_token: tokenFixtures.validAccessToken,
-          refresh_token: tokenFixtures.validRefreshToken,
-          expires_in: 3600,
-          token_type: 'bearer' as const
+          tokens: {
+            access_token: tokenFixtures.validAccessToken,
+            refresh_token: tokenFixtures.validRefreshToken,
+            expires_in: 3600,
+            token_type: 'bearer' as const
+          }
         };
 
         mockHttpClient.post.mockResolvedValue({ data: mockResponse });
 
-        const result = await auth.verifyMFA(mfaParams);
+        const result = await auth.verifyMfaChallenge('mfa-token-abc', '123456');
 
-        expect(mockHttpClient.post).toHaveBeenCalledWith('/api/v1/auth/mfa/verify', mfaParams);
+        expect(mockHttpClient.post).toHaveBeenCalledWith(
+          '/api/v1/mfa/challenge/verify',
+          { mfa_token: 'mfa-token-abc', code: '123456' },
+          { skipAuth: true }
+        );
         expect(mockTokenManager.setTokens).toHaveBeenCalled();
         expect(mockOnSignIn).toHaveBeenCalled();
         expect(result).toEqual({
           user: mockResponse.user,
-          tokens: {
-            access_token: mockResponse.access_token,
-            refresh_token: mockResponse.refresh_token,
-            expires_in: mockResponse.expires_in,
-            token_type: mockResponse.token_type
-          }
+          tokens: mockResponse.tokens
         });
       });
     });
 
     describe('enableMFA', () => {
-      it('should enable MFA successfully', async () => {
-        const method = 'totp';
+      it('should begin enrollment with the account password', async () => {
+        const password = 'CurrentPassword123!';
 
         mockHttpClient.post.mockResolvedValue({
           data: {
             secret: 'MFASECRET123',
             qr_code: 'data:image/png;base64,...',
-            backup_codes: ['code1', 'code2', 'code3']
+            backup_codes: ['code1', 'code2', 'code3'],
+            provisioning_uri: 'otpauth://totp/Janua:test'
           }
         });
 
-        const result = await auth.enableMFA(method);
+        const result = await auth.enableMFA(password);
 
-        expect(mockHttpClient.post).toHaveBeenCalledWith('/api/v1/auth/mfa/enable', { method });
+        expect(mockHttpClient.post).toHaveBeenCalledWith('/api/v1/mfa/enable', { password });
         expect(result).toEqual({
           secret: 'MFASECRET123',
           qr_code: 'data:image/png;base64,...',
-          backup_codes: ['code1', 'code2', 'code3']
+          backup_codes: ['code1', 'code2', 'code3'],
+          provisioning_uri: 'otpauth://totp/Janua:test'
         });
       });
     });
@@ -445,17 +460,15 @@ describe('Auth', () => {
 
         mockHttpClient.post.mockResolvedValue({
           data: {
-            success: true,
-            message: 'MFA disabled successfully'
+            message: 'MFA successfully disabled'
           }
         });
 
         const result = await auth.disableMFA(password);
 
-        expect(mockHttpClient.post).toHaveBeenCalledWith('/api/v1/auth/mfa/disable', { password });
+        expect(mockHttpClient.post).toHaveBeenCalledWith('/api/v1/mfa/disable', { password });
         expect(result).toEqual({
-          success: true,
-          message: 'MFA disabled successfully'
+          message: 'MFA successfully disabled'
         });
       });
     });
@@ -676,9 +689,12 @@ describe('Auth', () => {
 
         const result = await auth.regenerateMFABackupCodes(password);
 
-        expect(mockHttpClient.post).toHaveBeenCalledWith('/api/v1/mfa/regenerate-backup-codes', {
-          password: password
-        });
+        // `password` is a QUERY parameter on the handler, sent via `params`.
+        expect(mockHttpClient.post).toHaveBeenCalledWith(
+          '/api/v1/mfa/regenerate-backup-codes',
+          undefined,
+          { params: { password } }
+        );
         expect(result).toEqual(mockResponse);
       });
     });
@@ -694,9 +710,12 @@ describe('Auth', () => {
 
         const result = await auth.validateMFACode(code);
 
-        expect(mockHttpClient.post).toHaveBeenCalledWith('/api/v1/mfa/validate-code', {
-          code: code
-        });
+        // `code` is a QUERY parameter on the handler, sent via `params`.
+        expect(mockHttpClient.post).toHaveBeenCalledWith(
+          '/api/v1/mfa/validate-code',
+          undefined,
+          { params: { code } }
+        );
         expect(result).toEqual(mockResponse);
       });
     });
@@ -998,12 +1017,15 @@ describe('Auth', () => {
       it('should get passkey authentication options successfully', async () => {
         const email = 'user@example.com';
         const mockResponse = {
+          sessionId: 'sess_abc123',
           challenge: 'auth_challenge_123',
+          rpId: 'app.example.com',
+          timeout: 60000,
+          userVerification: 'preferred',
           allowCredentials: [
             {
               id: 'credential_id_123',
-              type: 'public-key',
-              transports: ['usb', 'nfc']
+              type: 'public-key'
             }
           ]
         };
@@ -1035,27 +1057,35 @@ describe('Auth', () => {
             signature: 'signature'
           }
         };
+        // Flat token response + partial user, and session_id as a query param.
         const mockResponse = {
-          user: userFixtures.validUser,
-          tokens: tokenFixtures.validTokens,
-          message: 'Passkey authentication successful'
+          verified: true,
+          access_token: tokenFixtures.validAccessToken,
+          refresh_token: tokenFixtures.validRefreshToken,
+          token_type: 'bearer' as const,
+          expires_in: 3600,
+          user: {
+            id: userFixtures.validUser.id,
+            email: userFixtures.validUser.email,
+            first_name: userFixtures.validUser.first_name,
+            last_name: userFixtures.validUser.last_name
+          }
         };
 
         mockHttpClient.post.mockResolvedValue({
           data: mockResponse
         });
 
-        const result = await auth.verifyPasskeyAuthentication(credential, 'auth_challenge_123', 'user@example.com');
+        const result = await auth.verifyPasskeyAuthentication(credential, 'sess_abc123', 'user@example.com');
 
         expect(mockHttpClient.post).toHaveBeenCalledWith('/api/v1/passkeys/authenticate/verify', {
           credential: credential,
-          challenge: 'auth_challenge_123',
           email: 'user@example.com'
-        }, { skipAuth: true });
+        }, { skipAuth: true, params: { session_id: 'sess_abc123' } });
         expect(result).toEqual(mockResponse);
         expect(mockTokenManager.setTokens).toHaveBeenCalledWith({
-          access_token: mockResponse.tokens.access_token,
-          refresh_token: mockResponse.tokens.refresh_token,
+          access_token: mockResponse.access_token,
+          refresh_token: mockResponse.refresh_token,
           expires_at: expect.any(Number)
         });
         expect(mockOnSignIn).toHaveBeenCalled();

--- a/packages/typescript-sdk/src/__tests__/auth/auth-mfa.test.ts
+++ b/packages/typescript-sdk/src/__tests__/auth/auth-mfa.test.ts
@@ -6,7 +6,6 @@ import { Auth } from '../../auth';
 import { HttpClient } from '../../http-client';
 import { TokenManager } from '../../utils';
 import { UserStatus } from '../../types';
-import type { MFAParams } from '../../types';
 
 // Inline fixtures
 const userFixtures = {
@@ -83,60 +82,89 @@ describe('Auth - MFA Operations', () => {
     auth = new Auth(mockHttpClient, mockTokenManager, mockOnSignIn, mockOnSignOut);
   });
 
-  describe('verifyMFA', () => {
-    it('should verify MFA code successfully', async () => {
-      const mfaParams: MFAParams = {
-        challenge_id: 'challenge-123',
-        code: '123456',
-        method: 'totp'
-      };
+  describe('verifyMFA (enrollment confirmation)', () => {
+    it('should confirm MFA enrollment with a TOTP code', async () => {
+      // verifyMFA finalizes enrollment against POST /api/v1/mfa/verify and
+      // returns { message } — it does NOT issue tokens. Token-issuing MFA during
+      // sign-in is verifyMfaChallenge (tested below).
+      const request = { code: '123456' };
+      const mockResponse = { message: 'MFA successfully enabled' };
 
+      mockHttpClient.post.mockResolvedValue({ data: mockResponse });
+
+      const result = await auth.verifyMFA(request);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith('/api/v1/mfa/verify', request);
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should reject a non-6-digit code before calling the API', async () => {
+      await expect(auth.verifyMFA({ code: '12' })).rejects.toThrow();
+      expect(mockHttpClient.post).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('verifyMfaChallenge (sign-in second factor)', () => {
+    it('should complete the challenge and persist tokens', async () => {
       const mockResponse = {
         user: userFixtures.verifiedUser,
-        access_token: tokenFixtures.validAccessToken,
-        refresh_token: tokenFixtures.validRefreshToken,
-        expires_in: 3600,
-        token_type: 'bearer' as const
+        tokens: tokenFixtures.validTokens
       };
 
       mockHttpClient.post.mockResolvedValue({ data: mockResponse });
 
-      const result = await auth.verifyMFA(mfaParams);
+      const result = await auth.verifyMfaChallenge('mfa-token-abc', '123456');
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith('/api/v1/auth/mfa/verify', mfaParams);
-      expect(mockTokenManager.setTokens).toHaveBeenCalled();
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        '/api/v1/mfa/challenge/verify',
+        { mfa_token: 'mfa-token-abc', code: '123456' },
+        { skipAuth: true }
+      );
+      expect(mockTokenManager.setTokens).toHaveBeenCalledWith({
+        access_token: tokenFixtures.validTokens.access_token,
+        refresh_token: tokenFixtures.validTokens.refresh_token,
+        expires_at: expect.any(Number)
+      });
       expect(mockOnSignIn).toHaveBeenCalled();
       expect(result).toEqual({
         user: mockResponse.user,
         tokens: {
-          access_token: mockResponse.access_token,
-          refresh_token: mockResponse.refresh_token,
-          expires_in: mockResponse.expires_in,
-          token_type: mockResponse.token_type
+          access_token: tokenFixtures.validTokens.access_token,
+          refresh_token: tokenFixtures.validTokens.refresh_token,
+          expires_in: tokenFixtures.validTokens.expires_in,
+          token_type: tokenFixtures.validTokens.token_type
         }
       });
+    });
+
+    it('should require a non-empty mfa_token and code', async () => {
+      await expect(auth.verifyMfaChallenge('', '123456')).rejects.toThrow();
+      await expect(auth.verifyMfaChallenge('mfa-token', '')).rejects.toThrow();
+      expect(mockHttpClient.post).not.toHaveBeenCalled();
     });
   });
 
   describe('enableMFA', () => {
-    it('should enable MFA successfully', async () => {
-      const method = 'totp';
+    it('should begin enrollment with the account password', async () => {
+      const password = 'CurrentPassword123!';
 
       mockHttpClient.post.mockResolvedValue({
         data: {
           secret: 'MFASECRET123',
           qr_code: 'data:image/png;base64,...',
-          backup_codes: ['code1', 'code2', 'code3']
+          backup_codes: ['code1', 'code2', 'code3'],
+          provisioning_uri: 'otpauth://totp/Janua:test'
         }
       });
 
-      const result = await auth.enableMFA(method);
+      const result = await auth.enableMFA(password);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith('/api/v1/auth/mfa/enable', { method });
+      expect(mockHttpClient.post).toHaveBeenCalledWith('/api/v1/mfa/enable', { password });
       expect(result).toEqual({
         secret: 'MFASECRET123',
         qr_code: 'data:image/png;base64,...',
-        backup_codes: ['code1', 'code2', 'code3']
+        backup_codes: ['code1', 'code2', 'code3'],
+        provisioning_uri: 'otpauth://totp/Janua:test'
       });
     });
   });
@@ -147,17 +175,26 @@ describe('Auth - MFA Operations', () => {
 
       mockHttpClient.post.mockResolvedValue({
         data: {
-          success: true,
-          message: 'MFA disabled successfully'
+          message: 'MFA successfully disabled'
         }
       });
 
       const result = await auth.disableMFA(password);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith('/api/v1/auth/mfa/disable', { password });
+      expect(mockHttpClient.post).toHaveBeenCalledWith('/api/v1/mfa/disable', { password });
       expect(result).toEqual({
-        success: true,
-        message: 'MFA disabled successfully'
+        message: 'MFA successfully disabled'
+      });
+    });
+
+    it('should include an optional code when provided', async () => {
+      mockHttpClient.post.mockResolvedValue({ data: { message: 'ok' } });
+
+      await auth.disableMFA('pw', '123456');
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith('/api/v1/mfa/disable', {
+        password: 'pw',
+        code: '123456'
       });
     });
   });
@@ -195,9 +232,13 @@ describe('Auth - MFA Operations', () => {
 
       const result = await auth.regenerateMFABackupCodes(password);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith('/api/v1/mfa/regenerate-backup-codes', {
-        password: password
-      });
+      // The handler binds `password` as a QUERY parameter, so it is sent via
+      // `params`, not the JSON body.
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        '/api/v1/mfa/regenerate-backup-codes',
+        undefined,
+        { params: { password } }
+      );
       expect(result).toEqual(mockResponse);
     });
   });
@@ -213,9 +254,12 @@ describe('Auth - MFA Operations', () => {
 
       const result = await auth.validateMFACode(code);
 
-      expect(mockHttpClient.post).toHaveBeenCalledWith('/api/v1/mfa/validate-code', {
-        code: code
-      });
+      // `code` is a QUERY parameter on the handler, sent via `params`.
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        '/api/v1/mfa/validate-code',
+        undefined,
+        { params: { code } }
+      );
       expect(result).toEqual(mockResponse);
     });
   });

--- a/packages/typescript-sdk/src/__tests__/auth/auth-passkey.test.ts
+++ b/packages/typescript-sdk/src/__tests__/auth/auth-passkey.test.ts
@@ -194,13 +194,18 @@ describe('Auth - Passkey Operations', () => {
   describe('getPasskeyAuthenticationOptions', () => {
     it('should get passkey authentication options successfully', async () => {
       const email = 'user@example.com';
+      // The server mints a `sessionId` that keys the one-time challenge; the SDK
+      // surfaces it so verifyPasskeyAuthentication can pass it back.
       const mockResponse = {
+        sessionId: 'sess_abc123',
         challenge: 'auth_challenge_123',
+        rpId: 'app.example.com',
+        timeout: 60000,
+        userVerification: 'preferred',
         allowCredentials: [
           {
             id: 'credential_id_123',
-            type: 'public-key',
-            transports: ['usb', 'nfc']
+            type: 'public-key'
           }
         ]
       };
@@ -232,27 +237,37 @@ describe('Auth - Passkey Operations', () => {
           signature: 'signature'
         }
       };
+      // The endpoint returns FLAT tokens (not nested under `tokens`) plus a
+      // partial user object.
       const mockResponse = {
-        user: userFixtures.validUser,
-        tokens: tokenFixtures.validTokens,
-        message: 'Passkey authentication successful'
+        verified: true,
+        access_token: tokenFixtures.validAccessToken,
+        refresh_token: tokenFixtures.validRefreshToken,
+        token_type: 'bearer' as const,
+        expires_in: 3600,
+        user: {
+          id: userFixtures.validUser.id,
+          email: userFixtures.validUser.email,
+          first_name: userFixtures.validUser.first_name,
+          last_name: userFixtures.validUser.last_name
+        }
       };
 
       mockHttpClient.post.mockResolvedValue({
         data: mockResponse
       });
 
-      const result = await auth.verifyPasskeyAuthentication(credential, 'auth_challenge_123', 'user@example.com');
+      const result = await auth.verifyPasskeyAuthentication(credential, 'sess_abc123', 'user@example.com');
 
+      // credential + email go in the body; session_id is a QUERY parameter.
       expect(mockHttpClient.post).toHaveBeenCalledWith('/api/v1/passkeys/authenticate/verify', {
         credential: credential,
-        challenge: 'auth_challenge_123',
         email: 'user@example.com'
-      }, { skipAuth: true });
+      }, { skipAuth: true, params: { session_id: 'sess_abc123' } });
       expect(result).toEqual(mockResponse);
       expect(mockTokenManager.setTokens).toHaveBeenCalledWith({
-        access_token: mockResponse.tokens.access_token,
-        refresh_token: mockResponse.tokens.refresh_token,
+        access_token: mockResponse.access_token,
+        refresh_token: mockResponse.refresh_token,
         expires_at: expect.any(Number)
       });
       expect(mockOnSignIn).toHaveBeenCalled();

--- a/packages/typescript-sdk/src/auth.ts
+++ b/packages/typescript-sdk/src/auth.ts
@@ -176,9 +176,19 @@ export class Auth {
 
     const response = await this.http.post<AuthApiResponse>('/api/v1/auth/login', request);
 
-    // Handle MFA requirement
-    if ('requires_mfa' in response.data) {
-      return response.data as any; // Return MFA challenge response
+    // Handle MFA requirement. The API (apps/api/app/routers/v1/auth.py:451-452)
+    // returns `mfa_required: true` + `mfa_token` and NO tokens when the user has
+    // a second factor. Surface that to the caller so it can render a code-entry
+    // step and call verifyMfaChallenge(). The prior check looked for a
+    // non-existent `requires_mfa` key, so this branch never fired and the code
+    // fell through to build an AuthResponse whose token fields were all
+    // undefined — silently "swallowing" the challenge.
+    if (response.data.mfa_required) {
+      return {
+        user: response.data.user,
+        mfa_required: true,
+        mfa_token: response.data.mfa_token,
+      };
     }
 
     // Extract tokens - support both nested (API actual) and flat (legacy) structures
@@ -199,6 +209,68 @@ export class Auth {
     }
 
     // Call onSignIn callback if it exists
+    if (this.onSignIn) {
+      this.onSignIn({ user: response.data.user });
+    }
+
+    return {
+      user: response.data.user,
+      tokens: {
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+        expires_in: tokens.expires_in,
+        token_type: tokens.token_type
+      }
+    };
+  }
+
+  /**
+   * Complete an MFA challenge during sign-in.
+   *
+   * After {@link signIn} returns `{ mfa_required: true, mfa_token }`, call this
+   * with the same `mfa_token` and the user's 6-digit TOTP code (or a formatted
+   * backup code, e.g. `ABCD-1234`) to obtain real session tokens. On success the
+   * tokens are persisted and the onSignIn callback fires, exactly as a normal
+   * sign-in would.
+   *
+   * Targets `POST /api/v1/mfa/challenge/verify`
+   * (apps/api/app/routers/v1/mfa.py:565), which returns the same
+   * `SignInResponse` shape as sign-in: `{ user, tokens: { access_token,
+   * refresh_token, expires_in, token_type } }`.
+   */
+  async verifyMfaChallenge(mfaToken: string, code: string): Promise<AuthResponse> {
+    if (!mfaToken) {
+      throw new ValidationError('mfa_token is required to complete the MFA challenge');
+    }
+    // Server accepts a 6-digit TOTP code or an 8-char backup code (with or
+    // without the XXXX-XXXX dash). Keep validation permissive but non-empty.
+    if (!code || !code.trim()) {
+      throw new ValidationError('An MFA code is required');
+    }
+
+    const response = await this.http.post<AuthApiResponse>(
+      '/api/v1/mfa/challenge/verify',
+      { mfa_token: mfaToken, code: code.trim() },
+      { skipAuth: true }
+    );
+
+    // The challenge-verify endpoint returns tokens nested under `tokens`
+    // (SignInResponse). Support the flat shape too for resilience.
+    const tokens = response.data.tokens || {
+      access_token: response.data.access_token!,
+      refresh_token: response.data.refresh_token!,
+      expires_in: response.data.expires_in!,
+      token_type: response.data.token_type || 'bearer'
+    };
+
+    if (tokens.access_token && tokens.refresh_token) {
+      await this.tokenManager.setTokens({
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+        expires_at: Date.now() + (tokens.expires_in * 1000)
+      });
+    }
+
     if (this.onSignIn) {
       this.onSignIn({ user: response.data.user });
     }
@@ -446,71 +518,73 @@ export class Auth {
   }
 
   /**
-   * Enable MFA (returns QR code and backup codes)
+   * Begin MFA enrollment for the signed-in user (returns TOTP secret, QR code,
+   * provisioning URI, and one-time backup codes). Requires the user's password.
+   *
+   * Targets `POST /api/v1/mfa/enable` (apps/api/app/routers/v1/mfa.py:236),
+   * whose body is `MFAEnableRequest = { password }`. The prior implementation
+   * POSTed `{ method }` to `/api/v1/auth/mfa/enable` — both the path (that route
+   * does not exist; the mfa router is mounted at `/mfa`, not `/auth/mfa`) and
+   * the body were wrong, so enrollment always failed.
    */
-  async enableMFA(method: string): Promise<MFAEnableResponse> {
-    const response = await this.http.post<MFAEnableResponse>('/api/v1/auth/mfa/enable', { method });
+  async enableMFA(password: string): Promise<MFAEnableResponse> {
+    const response = await this.http.post<MFAEnableResponse>('/api/v1/mfa/enable', { password });
     return response.data;
   }
 
   /**
-   * Verify MFA setup with TOTP code
+   * Verify MFA enrollment by confirming a TOTP code from the authenticator that
+   * scanned the QR from {@link enableMFA}. This finalizes enrollment; it does NOT
+   * issue session tokens (the user is already signed in during enrollment).
+   *
+   * Targets `POST /api/v1/mfa/verify` (apps/api/app/routers/v1/mfa.py:291),
+   * which requires the caller to be authenticated and returns
+   * `{ message: string }`. The prior code POSTed to `/api/v1/auth/mfa/verify`
+   * (nonexistent path) and expected tokens back.
+   *
+   * NOTE: to complete a second factor during SIGN-IN, use
+   * {@link verifyMfaChallenge} instead — that is the token-issuing path.
    */
-  async verifyMFA(request: MFAVerifyRequest): Promise<AuthResponse> {
+  async verifyMFA(request: MFAVerifyRequest): Promise<{ message: string }> {
     if (!/^\d{6}$/.test(request.code)) {
       throw new ValidationError('MFA code must be 6 digits');
     }
 
-    const response = await this.http.post<AuthApiResponse>('/api/v1/auth/mfa/verify', request);
-
-    // Extract tokens - support both nested (API actual) and flat (legacy) structures
-    const tokens = response.data.tokens || {
-      access_token: response.data.access_token!,
-      refresh_token: response.data.refresh_token!,
-      expires_in: response.data.expires_in!,
-      token_type: response.data.token_type || 'bearer'
-    };
-
-    // Store tokens
-    if (tokens.access_token && tokens.refresh_token) {
-      await this.tokenManager.setTokens({
-        access_token: tokens.access_token,
-        refresh_token: tokens.refresh_token,
-        expires_at: Date.now() + (tokens.expires_in * 1000)
-      });
-    }
-
-    // Call onSignIn callback if it exists
-    if (this.onSignIn) {
-      this.onSignIn({ user: response.data.user });
-    }
-
-    return {
-      user: response.data.user,
-      tokens: {
-        access_token: tokens.access_token,
-        refresh_token: tokens.refresh_token,
-        expires_in: tokens.expires_in,
-        token_type: tokens.token_type
-      }
-    };
-  }
-
-  /**
-   * Disable MFA
-   */
-  async disableMFA(password: string): Promise<{ message: string }> {
-    const response = await this.http.post<{ message: string }>('/api/v1/auth/mfa/disable', { password });
+    const response = await this.http.post<{ message: string }>('/api/v1/mfa/verify', request);
     return response.data;
   }
 
   /**
-   * Regenerate MFA backup codes
+   * Disable MFA for the signed-in user. Requires the account password.
+   *
+   * Targets `POST /api/v1/mfa/disable` (apps/api/app/routers/v1/mfa.py:321),
+   * body `{ password }` (an optional `code` may also be supplied). The prior
+   * code used the nonexistent `/api/v1/auth/mfa/disable` path.
+   */
+  async disableMFA(password: string, code?: string): Promise<{ message: string }> {
+    const body: { password: string; code?: string } = { password };
+    if (code) body.code = code;
+    const response = await this.http.post<{ message: string }>('/api/v1/mfa/disable', body);
+    return response.data;
+  }
+
+  /**
+   * Regenerate the user's one-time MFA backup codes (invalidates the old set).
+   * Requires the account password.
+   *
+   * Targets `POST /api/v1/mfa/regenerate-backup-codes`
+   * (apps/api/app/routers/v1/mfa.py:363). IMPORTANT: that handler declares
+   * `password: str` as a bare parameter, which FastAPI binds as a QUERY
+   * parameter, not a JSON body field. The prior code sent `{ password }` in the
+   * request body, so the server saw no password and rejected the call — hence
+   * `password` is passed via `params` here.
    */
   async regenerateMFABackupCodes(password: string): Promise<MFABackupCodesResponse> {
-    const response = await this.http.post<MFABackupCodesResponse>('/api/v1/mfa/regenerate-backup-codes', {
-      password
-    });
+    const response = await this.http.post<MFABackupCodesResponse>(
+      '/api/v1/mfa/regenerate-backup-codes',
+      undefined,
+      { params: { password } }
+    );
     return response.data;
   }
 
@@ -522,9 +596,14 @@ export class Auth {
       throw new ValidationError('Invalid MFA code format');
     }
 
-    const response = await this.http.post<{ valid: boolean; message: string }>('/api/v1/mfa/validate-code', {
-      code
-    });
+    // The handler (apps/api/app/routers/v1/mfa.py:400) declares `code: str` as a
+    // bare parameter → FastAPI binds it as a QUERY parameter, so it is sent via
+    // `params`, not the JSON body (which the server would ignore).
+    const response = await this.http.post<{ valid: boolean; message: string }>(
+      '/api/v1/mfa/validate-code',
+      undefined,
+      { params: { code } }
+    );
     return response.data;
   }
 
@@ -996,9 +1075,19 @@ export class Auth {
   }
 
   /**
-   * Get passkey authentication options
+   * Get passkey authentication (assertion) options to feed
+   * `navigator.credentials.get`.
+   *
+   * Targets `POST /api/v1/passkeys/authenticate/options`
+   * (apps/api/app/routers/v1/passkeys.py:291), body `{ email? }`. The response
+   * includes a server-minted `sessionId` (passkeys.py:336) that keys the
+   * one-time challenge stored in Redis. That `sessionId` MUST be passed back to
+   * {@link verifyPasskeyAuthentication} — the verify endpoint reads the challenge
+   * server-side by session id and never trusts a client-supplied challenge
+   * (2026-08-23 replay-hardening fix).
    */
   async getPasskeyAuthenticationOptions(email?: string): Promise<{
+    sessionId: string;
     challenge: string;
     rpId: string;
     timeout: number;
@@ -1006,6 +1095,7 @@ export class Auth {
     userVerification: string;
   }> {
     type PasskeyAuthOptions = {
+      sessionId: string;
       challenge: string;
       rpId: string;
       timeout: number;
@@ -1020,11 +1110,23 @@ export class Auth {
   }
 
   /**
-   * Verify passkey authentication
+   * Verify a passkey assertion and sign the user in.
+   *
+   * Targets `POST /api/v1/passkeys/authenticate/verify`
+   * (apps/api/app/routers/v1/passkeys.py:350). The handler takes the JSON body
+   * `{ email?, credential }` AND a `session_id` QUERY parameter (a bare `str`
+   * param, so it is not a body field). The server resolves the one-time
+   * challenge from Redis by that session id.
+   *
+   * The response is FLAT — `{ verified, access_token, refresh_token, token_type,
+   * expires_in, user }` (passkeys.py:472) — NOT nested under `tokens`. The prior
+   * code sent `challenge` in the body (ignored by the new endpoint) and read
+   * tokens from a nonexistent `response.data.tokens`, so it neither authenticated
+   * nor stored tokens.
    */
   async verifyPasskeyAuthentication(
     credential: PublicKeyCredentialJSON,
-    challenge: string,
+    sessionId: string,
     email?: string
   ): Promise<{
     verified: boolean;
@@ -1032,7 +1134,7 @@ export class Auth {
     refresh_token: string;
     token_type: string;
     expires_in: number;
-    user: User;
+    user: Pick<User, 'id' | 'email' | 'first_name' | 'last_name'>;
   }> {
     type PasskeyAuthResponse = {
       verified: boolean;
@@ -1040,27 +1142,26 @@ export class Auth {
       refresh_token: string;
       token_type: string;
       expires_in: number;
-      user: User;
-      tokens?: { access_token: string; refresh_token: string; expires_in: number };
+      user: Pick<User, 'id' | 'email' | 'first_name' | 'last_name'>;
     };
-    const response = await this.http.post<PasskeyAuthResponse>('/api/v1/passkeys/authenticate/verify', {
-      credential,
-      challenge,
-      email
-    }, { skipAuth: true });
+    const response = await this.http.post<PasskeyAuthResponse>(
+      '/api/v1/passkeys/authenticate/verify',
+      { credential, email },
+      { skipAuth: true, params: { session_id: sessionId } }
+    );
 
-    // Store tokens
-    if (response.data.tokens && response.data.tokens.access_token && response.data.tokens.refresh_token) {
+    // Tokens are flat at the top level of the response.
+    if (response.data.access_token && response.data.refresh_token) {
       await this.tokenManager.setTokens({
-        access_token: response.data.tokens.access_token,
-        refresh_token: response.data.tokens.refresh_token,
-        expires_at: Date.now() + (response.data.tokens.expires_in * 1000)
+        access_token: response.data.access_token,
+        refresh_token: response.data.refresh_token,
+        expires_at: Date.now() + (response.data.expires_in * 1000)
       });
     }
 
     // Call onSignIn callback if it exists
     if (this.onSignIn) {
-      this.onSignIn({ user: response.data.user });
+      this.onSignIn({ user: response.data.user as unknown as User });
     }
 
     return response.data;

--- a/packages/typescript-sdk/src/auth/core-auth-service.ts
+++ b/packages/typescript-sdk/src/auth/core-auth-service.ts
@@ -91,9 +91,15 @@ export class CoreAuthService {
 
     const response = await this.http.post<AuthApiResponse>('/api/v1/auth/login', request);
 
-    // Handle MFA requirement
-    if ('requires_mfa' in response.data) {
-      return response.data as unknown as AuthResponse;
+    // Handle MFA requirement. The API returns `mfa_required: true` + `mfa_token`
+    // and no tokens (apps/api/app/routers/v1/auth.py:451-452). The prior check
+    // looked for a non-existent `requires_mfa` key, so it never fired.
+    if (response.data.mfa_required) {
+      return {
+        user: response.data.user,
+        mfa_required: true,
+        mfa_token: response.data.mfa_token,
+      };
     }
 
     if (response.data.access_token && response.data.refresh_token) {

--- a/packages/typescript-sdk/src/auth/mfa-service.ts
+++ b/packages/typescript-sdk/src/auth/mfa-service.ts
@@ -22,39 +22,63 @@ export class MFAService {
   ) {}
 
   /**
-   * Get MFA status for current user
+   * Get MFA status for current user.
+   *
+   * NOTE: the Janua MFA router is mounted at `/api/v1/mfa`, NOT `/api/v1/auth/mfa`
+   * (apps/api/app/main.py:1076). The endpoints below use the correct prefix; the
+   * prior `/auth/mfa/...` paths 404'd.
    */
   async getMFAStatus(): Promise<MFAStatusResponse> {
-    const response = await this.http.get<MFAStatusResponse>('/api/v1/auth/mfa/status');
+    const response = await this.http.get<MFAStatusResponse>('/api/v1/mfa/status');
     return response.data;
   }
 
   /**
-   * Enable MFA for current user
+   * Begin MFA enrollment for the signed-in user. Requires the account password.
+   * Targets `POST /api/v1/mfa/enable` (mfa.py:236), body `{ password }`.
    */
-  async enableMFA(method: string): Promise<MFAEnableResponse> {
-    const response = await this.http.post<MFAEnableResponse>('/api/v1/auth/mfa/enable', { method });
+  async enableMFA(password: string): Promise<MFAEnableResponse> {
+    const response = await this.http.post<MFAEnableResponse>('/api/v1/mfa/enable', { password });
     return response.data;
   }
 
   /**
-   * Verify MFA code and complete authentication
+   * Confirm MFA enrollment with a TOTP code. Targets `POST /api/v1/mfa/verify`
+   * (mfa.py:291); returns `{ message }` and does NOT issue tokens. To complete a
+   * second factor during sign-in, use {@link verifyMfaChallenge} instead.
    */
-  async verifyMFA(request: MFAVerifyRequest): Promise<AuthResponse> {
+  async verifyMFA(request: MFAVerifyRequest): Promise<{ message: string }> {
+    const response = await this.http.post<{ message: string }>('/api/v1/mfa/verify', request);
+    return response.data;
+  }
+
+  /**
+   * Complete an MFA challenge during sign-in and obtain session tokens.
+   * Targets `POST /api/v1/mfa/challenge/verify` (mfa.py:565), which returns the
+   * SignInResponse shape `{ user, tokens }`.
+   */
+  async verifyMfaChallenge(mfaToken: string, code: string): Promise<AuthResponse> {
     const response = await this.http.post<{
       user: User;
-      access_token: string;
-      refresh_token: string;
-      expires_in: number;
-      token_type: 'bearer';
-    }>('/api/v1/auth/mfa/verify', request, { skipAuth: true });
+      tokens?: { access_token: string; refresh_token: string; expires_in: number; token_type: 'bearer' };
+      access_token?: string;
+      refresh_token?: string;
+      expires_in?: number;
+      token_type?: 'bearer';
+    }>('/api/v1/mfa/challenge/verify', { mfa_token: mfaToken, code }, { skipAuth: true });
 
-    // Store tokens
-    if (response.data.access_token && response.data.refresh_token) {
+    const tokens = response.data.tokens || {
+      access_token: response.data.access_token!,
+      refresh_token: response.data.refresh_token!,
+      expires_in: response.data.expires_in!,
+      token_type: response.data.token_type || 'bearer'
+    };
+
+    if (tokens.access_token && tokens.refresh_token) {
       await this.tokenManager.setTokens({
-        access_token: response.data.access_token,
-        refresh_token: response.data.refresh_token,
-        expires_at: Date.now() + (response.data.expires_in * 1000)
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+        expires_at: Date.now() + (tokens.expires_in * 1000)
       });
     }
 
@@ -62,73 +86,70 @@ export class MFAService {
       this.onSignIn({ user: response.data.user });
     }
 
-    return {
-      user: response.data.user,
-      tokens: {
-        access_token: response.data.access_token,
-        refresh_token: response.data.refresh_token,
-        expires_in: response.data.expires_in,
-        token_type: response.data.token_type
-      }
-    };
+    return { user: response.data.user, tokens };
   }
 
   /**
-   * Disable MFA for current user
+   * Disable MFA for current user. Targets `POST /api/v1/mfa/disable` (mfa.py:321).
    */
-  async disableMFA(password: string): Promise<{ message: string }> {
-    const response = await this.http.post<{ message: string }>('/api/v1/auth/mfa/disable', { password });
+  async disableMFA(password: string, code?: string): Promise<{ message: string }> {
+    const body: { password: string; code?: string } = { password };
+    if (code) body.code = code;
+    const response = await this.http.post<{ message: string }>('/api/v1/mfa/disable', body);
     return response.data;
   }
 
   /**
-   * Regenerate MFA backup codes
+   * Regenerate MFA backup codes. Targets
+   * `POST /api/v1/mfa/regenerate-backup-codes` (mfa.py:363). The handler binds
+   * `password` as a QUERY parameter, so it is sent via `params`.
    */
   async regenerateMFABackupCodes(password: string): Promise<MFABackupCodesResponse> {
     const response = await this.http.post<MFABackupCodesResponse>(
-      '/api/v1/auth/mfa/backup-codes/regenerate',
-      { password }
+      '/api/v1/mfa/regenerate-backup-codes',
+      undefined,
+      { params: { password } }
     );
     return response.data;
   }
 
   /**
-   * Validate MFA code without completing authentication
+   * Validate an MFA code without completing sign-in. Targets
+   * `POST /api/v1/mfa/validate-code` (mfa.py:400). `code` is a QUERY parameter.
    */
   async validateMFACode(code: string): Promise<{ valid: boolean; message: string }> {
     const response = await this.http.post<{ valid: boolean; message: string }>(
-      '/api/v1/auth/mfa/validate',
-      { code }
+      '/api/v1/mfa/validate-code',
+      undefined,
+      { params: { code } }
     );
     return response.data;
   }
 
   /**
-   * Get MFA recovery options for a user
+   * Get MFA recovery options for a user. Targets
+   * `GET /api/v1/mfa/recovery-options?email=...` (mfa.py:435).
    */
   async getMFARecoveryOptions(email: string): Promise<{
-    recovery_methods: Array<{
-      type: string;
-      hint: string;
-    }>;
+    recovery_available: boolean;
+    methods?: { backup_codes: boolean; email_recovery: boolean };
   }> {
-    const response = await this.http.post<{
-      recovery_methods: Array<{
-        type: string;
-        hint: string;
-      }>;
-    }>('/api/v1/auth/mfa/recovery/options', { email }, { skipAuth: true });
+    const response = await this.http.get<{
+      recovery_available: boolean;
+      methods?: { backup_codes: boolean; email_recovery: boolean };
+    }>(`/api/v1/mfa/recovery-options?email=${encodeURIComponent(email)}`, { skipAuth: true });
     return response.data;
   }
 
   /**
-   * Initiate MFA recovery process
+   * Initiate MFA recovery process. Targets
+   * `POST /api/v1/mfa/initiate-recovery` (mfa.py:475); `email` is a QUERY param.
    */
   async initiateMFARecovery(email: string): Promise<{ message: string }> {
     const response = await this.http.post<{ message: string }>(
-      '/api/v1/auth/mfa/recovery/initiate',
-      { email },
-      { skipAuth: true }
+      '/api/v1/mfa/initiate-recovery',
+      undefined,
+      { params: { email }, skipAuth: true }
     );
     return response.data;
   }

--- a/packages/typescript-sdk/src/client.ts
+++ b/packages/typescript-sdk/src/client.ts
@@ -627,10 +627,23 @@ export class JanuaClient extends EventEmitter<SdkEventMap> {
   // ===================================
 
   /**
-   * Sign in a user (convenience method)
+   * Sign in a user (convenience method).
+   *
+   * If the account has a second factor, the result carries
+   * `{ mfa_required: true, mfa_token }` and NO tokens — complete it with
+   * {@link verifyMfaChallenge}.
    */
   async signIn(request: import('./types').SignInRequest): Promise<import('./types').AuthResponse> {
     return this.auth.signIn(request);
+  }
+
+  /**
+   * Complete an MFA challenge raised by {@link signIn} (convenience method).
+   * Pass the `mfa_token` from the sign-in result plus the user's TOTP or backup
+   * code; on success the session tokens are persisted.
+   */
+  async verifyMfaChallenge(mfaToken: string, code: string): Promise<import('./types').AuthResponse> {
+    return this.auth.verifyMfaChallenge(mfaToken, code);
   }
 
   /**

--- a/packages/typescript-sdk/src/types.ts
+++ b/packages/typescript-sdk/src/types.ts
@@ -332,12 +332,28 @@ export interface AuthApiResponse {
   refresh_token?: string;
   expires_in?: number;
   token_type?: 'bearer';
+  // MFA challenge fields — when the user has a second factor configured, the
+  // sign-in endpoints (/signin, /login, /magic-link/verify) return no tokens and
+  // instead set mfa_required=true plus a short-lived mfa_token. The caller must
+  // then complete verifyMfaChallenge(mfa_token, code) to obtain real tokens.
+  // (apps/api/app/routers/v1/auth.py:451-452, SignInResponse at :148-152)
+  mfa_required?: boolean;
+  mfa_token?: string;
 }
 
 // Client Response interfaces (what the SDK returns)
 export interface AuthResponse {
   user: User;
-  tokens: TokenResponse;
+  // Absent on an MFA challenge (mfa_required=true) — the tokens are only issued
+  // after verifyMfaChallenge completes the second factor.
+  tokens?: TokenResponse;
+  /** True when a second factor is required before tokens are issued. */
+  mfa_required?: boolean;
+  /**
+   * Short-lived (5min) challenge token to pass to verifyMfaChallenge together
+   * with the user's TOTP or backup code. Only present when mfa_required is true.
+   */
+  mfa_token?: string;
 }
 
 export interface MFAEnableResponse {

--- a/packages/typescript-sdk/src/webauthn-helper.ts
+++ b/packages/typescript-sdk/src/webauthn-helper.ts
@@ -172,16 +172,22 @@ export class WebAuthnHelper {
       }
     };
 
-    // Verify with server and get auth tokens - pass credential, challenge, and email
+    // Verify with server and get auth tokens. The verify endpoint reads the
+    // one-time challenge server-side by `sessionId` (it does NOT accept a
+    // client-supplied challenge — 2026-08-23 replay-hardening), so we pass the
+    // sessionId minted by getPasskeyAuthenticationOptions, not options.challenge.
     const result = await this.auth.verifyPasskeyAuthentication(
       verificationData,
-      options.challenge,
+      options.sessionId,
       email
     );
 
-    // Map response to AuthResponse format - cast token_type to literal 'bearer'
+    // Map response to AuthResponse format - cast token_type to literal 'bearer'.
+    // The passkey verify endpoint returns only a partial user object
+    // ({id, email, first_name, last_name}); callers that need the full profile
+    // should follow up with getCurrentUser().
     return {
-      user: result.user,
+      user: result.user as import('./types').User,
       tokens: {
         access_token: result.access_token,
         refresh_token: result.refresh_token,

--- a/packages/ui/src/components/auth/sign-in.test.tsx
+++ b/packages/ui/src/components/auth/sign-in.test.tsx
@@ -320,10 +320,13 @@ describe('SignIn', () => {
       const user = userEvent.setup()
       const mockOnMFARequired = vi.fn()
 
+      // The API returns the MFA challenge as a 200 with mfa_required + mfa_token
+      // (SignInResponse), NOT a 403. The component branches on response.ok &&
+      // data.mfa_required.
       global.fetch = vi.fn().mockResolvedValue({
-        ok: false,
-        status: 403,
-        json: async () => ({ mfa_required: true, session_id: 'abc123' }),
+        ok: true,
+        status: 200,
+        json: async () => ({ mfa_required: true, mfa_token: 'mfa-token-abc' }),
       })
 
       render(<SignIn onMFARequired={mockOnMFARequired} />)
@@ -340,6 +343,43 @@ describe('SignIn', () => {
         expect(mockOnMFARequired).toHaveBeenCalledWith(
           expect.objectContaining({ mfa_required: true })
         )
+      })
+    })
+
+    it('should render the built-in MFA code step when no onMFARequired handler is given', async () => {
+      const user = userEvent.setup()
+
+      // SDK path: signIn resolves with the MFA challenge; verifyMfaChallenge
+      // completes it and returns the user.
+      const afterSignIn = vi.fn()
+      const mockClient = {
+        auth: {
+          signIn: vi.fn().mockResolvedValue({
+            user: { id: 'u1', email: 'test@example.com' },
+            mfa_required: true,
+            mfa_token: 'mfa-token-abc',
+          }),
+          verifyMfaChallenge: vi.fn().mockResolvedValue({
+            user: { id: 'u1', email: 'test@example.com' },
+            tokens: { access_token: 'a', refresh_token: 'r', expires_in: 3600, token_type: 'bearer' },
+          }),
+        },
+      }
+
+      render(<SignIn januaClient={mockClient} afterSignIn={afterSignIn} />)
+
+      await user.type(screen.getByRole('textbox', { name: /email/i }), 'test@example.com')
+      await user.type(screen.getByLabelText('Password'), 'password123')
+      await user.click(screen.getByRole('button', { name: /sign in/i }))
+
+      // The code-entry step appears.
+      const codeInput = await screen.findByLabelText(/verification code/i)
+      await user.type(codeInput, '123456')
+      await user.click(screen.getByRole('button', { name: /^verify$/i }))
+
+      await waitFor(() => {
+        expect(mockClient.auth.verifyMfaChallenge).toHaveBeenCalledWith('mfa-token-abc', '123456')
+        expect(afterSignIn).toHaveBeenCalled()
       })
     })
   })

--- a/packages/ui/src/components/auth/sign-in.tsx
+++ b/packages/ui/src/components/auth/sign-in.tsx
@@ -137,6 +137,30 @@ export function SignIn({
   const [isLoading, setIsLoading] = React.useState(false)
   const [error, setError] = React.useState<string | null>(null)
 
+  // MFA challenge state. When sign-in returns `mfa_required`, we hold the
+  // short-lived `mfa_token` here and render a code-entry step in place of the
+  // credentials form. `null` means no challenge is in progress.
+  const [mfaToken, setMfaToken] = React.useState<string | null>(null)
+  const [mfaCode, setMfaCode] = React.useState('')
+
+  // Finalize a successful sign-in (credentials, MFA, or fetch fallback) by
+  // awaiting the consumer's afterSignIn bridge, then navigating. AWAIT matters:
+  // consumers use afterSignIn to mirror the SDK's freshly persisted tokens into
+  // an HttpOnly session cookie. If we don't await, a consumer that navigates on
+  // return races the un-awaited bridge — the edge middleware then sees no cookie
+  // and bounces the (authenticated) user back to /login with tokens stranded in
+  // localStorage. Awaiting also lets a bridge failure surface through onError
+  // instead of becoming a silent unhandled rejection.
+  const completeSignIn = React.useCallback(
+    async (user: unknown) => {
+      await afterSignIn?.(user)
+      if (redirectUrl) {
+        window.location.href = redirectUrl
+      }
+    },
+    [afterSignIn, redirectUrl]
+  )
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setError(null)
@@ -150,26 +174,23 @@ export function SignIn({
           remember,
         })
 
-        // Check if MFA is required
-        if (response.mfaRequired && onMFARequired) {
-          onMFARequired(response)
+        // MFA challenge. The API/SDK use snake_case `mfa_required` + `mfa_token`
+        // (SignInResponse; apps/api/app/routers/v1/auth.py:451-452). A prior
+        // version checked camelCase `mfaRequired`, which never matched, so the
+        // MFA step never rendered. If the consumer supplied onMFARequired, defer
+        // to it; otherwise render the built-in code-entry step below.
+        if (response.mfa_required) {
+          if (onMFARequired) {
+            onMFARequired(response)
+          } else {
+            setMfaToken(response.mfa_token ?? null)
+            setMfaCode('')
+          }
           setIsLoading(false)
           return
         }
 
-        // AWAIT afterSignIn: consumers use it to mirror the SDK's freshly
-        // persisted tokens into an HttpOnly session cookie (the admin's
-        // /api/auth/session bridge). If we don't await, a consumer that
-        // navigates on return races the un-awaited bridge — the edge
-        // middleware then sees no cookie and bounces the (authenticated)
-        // user back to /login with tokens stranded in localStorage. Awaiting
-        // also lets a bridge failure surface through onError instead of
-        // becoming a silent unhandled rejection.
-        await afterSignIn?.(response.user)
-
-        if (redirectUrl) {
-          window.location.href = redirectUrl
-        }
+        await completeSignIn(response.user)
       } else {
         const response = await fetch(`${apiUrl}/api/v1/auth/login`, {
           method: 'POST',
@@ -178,31 +199,31 @@ export function SignIn({
           body: JSON.stringify({ email, password, remember }),
         })
 
-        if (!response.ok) {
-          const errorData = await response.json().catch(() => ({}))
+        // The MFA challenge is a 200 with `mfa_required: true` + `mfa_token`
+        // (NOT an error status). Read the body first, then branch on it, before
+        // treating a non-OK status as a failure.
+        const data = await response.json().catch(() => ({}))
 
-          // Check for MFA challenge response
-          if (response.status === 403 && errorData.mfa_required && onMFARequired) {
-            onMFARequired(errorData)
-            setIsLoading(false)
-            return
+        if (response.ok && data.mfa_required) {
+          if (onMFARequired) {
+            onMFARequired(data)
+          } else {
+            setMfaToken(data.mfa_token ?? null)
+            setMfaCode('')
           }
+          setIsLoading(false)
+          return
+        }
 
-          const actionableError = parseApiError(errorData, { status: response.status })
+        if (!response.ok) {
+          const actionableError = parseApiError(data, { status: response.status })
           setError(formatErrorMessage(actionableError, true))
           onError?.(new Error(actionableError.message))
           setIsLoading(false)
           return
         }
 
-        const data = await response.json()
-        // Awaited for the same reason as the SDK branch above: a consumer's
-        // cookie-bridge must finish before any post-sign-in navigation.
-        await afterSignIn?.(data.user)
-
-        if (redirectUrl) {
-          window.location.href = redirectUrl
-        }
+        await completeSignIn(data.user)
       }
     } catch (err) {
       const actionableError = parseApiError(err, {
@@ -213,6 +234,57 @@ export function SignIn({
     } finally {
       setIsLoading(false)
     }
+  }
+
+  // Complete the second factor. Uses the SDK's verifyMfaChallenge when a client
+  // is present (it persists tokens and fires onSignIn); otherwise POSTs directly
+  // to /api/v1/mfa/challenge/verify for the fetch-fallback path.
+  const handleMfaSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!mfaToken) return
+    setError(null)
+    setIsLoading(true)
+
+    try {
+      if (januaClient) {
+        const result = await januaClient.auth.verifyMfaChallenge(mfaToken, mfaCode)
+        setMfaToken(null)
+        await completeSignIn(result.user)
+      } else {
+        const response = await fetch(`${apiUrl}/api/v1/mfa/challenge/verify`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ mfa_token: mfaToken, code: mfaCode }),
+        })
+
+        const data = await response.json().catch(() => ({}))
+        if (!response.ok) {
+          const actionableError = parseApiError(data, { status: response.status })
+          setError(formatErrorMessage(actionableError, true))
+          onError?.(new Error(actionableError.message))
+          setIsLoading(false)
+          return
+        }
+        setMfaToken(null)
+        await completeSignIn(data.user)
+      }
+    } catch (err) {
+      const actionableError = parseApiError(err, {
+        message: err instanceof Error ? err.message : undefined,
+      })
+      setError(formatErrorMessage(actionableError, true))
+      onError?.(new Error(actionableError.message))
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleMfaCancel = () => {
+    setMfaToken(null)
+    setMfaCode('')
+    setError(null)
+    setPassword('')
   }
 
   const handleSocialLogin = async (provider: string) => {
@@ -250,6 +322,45 @@ export function SignIn({
       })
       setError(formatErrorMessage(actionableError, true))
       onError?.(new Error(actionableError.message))
+      setIsLoading(false)
+    }
+  }
+
+  // Passkey (WebAuthn) sign-in. Drives the browser assertion ceremony via the
+  // SDK's client.signInWithPasskey, which fetches options (with a server session
+  // id), calls navigator.credentials.get, and verifies — persisting tokens on
+  // success. Requires a januaClient; without one there is no ceremony to run.
+  const handlePasskeyLogin = async () => {
+    setError(null)
+    if (!januaClient) {
+      const message =
+        'Passkey sign-in requires a configured Janua client. Pass januaClient to <SignIn>.'
+      setError(message)
+      onError?.(new Error(message))
+      return
+    }
+    if (typeof window === 'undefined' || !window.PublicKeyCredential) {
+      const message = 'Passkeys are not supported in this browser.'
+      setError(message)
+      onError?.(new Error(message))
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      // Pass the typed email (if any) so a non-discoverable credential can be
+      // matched; empty is fine for discoverable (resident) passkeys.
+      const result = await januaClient.signInWithPasskey(email || undefined)
+      await completeSignIn(result.user)
+    } catch (err) {
+      // A user cancelling the OS prompt throws — surface it gently, not as a
+      // hard failure banner shape a wrong password would use.
+      const actionableError = parseApiError(err, {
+        message: err instanceof Error ? err.message : 'Passkey sign-in failed',
+      })
+      setError(formatErrorMessage(actionableError, true))
+      onError?.(new Error(actionableError.message))
+    } finally {
       setIsLoading(false)
     }
   }
@@ -306,6 +417,78 @@ export function SignIn({
       </a>
     </p>
   ) : undefined
+
+  // ── MFA challenge step ──
+  // Rendered in place of the credentials form once sign-in returns
+  // `mfa_required`. It collects the second-factor code and completes the
+  // challenge with the held mfa_token. Only shown when the consumer did NOT
+  // supply an onMFARequired handler (that handler owns the UX otherwise).
+  if (mfaToken) {
+    const mfaHeader = (
+      <div className="text-center mb-6" style={{ animation: 'janua-fade-in 300ms ease' }}>
+        <h2 className="text-2xl font-bold">Two-factor authentication</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Enter the 6-digit code from your authenticator app, or a backup code.
+        </p>
+      </div>
+    )
+
+    return (
+      <AuthCard layout={layout} logo={logoUrl} header={mfaHeader} className={className}>
+        <form onSubmit={handleMfaSubmit} className="space-y-4">
+          {error && (
+            <div
+              className="bg-destructive/15 text-destructive text-sm p-3 rounded-md"
+              style={{ animation: 'janua-slide-up 200ms ease, janua-shake 400ms ease' }}
+            >
+              {error}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="signin-mfa-code">Verification code</Label>
+            <Input
+              id="signin-mfa-code"
+              // inputMode numeric for TOTP, but allow letters/dash for backup codes.
+              inputMode="text"
+              autoComplete="one-time-code"
+              placeholder="123456"
+              value={mfaCode}
+              onChange={(e) => setMfaCode(e.target.value)}
+              required
+              autoFocus
+              disabled={isLoading}
+            />
+          </div>
+
+          <Button type="submit" className="w-full" disabled={isLoading || !mfaCode.trim()}>
+            {isLoading ? (
+              <>
+                <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                Verifying...
+              </>
+            ) : (
+              'Verify'
+            )}
+          </Button>
+
+          <Button
+            type="button"
+            variant="ghost"
+            className="w-full"
+            disabled={isLoading}
+            onClick={handleMfaCancel}
+          >
+            Back to sign in
+          </Button>
+        </form>
+
+        <p className="text-center text-xs text-muted-foreground mt-3 opacity-60">
+          Powered by Janua
+        </p>
+      </AuthCard>
+    )
+  }
 
   return (
     <AuthCard layout={layout} logo={logoUrl} header={header} footer={footer} className={className}>
@@ -407,10 +590,7 @@ export function SignIn({
             variant="outline"
             className="w-full"
             disabled={isLoading}
-            onClick={() => {
-              // Passkey auth handled by PasskeyButton component in Phase 5
-              // Placeholder for direct integration
-            }}
+            onClick={handlePasskeyLogin}
           >
             Sign in with Passkey
           </Button>

--- a/packages/vue-sdk/src/composables.ts
+++ b/packages/vue-sdk/src/composables.ts
@@ -329,11 +329,15 @@ export function useMFA() {
   const error = ref<Error | null>(null);
   const isLoading = ref(false);
 
-  const enableMFA = async (type: 'totp' | 'sms') => {
+  // Begin TOTP enrollment. The /mfa/enable endpoint requires the account
+  // password (it verifies it before issuing a secret), so this takes a password,
+  // not an MFA "type" — the prior `type` argument was sent to an endpoint that
+  // ignored it. SMS/email enrollment is not implemented server-side.
+  const enableMFA = async (password: string) => {
     error.value = null;
     isLoading.value = true;
     try {
-      return await client.auth.enableMFA(type);
+      return await client.auth.enableMFA(password);
     } catch (e) {
       error.value = e instanceof Error ? e : new Error(String(e));
       throw e;


### PR DESCRIPTION
The P1 MFA/passkey completion work — the UIs/SDK methods that must exist **before** `MFA_ENFORCE_ON_LOGIN` can ever be flipped on.

> ⚠️ **`MFA_ENFORCE_ON_LOGIN` stays default `False`** — `config.py` and `mfa_enforcement.py` are untouched. Merging this does NOT change enforcement or lock anyone out. It builds the challenge UIs that must ship first.

## Built (P1 #1/#2/#3)
- **MFA-challenge UI + SDK.** `signIn` now surfaces `mfa_required`/`mfa_token` (was silently swallowing them → MFA users "logged in" with no session); added `verifyMfaChallenge(mfa_token, code)`. Dashboard `login()` + login page render a code-entry step. Fixed stale SDK MFA endpoints (`/mfa/enable`, `/mfa/regenerate-backup-codes`, query-param bindings).
- **Passkey LOGIN.** No caller existed for `/authenticate/options → navigator.credentials.get → /authenticate/verify` (now `session_id`-based). Built it in the dashboard + hosted login + SDK.
- **Hosted OAuth login MFA step.** Real challenge screen so OAuth/OIDC logins (every downstream app) can complete the second factor; resumes the OAuth redirect.
- Downstream consumer fixes (nextjs/react/vue SDKs) forced by `tokens` becoming optional — each also closed a latent MFA gap.

## Two pre-existing bugs found + fixed (both were blocking, both independently confirmed)
1. **`ActivityLog(details=...)` → 500 on every MFA/passkey log write.** The model column is `activity_metadata`; `details` is unmapped → `TypeError`. So `/mfa/challenge/verify` and `/passkeys/authenticate/verify` returned **500 on success**. Never caught because the comprehensive tests are quarantined out of CI. Fixed across `mfa.py` (9 sites) + `passkeys.py` (4).
2. **Backup codes could never complete a challenge.** `code` had `max_length=8` but formatted backup codes are `XXXX-XXXX` (9 chars) — rejected at validation before `consume_backup_code`. Raised to 9 (the field's own comment said "9 with dash").

## Tests
Python unit lane **3470 passed / 100 skipped**; TS SDK 916 pass + `tsc` 0 errors; ui 46 pass; react-sdk 123 pass; nextjs/vue/dashboard `tsc` clean. +7 new API tests (`test_mfa_challenge_verify.py`, `test_login_form_mfa.py`).

**Breaking API change for review:** the `enableMFA` signature changes `method` → `password` in the TS/react/vue SDKs (the old arg was sent to an endpoint that ignored it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)