### PR TITLE
feat(oauth): emit organization claims on human tokens

### DIFF
--- a/apps/api/app/routers/v1/oauth_provider.py
+++ b/apps/api/app/routers/v1/oauth_provider.py
@@ -272,6 +272,83 @@ async def _get_user_entitlements(
     return entitlements
 
 
+async def _get_user_org_claims(user: User, db: AsyncSession) -> dict:
+    """Resolve organization claims for HUMAN tokens (authorization_code + refresh).
+
+    Machine (client_credentials) tokens have always carried ``org_id`` from the
+    OAuth client's own organization binding; human tokens carried none, so an
+    org-scoped resource server (e.g. symbiosis-hcm, which 403s any request
+    whose token lacks ``org_id``) could never authorize a browser login.
+
+    Contract:
+      - ``orgs``: every ACTIVE membership as ``{id, slug, role}``. Omitted
+        entirely when the user has none.
+      - ``org_id`` / ``tenant_id`` / ``org_slug``: emitted ONLY when
+        unambiguous — exactly one active membership, or ``user.tenant_id``
+        names one of them. Ambiguity emits ``orgs`` alone; consumers must not
+        guess a tenant.
+
+    Memberships with status other than ``active`` (pending/inactive/removed)
+    never contribute — a removed member must not keep tenant access through a
+    long-lived refresh chain. Failure to resolve emits no org claims at all
+    (fail-closed: downstream org-scoped services reject, never mis-scope).
+    """
+    try:
+        result = await db.execute(
+            select(OrganizationMember, Organization)
+            .join(
+                Organization,
+                Organization.id == OrganizationMember.organization_id,
+            )
+            .where(
+                OrganizationMember.user_id == user.id,
+                OrganizationMember.status == "active",
+            )
+        )
+        rows = result.all()
+    except Exception as e:
+        logger.warning(
+            "Failed to fetch org claims, omitting from token",
+            user_id=str(user.id),
+            error=str(e),
+        )
+        await db.rollback()
+        return {}
+
+    if not rows:
+        return {}
+
+    claims: dict = {
+        "orgs": [
+            {"id": str(org.id), "slug": org.slug, "role": member.role or "member"}
+            for member, org in rows
+        ]
+    }
+
+    primary = None
+    if len(rows) == 1:
+        primary = rows[0][1]
+    else:
+        tenant_id = getattr(user, "tenant_id", None)
+        if tenant_id:
+            tenant_id = str(tenant_id)
+            for _member, org in rows:
+                if str(org.id) == tenant_id:
+                    primary = org
+                    break
+
+    if primary is not None:
+        claims.update(
+            {
+                "org_id": str(primary.id),
+                "tenant_id": str(primary.id),
+                "org_slug": primary.slug,
+            }
+        )
+
+    return claims
+
+
 # ============================================================================
 # Cookie-based Authentication Helper
 # ============================================================================
@@ -1616,6 +1693,10 @@ async def _handle_authorization_code_grant(
     # bootstrap. See app/services/entitlements_service.py.
     madfam_entitled_products = entitlements_to_claim(await get_user_entitlements(user, db))
 
+    # Organization claims for org-scoped resource servers (symbiosis-hcm etc.);
+    # unambiguous org_id or none — see _get_user_org_claims.
+    org_claims = await _get_user_org_claims(user, db)
+
     # Resolve per-client audience (falls back to global JWT_AUDIENCE)
     client_audience = client.audience or settings.JWT_AUDIENCE
 
@@ -1635,6 +1716,9 @@ async def _handle_authorization_code_grant(
             "is_admin": entitlements["is_admin"],
             # MADFAM ecosystem per-product entitlements
             "madfam_entitled_products": madfam_entitled_products,
+            # Organization membership claims (orgs always when member of any;
+            # org_id/tenant_id/org_slug only when unambiguous)
+            **org_claims,
         },
     )
 
@@ -1725,6 +1809,10 @@ async def _handle_refresh_token_grant(
     # Per-product MADFAM ecosystem grants (Selva-unified SSO Phase 1).
     madfam_entitled_products = entitlements_to_claim(await get_user_entitlements(user, db))
 
+    # Organization claims for org-scoped resource servers (symbiosis-hcm etc.);
+    # unambiguous org_id or none — see _get_user_org_claims.
+    org_claims = await _get_user_org_claims(user, db)
+
     # Resolve per-client audience (falls back to global JWT_AUDIENCE)
     client_audience = client.audience or settings.JWT_AUDIENCE
 
@@ -1744,6 +1832,9 @@ async def _handle_refresh_token_grant(
             "is_admin": entitlements["is_admin"],
             # MADFAM ecosystem per-product entitlements
             "madfam_entitled_products": madfam_entitled_products,
+            # Organization membership claims (orgs always when member of any;
+            # org_id/tenant_id/org_slug only when unambiguous)
+            **org_claims,
         },
     )
 

--- a/apps/api/tests/unit/routers/test_oauth_provider_router.py
+++ b/apps/api/tests/unit/routers/test_oauth_provider_router.py
@@ -887,3 +887,122 @@ class TestOidcEndSession:
 
         assert exc_info.value.status_code == 400
         assert "post_logout_redirect_uri" in exc_info.value.detail
+
+
+class TestUserOrgClaims:
+    """_get_user_org_claims — organization claims on HUMAN tokens.
+
+    Contract under test: `orgs` lists every ACTIVE membership; `org_id` /
+    `tenant_id` / `org_slug` appear only when unambiguous (single active
+    membership, or user.tenant_id names one); non-active memberships and
+    lookup failures emit nothing (fail-closed).
+    """
+
+    @staticmethod
+    def _user(tenant_id=None):
+        user = MagicMock()
+        user.id = uuid.uuid4()
+        user.tenant_id = tenant_id
+        return user
+
+    @staticmethod
+    def _membership_row(role="member", slug="acme", org_id=None):
+        member = MagicMock()
+        member.role = role
+        org = MagicMock()
+        org.id = org_id or uuid.uuid4()
+        org.slug = slug
+        return (member, org)
+
+    @staticmethod
+    def _db_returning(rows):
+        db = AsyncMock()
+        result = MagicMock()  # result methods are sync (see TESTING_PATTERNS.md)
+        result.all.return_value = rows
+        db.execute = AsyncMock(return_value=result)
+        return db
+
+    async def test_single_active_membership_emits_unambiguous_org(self):
+        from app.routers.v1.oauth_provider import _get_user_org_claims
+
+        row = self._membership_row(role="member", slug="crea")
+        db = self._db_returning([row])
+
+        claims = await _get_user_org_claims(self._user(), db)
+
+        org = row[1]
+        assert claims["org_id"] == str(org.id)
+        assert claims["tenant_id"] == str(org.id)
+        assert claims["org_slug"] == "crea"
+        assert claims["orgs"] == [{"id": str(org.id), "slug": "crea", "role": "member"}]
+
+    async def test_multiple_memberships_without_tenant_emit_orgs_only(self):
+        from app.routers.v1.oauth_provider import _get_user_org_claims
+
+        rows = [
+            self._membership_row(slug="org-a"),
+            self._membership_row(slug="org-b", role="admin"),
+        ]
+        db = self._db_returning(rows)
+
+        claims = await _get_user_org_claims(self._user(tenant_id=None), db)
+
+        assert "org_id" not in claims
+        assert "tenant_id" not in claims
+        assert "org_slug" not in claims
+        assert [o["slug"] for o in claims["orgs"]] == ["org-a", "org-b"]
+
+    async def test_multiple_memberships_with_matching_tenant_pick_it(self):
+        from app.routers.v1.oauth_provider import _get_user_org_claims
+
+        target = self._membership_row(slug="org-b", role="admin")
+        rows = [self._membership_row(slug="org-a"), target]
+        db = self._db_returning(rows)
+
+        claims = await _get_user_org_claims(self._user(tenant_id=target[1].id), db)
+
+        assert claims["org_id"] == str(target[1].id)
+        assert claims["org_slug"] == "org-b"
+        assert len(claims["orgs"]) == 2
+
+    async def test_no_memberships_emit_no_org_claims(self):
+        from app.routers.v1.oauth_provider import _get_user_org_claims
+
+        db = self._db_returning([])
+
+        claims = await _get_user_org_claims(self._user(), db)
+
+        assert claims == {}
+
+    async def test_lookup_failure_is_fail_closed_and_rolls_back(self):
+        from app.routers.v1.oauth_provider import _get_user_org_claims
+
+        db = AsyncMock()
+        db.execute = AsyncMock(side_effect=RuntimeError("db down"))
+
+        claims = await _get_user_org_claims(self._user(), db)
+
+        assert claims == {}
+        db.rollback.assert_awaited_once()
+
+    async def test_query_filters_on_user_and_active_status(self):
+        from app.routers.v1.oauth_provider import _get_user_org_claims
+
+        db = self._db_returning([])
+        await _get_user_org_claims(self._user(), db)
+
+        query = db.execute.await_args.args[0]
+        compiled = str(query)
+        assert "organization_members" in compiled
+        assert "status" in compiled
+        assert "user_id" in compiled
+
+    async def test_null_member_role_defaults_to_member(self):
+        from app.routers.v1.oauth_provider import _get_user_org_claims
+
+        row = self._membership_row(role=None, slug="crea")
+        db = self._db_returning([row])
+
+        claims = await _get_user_org_claims(self._user(), db)
+
+        assert claims["orgs"][0]["role"] == "member"


### PR DESCRIPTION
Human (authorization_code + refresh) access tokens now carry organization claims; machine tokens already did via the client's org binding.

**Contract**
- `orgs`: every ACTIVE membership as `{id, slug, role}` — omitted when none.
- `org_id` / `tenant_id` / `org_slug`: only when unambiguous — exactly one active membership, or `user.tenant_id` names one of them. Ambiguity emits `orgs` alone; consumers must not guess.
- Non-active memberships (pending/inactive/removed) never contribute; lookup failure emits no org claims (fail-closed: org-scoped services reject, never mis-scope).

**Why now**: this is the change CTM_SSO_AND_LAUNCHER_DESIGN calls "the single most important Janua change" — symbiosis-hcm scopes every request by the token's `org_id` (missing claim → 403), so no human could ever authorize a browser login to an org-scoped service. Enables internal-devops ADR-009 (CTM employee SSO access tiers); companion PRs: symbiosis-hcm #50 (Mi ficha self-service), crea-map #41 (launcher v0, merged).

**Scope notes**: access tokens only (id_token/userinfo untouched — follow-up if a consumer needs it). Pre-existing wart flagged, not fixed here: `_get_user_entitlements` derives the `roles` claim without filtering membership `status`, so removed members keep org roles in tokens — worth its own reviewed fix.

Tests: 7 new cases in tests/unit/routers/test_oauth_provider_router.py (64/64 file-local green); diff is ruff-clean (6 pre-existing findings in that file untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)