### PR TITLE
feat(auth): magic-link rate limit as a config knob (default unchanged)

### DIFF
--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -102,6 +102,18 @@ class Settings(BaseSettings):
     )
 
     # Redis
+    # Rate limits
+    MAGIC_LINK_RATE_LIMIT: str = Field(
+        default="5/hour",
+        description=(
+            "slowapi limit string for POST /auth/magic-link, keyed by client IP. "
+            "The default protects against email-bombing, but a team onboarding "
+            "ceremony from ONE shared IP (an office WiFi) hard-stops at the 6th "
+            "person. Raise temporarily (e.g. '60/hour') for the ceremony window, "
+            "then restore."
+        ),
+    )
+
     REDIS_URL: str = Field(default="redis://localhost:6379/0", description="Redis connection URL")
     REDIS_POOL_SIZE: int = Field(default=10)
     REDIS_DECODE_RESPONSES: bool = Field(default=True)

--- a/apps/api/app/routers/v1/auth.py
+++ b/apps/api/app/routers/v1/auth.py
@@ -2153,7 +2153,11 @@ async def resend_verification_email(
 
 
 @router.post("/magic-link")
-@limiter.limit("5/hour")  # Rate limiting for magic link requests
+# Config knob (default "5/hour", per client IP): a team-onboarding ceremony from
+# one shared office IP dies at the 6th request under the hardcoded limit — see
+# Settings.MAGIC_LINK_RATE_LIMIT. Callable so per-request evaluation follows the
+# deployed env without code changes.
+@limiter.limit(lambda: settings.MAGIC_LINK_RATE_LIMIT)
 async def send_magic_link(
     request: Request,
     magic_link_data: MagicLinkRequest,

--- a/apps/api/tests/unit/test_magic_link_rate_limit_knob.py
+++ b/apps/api/tests/unit/test_magic_link_rate_limit_knob.py
@@ -1,0 +1,28 @@
+"""MAGIC_LINK_RATE_LIMIT — the ceremony knob.
+
+The magic-link endpoint is rate-limited per client IP. The default (5/hour)
+protects against email-bombing, but a team-onboarding ceremony from one shared
+office IP hard-stops at the sixth person. These tests pin the knob: the default
+is unchanged, the env override works, and the route reads the setting (not a
+hardcoded string).
+"""
+
+from pathlib import Path
+
+from app.config import Settings
+
+
+class TestMagicLinkRateLimitKnob:
+    def test_default_is_unchanged_five_per_hour(self):
+        assert Settings().MAGIC_LINK_RATE_LIMIT == "5/hour"
+
+    def test_env_override_is_respected(self, monkeypatch):
+        monkeypatch.setenv("MAGIC_LINK_RATE_LIMIT", "60/hour")
+        assert Settings().MAGIC_LINK_RATE_LIMIT == "60/hour"
+
+    def test_route_uses_the_setting_not_a_hardcoded_limit(self):
+        source = Path("app/routers/v1/auth.py").read_text()
+        anchor = source.index('@router.post("/magic-link")')
+        window = source[anchor : anchor + 500]
+        assert "settings.MAGIC_LINK_RATE_LIMIT" in window
+        assert '@limiter.limit("5/hour")' not in window


### PR DESCRIPTION
Found while planning a client team's onboarding ceremony: `POST /auth/magic-link` is `5/hour` keyed by client IP — 13–20 people requesting sign-in links from one office WiFi hard-stop at the sixth request.

This makes the limit read `Settings.MAGIC_LINK_RATE_LIMIT` (env-mappable, default `"5/hour"` — zero behavior change until an operator sets it). slowapi callable form, evaluated per request. Tests pin: default unchanged, env override works, route reads the setting (source-anchored regression guard).

Ceremony usage: set `MAGIC_LINK_RATE_LIMIT=60/hour` on the api deployment for the window, restore after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)