### PR TITLE
fix(test): bump fakeredis so MFA-verify tests pass on CI (unbreak main)

### DIFF
--- a/apps/api/requirements-test.txt
+++ b/apps/api/requirements-test.txt
@@ -10,7 +10,7 @@ pytest-env==1.1.3
 coverage==7.3.4
 structlog==23.2.0
 aiosqlite==0.19.0
-fakeredis[aioredis]==2.21.0
+fakeredis>=2.26.0  # >=2.26 supports RESP3 HELLO (redis-py>=5); 2.21 raised "unknown command `hello`" against redis 8.x. Async support is built in — no [aioredis] extra.
 
 # Additional testing utilities
 respx==0.20.2

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -91,4 +91,4 @@ pytest>=9.0.3  # GHSA-6w46-j5rx-g56g
 pytest-asyncio>=0.24.0  # Updated
 pytest-cov>=6.0.0  # Updated
 black>=26.3.1  # GHSA-3936-cmfr-pm3m
-fakeredis[aioredis]>=2.21.0  # Required for CI testing
+fakeredis>=2.26.0  # Required for CI testing; >=2.26 supports the RESP3 HELLO handshake redis-py>=5 negotiates (2.21 raised "unknown command `hello`" against redis 8.x). The [aioredis] extra was removed in newer fakeredis — async support is built in.


### PR DESCRIPTION
**Unbreaks `main`.** PR #560 merged with 3 tests still pending in the `Tests & Coverage` lane; they then failed on main, turning the branch red.

## What failed
`test_mfa_challenge_verify.py::test_valid_totp_returns_tokens`, `::test_valid_backup_code_returns_tokens`, and `test_login_form_mfa.py::test_valid_code_sets_cookies_and_redirects` — all returned **500** with `redis.exceptions.ResponseError: unknown command \`hello\``. They are the only tests that drive `AuthService.create_session`, which issues a real Redis command through the in-memory fake. The other 3468 unit tests passed (they don't execute a Redis command through the fake).

## Root cause
`fakeredis==2.21.0` (pinned in `requirements-test.txt`) does not implement the RESP3 `HELLO` handshake that `redis-py>=5` negotiates on connect. Reproduced directly: with `redis 8.1.0`, a bare `FakeRedis().set()` raises "unknown command \`hello\`" on 2.21.0 and **succeeds** on 2.37.1.

## Fix
Require `fakeredis>=2.26.0` (RESP3/HELLO support) in both requirements files; drop the now-removed `[aioredis]` extra (async support is built in; the `fakeredis.aioredis` submodule the tests import still exists). **No test or app code changed** — the tests are correct; only the test dependency was too old for the redis-py the app already ships.

## Verified
Locally against `redis 8.1.0` + `fakeredis 2.37.1`: the 2 MFA test files (7 tests, incl. the 3 that failed on main) all pass. Letting CI fully confirm before merge this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)