### PR TITLE
fix(oauth): machine clients key by consumer-edge name — multiple confidential clients per audience + audit rows for internal registrations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,6 +345,9 @@ Janua integrates with Dhanam (billing platform) for subscription management via 
 
 **Client Registration:** `POST /api/v1/oauth/clients/register` — headless, idempotent
 client registration via `X-Internal-API-Key` header (for consumer bootstrap scripts).
+Identity is the client **`name`** (one client per consumer edge, ADR-006): same name
+updates in place and returns no secret; a new name creates a new client **even on a
+shared `audience`**. Writes `audit_logs` rows for every internal-key registration.
 
 **Consumer provisioning CLI:** `@janua/cli` (`packages/cli`) — `janua provision apply|plan|verify`
 with `janua.client.yaml`. Publish tag `cli-v*`. Template: `examples/consumer-bootstrap/`.

--- a/apps/api/app/routers/v1/oauth_clients.py
+++ b/apps/api/app/routers/v1/oauth_clients.py
@@ -17,7 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import settings
 from app.database import get_db
 from app.dependencies import get_current_user, require_admin, verify_internal_api_key
-from app.models import OAuthClient, User
+from app.models import AuditLog, OAuthClient, User
 from app.schemas.oauth_client import (
     OAuthClientCreate,
     OAuthClientDetailResponse,
@@ -51,6 +51,53 @@ async def get_oauth_client_service(
     return OAuthClientService(db)
 
 
+# Actor recorded for registrations authenticated by the shared INTERNAL_API_KEY.
+# The key authenticates a *machine* caller, not a person: there is no user
+# behind it, so `user_id` stays NULL (the column is nullable) and the principal
+# is named in `details.actor` rather than faked onto a human's id. Attributing
+# these to the bootstrap admin would be worse than leaving it null — it would
+# read as that admin having provisioned credentials they never touched.
+INTERNAL_API_KEY_PRINCIPAL = "internal-api-key"
+
+
+def _record_internal_registration_audit(
+    db: AsyncSession,
+    *,
+    action: str,
+    client: OAuthClient,
+) -> None:
+    """Stage an audit_logs row for an internal-key OAuth client registration.
+
+    Internal-key registrations previously wrote NO audit row at all: machine
+    credentials could be minted or reconfigured through
+    ``POST /oauth/clients/register`` and the only trace was an application log
+    line, which is not queryable as an audit record and does not survive log
+    rotation.
+
+    Follows the same direct-``AuditLog`` construction used by
+    ``OAuthClientService`` (create/update/delete/rotate). Never records secret
+    material — only the client name, public client_id, and audience.
+
+    Staged on the session; the caller commits alongside the client write so the
+    audit row and the registration land in one transaction.
+    """
+    db.add(
+        AuditLog(
+            user_id=None,
+            action=action,
+            resource_type="oauth_client",
+            resource_id=client.id,
+            details={
+                "actor": INTERNAL_API_KEY_PRINCIPAL,
+                "actor_type": "service",
+                "client_id": client.client_id,
+                "name": _safe_oauth_client_name(client.name),
+                "audience": client.audience,
+            },
+        )
+    )
+
+
 @router.post("/register", response_model=OAuthClientDetailResponse)
 async def register_oauth_client(
     data: OAuthClientCreate,
@@ -66,40 +113,54 @@ async def register_oauth_client(
     Consumer services call this from their own bootstrap scripts using the
     shared INTERNAL_API_KEY, without needing a human login.
 
-    **Idempotent and convergent**: If a client with the same stable key already
-    exists, reconciles non-secret fields from the request and returns the
-    existing client (HTTP 200, no secret). The stable key is `client_key`, or
-    `audience` when `client_key` is omitted. Legacy clients still fall back to
-    name matching. On first creation, returns HTTP 201 with the client_secret
-    for confidential clients (only shown once).
+    **Idempotent and convergent, keyed by CONSUMER EDGE**: the stable identity of
+    a registration is the client **`name`**. Re-registering the same name
+    reconciles non-secret fields and returns the existing client (HTTP 200, no
+    secret). A *new* name creates a new client (HTTP 201 + `client_secret`, shown
+    exactly once) **even when it shares an `audience` with an existing client**.
+
+    Several consumer edges legitimately target one audience — `zavlo-cfdi-emitter`
+    and `nauta-legal-drafts` both call `karafiel-api` — and per ADR-006 each edge
+    gets its own client scoped to exactly what it calls.
 
     **Auth**: X-Internal-API-Key header (shared secret from K8s).
     """
-    registration_key = data.client_key or data.audience
     if data.client_key and data.audience and data.client_key != data.audience:
         raise HTTPException(
             status_code=400,
             detail="client_key must match audience until a separate client key column exists",
         )
 
+    # Upsert identity is the NAME — the stable consumer-edge identifier.
+    #
+    # This used to try `client_key || audience` FIRST and fall back to name.
+    # Audience is not an identity: it names the API being *called*, and many
+    # consumer edges call the same API. Registering a second same-audience
+    # client therefore reached into the first client's row and renamed it,
+    # rewrote its scopes and description, and returned 200 with no secret — a
+    # silent hijack that left the original consumer holding a client_id whose
+    # scopes now belonged to somebody else, with no new credential issued to
+    # either party. The token path already supported N clients per audience
+    # (tests/unit/routers/test_service_token_clients.py mints independently for
+    # two karafiel-api clients); only this registration key disagreed.
+    #
+    # Names are stable by construction — they are declared in each consumer's
+    # checked-in manifest (examples/consumer-bootstrap/janua.client.yaml) and in
+    # scripts/seed_service_clients.py — so every existing caller keeps
+    # converging onto its own row exactly as before. See the PR body for the
+    # old-vs-new semantics table.
+    #
+    # A pinned `client_id` still takes precedence when supplied: it is a
+    # stronger identity claim than the name, and honoring it first keeps
+    # re-registration idempotent for consumers that rename their edge while
+    # pinning the id.
     existing_client = None
-    if registration_key:
-        existing = await db.execute(
-            select(OAuthClient)
-            .where(OAuthClient.audience == registration_key)
-            .order_by(OAuthClient.created_at)
-            .limit(1)
-        )
-        existing_client = existing.scalar_one_or_none()
+
+    if data.client_id:
+        existing_client = await service.get_client_by_client_id(data.client_id)
 
     if not existing_client:
         existing_client = await service.get_client_by_name(data.name)
-
-    if not existing_client:
-        existing = await db.execute(
-            select(OAuthClient).where(OAuthClient.name == data.name).order_by(OAuthClient.created_at).limit(1)
-        )
-        existing_client = existing.scalar_one_or_none()
 
     if existing_client:
         if data.client_id and existing_client.client_id != data.client_id:
@@ -107,7 +168,13 @@ async def register_oauth_client(
                 status_code=409,
                 detail="Client name already registered with a different client_id",
             )
-        existing_client.name = data.name
+        if existing_client.name != data.name:
+            # Reached only via a pinned client_id: the id is the stronger claim,
+            # so a rename under a pinned id is an update, not a hijack.
+            raise HTTPException(
+                status_code=409,
+                detail="client_id already registered to a different client",
+            )
         existing_client.description = data.description
         existing_client.redirect_uris = data.redirect_uris
         existing_client.allowed_scopes = data.allowed_scopes or [
@@ -125,22 +192,16 @@ async def register_oauth_client(
         if data.is_confidential is not None:
             existing_client.is_confidential = data.is_confidential
         existing_client.updated_at = datetime.utcnow()
+        _record_internal_registration_audit(
+            db,
+            action="oauth_client_registered_internal_updated",
+            client=existing_client,
+        )
         await db.commit()
         await db.refresh(existing_client)
 
         response.status_code = 200
         return _client_detail_response(existing_client)
-
-    if data.client_id:
-        existing_by_id = await service.get_client_by_client_id(data.client_id)
-        if existing_by_id:
-            if existing_by_id.name == data.name:
-                response.status_code = 200
-                return _client_detail_response(existing_by_id)
-            raise HTTPException(
-                status_code=409,
-                detail="client_id already registered to a different client",
-            )
 
     # Resolve bootstrap admin user (first admin by creation date)
     admin_result = await db.execute(
@@ -169,6 +230,18 @@ async def register_oauth_client(
 
     safe_name = _safe_oauth_client_name(data.name)
     logger.info("OAuth client registered via bootstrap: %s (client_id=%s)", safe_name, client.client_id)
+
+    # create_client() writes an `oauth_client_created` row attributed to the
+    # bootstrap admin. That row cannot distinguish a human dashboard create from
+    # an unattended internal-key registration, so record the registration itself
+    # as well — otherwise the internal-key path leaves no trace of who provisioned
+    # a machine credential.
+    _record_internal_registration_audit(
+        db,
+        action="oauth_client_registered_internal_created",
+        client=client,
+    )
+    await db.commit()
 
     response.status_code = 201
     return OAuthClientDetailResponse(

--- a/apps/api/tests/unit/routers/test_oauth_clients_register_consumer_edge.py
+++ b/apps/api/tests/unit/routers/test_oauth_clients_register_consumer_edge.py
@@ -1,0 +1,472 @@
+"""
+POST /api/v1/oauth/clients/register keys by CONSUMER EDGE (client name), not
+by audience — and writes audit_logs rows for internal-key registrations.
+
+Before this, the registration upsert key was ``client_key || audience`` with
+name only as a fallback. Audience is not an identity: it names the API being
+*called*, and several consumer edges legitimately call the same API
+(``zavlo-cfdi-emitter`` and ``nauta-legal-drafts`` both target ``karafiel-api``;
+see scripts/seed_service_clients.py). Registering a second same-audience client
+therefore reached into the FIRST client's row — renaming it, rewriting its
+scopes and description — and returned 200 with no secret. The original consumer
+kept a client_id whose scopes now belonged to somebody else, and the new
+consumer never received a credential at all.
+
+ADR-006 (internal-devops decisions/adr-006-entitlement-claim-and-tier-naming.md)
+states the intended contract in as many words: "One such client per consumer
+edge — Fashion Cabinet (fashion-cabinet-body-render), white-label, and
+Selva→Tablaco-quote each get their own, scoped to exactly what they call."
+
+The token path already honoured that contract — see
+test_service_token_clients.py, which mints independently for two karafiel-api
+clients. Only the registration key disagreed.
+
+Second gap covered here: internal-key registrations wrote NO audit_logs row, so
+machine credentials could be minted or reconfigured with no queryable trace.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+from app.config import settings
+from app.core.database import get_db as core_get_db
+from app.core.jwt_manager import jwt_manager
+from app.core.redis import get_redis
+from app.database import get_db
+from app.main import app
+from app.models import AuditLog, Base, OAuthClient, User, UserStatus
+
+INTERNAL_KEY = "test-internal-api-key-consumer-edge"
+REGISTER_URL = "/api/v1/oauth/clients/register"
+TOKEN_URL = "/api/v1/oauth/token"
+
+SHARED_AUDIENCE = "karafiel-api"
+
+
+@pytest_asyncio.fixture
+async def registry():
+    """Register-capable app plus a handle on the same session factory.
+
+    Tests assert on rows the endpoint wrote (oauth_clients, audit_logs), so
+    they need the same in-memory database the app is writing to.
+    """
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with session_factory() as session:
+            yield session
+
+    redis = AsyncMock()
+    redis.ping.return_value = True
+    redis.get.return_value = None
+    redis.set.return_value = True
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[core_get_db] = override_get_db
+    app.dependency_overrides[get_redis] = lambda: redis
+
+    settings.INTERNAL_API_KEY = INTERNAL_KEY
+
+    admin = User(
+        id=uuid.uuid4(),
+        email="admin-consumer-edge@janua.test",
+        email_verified=True,
+        status=UserStatus.ACTIVE,
+        is_admin=True,
+        is_active=True,
+    )
+    async with session_factory() as session:
+        session.add(admin)
+        await session.commit()
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client, session_factory
+
+    app.dependency_overrides.clear()
+    settings.INTERNAL_API_KEY = None
+    await engine.dispose()
+
+
+def _machine_payload(name: str, *, audience: str = SHARED_AUDIENCE, scopes: list[str]) -> dict:
+    """A confidential client_credentials consumer edge, as ADR-006 describes."""
+    return {
+        "name": name,
+        "description": f"{name} consumer edge",
+        "redirect_uris": [],
+        "audience": audience,
+        "allowed_scopes": scopes,
+        "grant_types": ["client_credentials"],
+        "is_confidential": True,
+    }
+
+
+async def _register(client: AsyncClient, payload: dict):
+    return await client.post(
+        REGISTER_URL,
+        json=payload,
+        headers={"X-Internal-API-Key": INTERNAL_KEY},
+    )
+
+
+class TestMultipleClientsPerAudience:
+    """A new NAME creates a new client even when the audience is taken."""
+
+    async def test_second_name_same_audience_creates_a_second_client(self, registry):
+        api, session_factory = registry
+
+        first = await _register(
+            api, _machine_payload("zavlo-cfdi-emitter", scopes=["cfdi:issue"])
+        )
+        assert first.status_code == 201, first.text
+        assert first.json()["client_secret"] is not None
+
+        # NOTE: the seed list's `legal:client-profile` is not usable here — the
+        # HTTP schema's scope regex (`^[a-z][a-z0-9_]*:[a-z][a-z0-9_]*$`) rejects
+        # the hyphen, so that scope is reachable only via the DB seed path. That
+        # pre-existing divergence between the two provisioning paths is out of
+        # scope for this change; `legal:draft` exercises the same behaviour.
+        second = await _register(
+            api, _machine_payload("nauta-legal-drafts", scopes=["legal:draft"])
+        )
+
+        # The whole point: a genuine 201 create, not a 200 upsert onto the first.
+        assert second.status_code == 201, second.text
+        assert second.json()["client_secret"] is not None
+        assert second.json()["client_id"] != first.json()["client_id"]
+
+        # Both rows exist, both on the shared audience.
+        async with session_factory() as session:
+            rows = (
+                (
+                    await session.execute(
+                        select(OAuthClient).where(OAuthClient.audience == SHARED_AUDIENCE)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        assert sorted(r.name for r in rows) == ["nauta-legal-drafts", "zavlo-cfdi-emitter"]
+
+    async def test_first_client_is_not_hijacked_by_the_second(self, registry):
+        """The old semantics renamed the existing row and rewrote its scopes.
+
+        This is the regression that must stay dead: after registering a second
+        same-audience edge, the FIRST client keeps its name, its client_id, and
+        its own scope allowlist.
+        """
+        api, session_factory = registry
+
+        first = await _register(
+            api, _machine_payload("zavlo-cfdi-emitter", scopes=["cfdi:issue"])
+        )
+        assert first.status_code == 201, first.text
+        first_client_id = first.json()["client_id"]
+
+        await _register(
+            api, _machine_payload("nauta-legal-drafts", scopes=["legal:draft"])
+        )
+
+        async with session_factory() as session:
+            preserved = (
+                await session.execute(
+                    select(OAuthClient).where(OAuthClient.client_id == first_client_id)
+                )
+            ).scalar_one()
+
+        assert preserved.name == "zavlo-cfdi-emitter"
+        assert preserved.allowed_scopes == ["cfdi:issue"]
+        assert preserved.description == "zavlo-cfdi-emitter consumer edge"
+
+    async def test_four_consumer_edges_coexist_on_overlapping_audiences(self, registry):
+        """The edges ADR-006 names, plus the hyperobjects-coverage client.
+
+        fashion-cabinet-body-render, white-label licence minting and
+        Selva→Tablaco quotes all target yantra4d-api; under the old key only one
+        of them could exist.
+        """
+        api, session_factory = registry
+
+        edges = [
+            ("fashion-cabinet-body-render", "yantra4d-api", ["yantra4d:render"]),
+            ("yantra4d-white-label-licence", "yantra4d-api", ["yantra4d:license"]),
+            ("selva-tablaco-quote", "yantra4d-api", ["yantra4d:quote"]),
+            ("ceq-hyperobjects-coverage", "yantra4d-api", ["yantra4d:coverage"]),
+        ]
+
+        client_ids = set()
+        for name, audience, scopes in edges:
+            response = await _register(
+                api, _machine_payload(name, audience=audience, scopes=scopes)
+            )
+            assert response.status_code == 201, f"{name}: {response.text}"
+            assert response.json()["client_secret"] is not None, f"{name} got no secret"
+            client_ids.add(response.json()["client_id"])
+
+        # Four distinct credentials, not one row rewritten four times.
+        assert len(client_ids) == 4
+
+        async with session_factory() as session:
+            rows = (
+                (
+                    await session.execute(
+                        select(OAuthClient).where(OAuthClient.audience == "yantra4d-api")
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        assert sorted(r.name for r in rows) == sorted(e[0] for e in edges)
+        # Each kept its own least-privilege scope allowlist.
+        assert {r.name: r.allowed_scopes for r in rows} == {
+            name: scopes for name, _, scopes in edges
+        }
+
+    async def test_both_same_audience_clients_mint_tokens_independently(self, registry):
+        """Two edges on one audience each mint their own scoped token.
+
+        Registration is only useful if the credentials it hands out work. Both
+        secrets are exercised through the real POST /oauth/token
+        client_credentials path, and neither token carries the other's scope.
+        """
+        api, _ = registry
+
+        zavlo = await _register(
+            api, _machine_payload("zavlo-cfdi-emitter", scopes=["cfdi:issue"])
+        )
+        nauta = await _register(
+            api, _machine_payload("nauta-legal-drafts", scopes=["legal:draft"])
+        )
+        assert zavlo.status_code == 201 and nauta.status_code == 201
+
+        for issued, scope in ((zavlo, "cfdi:issue"), (nauta, "legal:draft")):
+            body = issued.json()
+            token_response = await api.post(
+                TOKEN_URL,
+                data={
+                    "grant_type": "client_credentials",
+                    "client_id": body["client_id"],
+                    "client_secret": body["client_secret"],
+                    "scope": scope,
+                },
+            )
+            assert token_response.status_code == 200, token_response.text
+            claims = jwt_manager.verify_token(
+                token_response.json()["access_token"],
+                token_type="access",
+                audience=SHARED_AUDIENCE,
+            )
+            assert claims is not None
+            assert claims["client_id"] == body["client_id"]
+            assert claims["sub"] == f"service-account:{body['client_id']}"
+            assert claims["scope"] == scope
+            assert claims["aud"] == SHARED_AUDIENCE
+
+        # Fail closed across edges: zavlo cannot mint nauta's scope.
+        crossed = await api.post(
+            TOKEN_URL,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": zavlo.json()["client_id"],
+                "client_secret": zavlo.json()["client_secret"],
+                "scope": "legal:draft",
+            },
+        )
+        assert crossed.status_code == 400
+
+
+class TestSameNameStillUpdates:
+    """Backward compatibility: a stable name keeps converging on its own row."""
+
+    async def test_same_name_reregistration_updates_without_secret(self, registry):
+        api, session_factory = registry
+
+        created = await _register(
+            api, _machine_payload("zavlo-cfdi-emitter", scopes=["cfdi:issue"])
+        )
+        assert created.status_code == 201
+        original_client_id = created.json()["client_id"]
+
+        again = await _register(
+            api, _machine_payload("zavlo-cfdi-emitter", scopes=["cfdi:issue", "cfdi:cancel"])
+        )
+        assert again.status_code == 200, again.text
+        assert again.json()["client_id"] == original_client_id
+        # An upsert never re-issues a credential.
+        assert again.json()["client_secret"] is None
+        # ...but it does reconcile non-secret fields.
+        assert again.json()["allowed_scopes"] == ["cfdi:issue", "cfdi:cancel"]
+
+        async with session_factory() as session:
+            count = len(
+                
+                    (
+                        await session.execute(
+                            select(OAuthClient).where(
+                                OAuthClient.name == "zavlo-cfdi-emitter"
+                            )
+                        )
+                    )
+                    .scalars()
+                    .all()
+                
+            )
+        assert count == 1
+
+    async def test_same_name_may_move_its_audience(self, registry):
+        """A single-client-per-audience caller that repoints its audience still
+        updates in place rather than forking a second row."""
+        api, session_factory = registry
+
+        first = await _register(
+            api, _machine_payload("routecraft-billing-relay", audience="dhanam-api", scopes=["billing:events"])
+        )
+        assert first.status_code == 201
+
+        moved = await _register(
+            api,
+            _machine_payload(
+                "routecraft-billing-relay", audience="dhanam-api-v2", scopes=["billing:events"]
+            ),
+        )
+        assert moved.status_code == 200, moved.text
+        assert moved.json()["client_id"] == first.json()["client_id"]
+        assert moved.json()["audience"] == "dhanam-api-v2"
+
+        async with session_factory() as session:
+            rows = (
+                (
+                    await session.execute(
+                        select(OAuthClient).where(
+                            OAuthClient.name == "routecraft-billing-relay"
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+        assert len(rows) == 1
+
+
+class TestInternalRegistrationAuditRows:
+    """Internal-key registrations are recorded in audit_logs."""
+
+    @staticmethod
+    async def _audit_rows(session_factory, action: str) -> list[AuditLog]:
+        async with session_factory() as session:
+            return list(
+                (await session.execute(select(AuditLog).where(AuditLog.action == action)))
+                .scalars()
+                .all()
+            )
+
+    async def test_create_writes_an_audit_row(self, registry):
+        api, session_factory = registry
+
+        created = await _register(
+            api, _machine_payload("zavlo-cfdi-emitter", scopes=["cfdi:issue"])
+        )
+        assert created.status_code == 201
+
+        rows = await self._audit_rows(
+            session_factory, "oauth_client_registered_internal_created"
+        )
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.resource_type == "oauth_client"
+        # The internal API key authenticates a machine, not a person: the row is
+        # not falsely attributed to the bootstrap admin.
+        assert row.user_id is None
+        assert row.details["actor"] == "internal-api-key"
+        assert row.details["actor_type"] == "service"
+        assert row.details["name"] == "zavlo-cfdi-emitter"
+        assert row.details["audience"] == SHARED_AUDIENCE
+        assert row.details["client_id"] == created.json()["client_id"]
+
+    async def test_update_writes_an_audit_row(self, registry):
+        api, session_factory = registry
+
+        await _register(api, _machine_payload("zavlo-cfdi-emitter", scopes=["cfdi:issue"]))
+        again = await _register(
+            api, _machine_payload("zavlo-cfdi-emitter", scopes=["cfdi:issue"])
+        )
+        assert again.status_code == 200
+
+        rows = await self._audit_rows(
+            session_factory, "oauth_client_registered_internal_updated"
+        )
+        assert len(rows) == 1
+        assert rows[0].details["name"] == "zavlo-cfdi-emitter"
+        assert rows[0].user_id is None
+
+    async def test_audit_rows_never_carry_secret_material(self, registry):
+        api, session_factory = registry
+
+        created = await _register(
+            api, _machine_payload("zavlo-cfdi-emitter", scopes=["cfdi:issue"])
+        )
+        secret = created.json()["client_secret"]
+        assert secret and secret.startswith("jns_")
+
+        async with session_factory() as session:
+            rows = list((await session.execute(select(AuditLog))).scalars().all())
+
+        assert rows
+        for row in rows:
+            serialized = str(row.details)
+            assert secret not in serialized
+            assert "jns_" not in serialized
+            assert "client_secret" not in serialized
+
+    async def test_each_consumer_edge_registration_is_separately_auditable(self, registry):
+        """Two edges on one audience produce two distinct create rows.
+
+        Under the old semantics the second registration silently mutated the
+        first client and left no record at all.
+        """
+        api, session_factory = registry
+
+        await _register(api, _machine_payload("zavlo-cfdi-emitter", scopes=["cfdi:issue"]))
+        await _register(api, _machine_payload("nauta-legal-drafts", scopes=["legal:draft"]))
+
+        rows = await self._audit_rows(
+            session_factory, "oauth_client_registered_internal_created"
+        )
+        assert sorted(r.details["name"] for r in rows) == [
+            "nauta-legal-drafts",
+            "zavlo-cfdi-emitter",
+        ]
+        assert len({r.details["client_id"] for r in rows}) == 2
+
+
+class TestSeedListStaysConsistentWithTheEndpoint:
+    """The operator seed path already keyed by name; the endpoint now agrees."""
+
+    def test_seed_list_holds_two_clients_on_one_audience(self):
+        from scripts.seed_service_clients import SERVICE_CLIENTS
+
+        karafiel = [c for c in SERVICE_CLIENTS if c["audience"] == "karafiel-api"]
+        # This is the shipped configuration the old registration key could not
+        # express: two named edges, one audience.
+        assert sorted(c["name"] for c in karafiel) == [
+            "nauta-legal-drafts",
+            "zavlo-cfdi-emitter",
+        ]
+        assert len({c["name"] for c in SERVICE_CLIENTS}) == len(SERVICE_CLIENTS)

--- a/docs/service-tokens.md
+++ b/docs/service-tokens.md
@@ -40,7 +40,21 @@ Issuer (production): `https://auth.madfam.io`
 
 Provisioned by an operator with `apps/api/scripts/seed_service_clients.py`
 (or zero-touch via `POST /api/v1/oauth/clients/register` +
-`X-Internal-API-Key`). Registration properties:
+`X-Internal-API-Key`).
+
+**One client per consumer edge, keyed by `name`.** Registration identity is the
+client **`name`** — the stable consumer-edge identifier declared in the
+consumer's `janua.client.yaml` (or in `seed_service_clients.py`). Re-registering
+the same name reconciles non-secret fields and returns 200 with **no** secret; a
+new name creates a new client (201 + `client_secret`, shown once) **even when it
+shares an `audience`**. Audience names the API being *called*, and several edges
+legitimately call one API: `zavlo-cfdi-emitter` and `nauta-legal-drafts` both
+target `karafiel-api`. Per ADR-006 each edge gets its own client scoped to
+exactly what it calls. Internal-key registrations are recorded in `audit_logs`
+(`oauth_client_registered_internal_created` / `..._updated`), attributed to the
+`internal-api-key` principal and carrying no secret material.
+
+Registration properties:
 
 ```jsonc
 // zavlo-cfdi-emitter


### PR DESCRIPTION
`POST /api/v1/oauth/clients/register` (internal-API-key protected) upserted by
`client_key || audience`, with the client name only as a fallback. Audience is
not an identity: it names the API being **called**, and several consumer edges
legitimately call the same API. The practical effect was that only **one machine
client could exist per audience**, and registering a second one silently
hijacked the first.

This is not hypothetical. `apps/api/scripts/seed_service_clients.py` already
ships two clients on `karafiel-api` — `zavlo-cfdi-emitter` (`cfdi:issue`) and
`nauta-legal-drafts` (`legal:draft`, `legal:client-profile`) — a configuration
the HTTP registration path could not express. The operator seed path keys by
name (`seed_core_clients.py:320`, `WHERE name = :name OR client_id = :cid`) and
was always correct; only the HTTP endpoint disagreed with it.

## Old vs new semantics

| Scenario | Old | New |
|---|---|---|
| Same name, same audience, re-register | 200, update, no secret | **200, update, no secret** (unchanged) |
| **New name, audience already taken** | **200 — renames + rewrites the EXISTING client's scopes/description; no secret to anyone** | **201, creates a second client, secret returned once** |
| New name, new audience | 201 + secret | 201 + secret (unchanged) |
| Same name, audience changed | 200, update in place | 200, update in place (unchanged) |
| Pinned `client_id`, re-register same name | 200, no secret | 200, no secret (unchanged) |
| Pinned `client_id` bound to a different name | 409 | 409 (unchanged) |
| Name registered under a different pinned `client_id` | 409 | 409 (unchanged) |
| Internal-key registration | **no `audit_logs` row** | **`audit_logs` row written** |

New upsert identity, in precedence order:

1. pinned `client_id` when supplied (the stronger identity claim), then
2. the client **`name`** — the stable consumer-edge identifier.

Audience is no longer an identity key at all; it remains a stored, reconcilable
field.

## Backward compatibility

**No existing caller changes behavior.** Consumer names are stable by
construction — they are declared in each consumer's checked-in manifest
(`examples/consumer-bootstrap/janua.client.yaml`) or in
`seed_service_clients.py`, and `@janua/cli` already documents the endpoint as
"idempotent by client name or pinned `spec.client_id`" (`packages/cli/README.md:19`).
The endpoint had drifted from its own published contract; this restores it.

For any caller that has registered before, the audience key and the name key
resolved to *the same row* — the row it created itself — so name-first lookup
returns exactly what audience-first returned. The only behavior that changes is
the case that was broken: a **different** name arriving on a taken audience now
gets its own client instead of overwriting somebody else's.

The one deliberate semantic change: a caller that renames its edge while keeping
its audience (and without pinning a `client_id`) now gets a **new** client with
a fresh secret rather than silently renaming the old row. That is the correct
outcome — a renamed edge is a new consumer identity — and it fails loudly (a new
`client_id` the caller must adopt) rather than quietly repointing an existing
credential. No repo-tracked caller does this.

## Migration verdict: NO MIGRATION REQUIRED

The only unique index on `oauth_clients` is on `client_id`
(`alembic/versions/000_init.py:735`). Neither `name` nor `audience` carries a
unique constraint in the model (`app/models/__init__.py:381-422`) or in any
migration, so multiple rows sharing an `audience` were already representable —
the database was never the constraint, the endpoint's lookup was. This change is
**code-only**; nothing needs `alembic upgrade`, and there is no promote-ordering
hazard. (Janua's promote pipeline runs no migrations, so a schema change here
would have needed an operator in-pod step; none is needed.)

## Audit gap closed

Internal-key registrations wrote no `audit_logs` row: machine credentials could
be minted or reconfigured through the internal API with the only trace being an
application log line, which is not queryable as an audit record and does not
survive log rotation.

Both branches now write a row via `_record_internal_registration_audit`, using
the same direct-`AuditLog` construction as `OAuthClientService`
(create/update/delete/rotate):

- `oauth_client_registered_internal_created` (201 path)
- `oauth_client_registered_internal_updated` (200 path)

`user_id` is left **NULL** and the principal is named in
`details.actor = "internal-api-key"` (`actor_type: "service"`). The shared key
authenticates a machine, not a person; attributing these rows to the bootstrap
admin would read as that admin having provisioned credentials they never
touched. `details` carries the client name, public `client_id` and audience —
**never secret material**, and a test asserts that.

The audit row is staged on the same session and committed with the client write,
so a registration and its audit record land in one transaction.

## Consumer edges this unblocks

Four edges that target overlapping audiences and could not previously coexist:

1. `fashion-cabinet-body-render` — Fashion Cabinet → Yantra4D live MTM body render
2. white-label licence minting — Janua-signed licences carrying `yantra4d_tier`
3. Selva → Tablaco quotes
4. `ceq-hyperobjects-coverage` — hyperobjects coverage for ceq

ADR-006 (`internal-devops/decisions/adr-006-entitlement-claim-and-tier-naming.md`)
already specifies this contract in as many words: *"One such client per consumer
edge — Fashion Cabinet (`fashion-cabinet-body-render`), white-label, and
Selva→Tablaco-quote each get their own, scoped to exactly what they call."*
This makes the registration endpoint able to express it.

## Tests

New: `apps/api/tests/unit/routers/test_oauth_clients_register_consumer_edge.py`

- second name on a shared audience creates a **second** client (201 + secret)
- the first client is **not hijacked** — name, `client_id`, scopes and
  description all preserved (the dead old-semantics regression)
- all four consumer edges coexist on `yantra4d-api`, each keeping its own
  least-privilege scope allowlist
- **both same-audience clients mint tokens independently** through the real
  `POST /oauth/token` `client_credentials` path, with verified claims — and
  fail closed across edges (zavlo cannot mint `legal:draft`)
- same-name re-registration updates in place, returns **no** secret, leaves one row
- a same-name caller may still move its audience in place
- audit rows written on both create and update, `user_id` NULL,
  `actor = internal-api-key`
- audit rows carry **no** secret material
- two edges produce two separately auditable create rows
- the shipped seed list holds two clients on one audience (the config the old
  key could not express)

Existing `test_oauth_clients_register.py`, `test_oauth_clients_duplicate_guard.py`,
`test_service_token_clients.py` and `test_oauth_client_name_lookup.py` pass
unchanged — **no existing assertion needed editing**, which is the
backward-compat argument in executable form.

### Local verification

```
cd apps/api
python -m pytest tests/unit/routers/test_oauth_clients_register_consumer_edge.py --no-cov -q
  → 11 passed

python -m pytest tests/unit/routers/test_oauth_clients_register.py \
    tests/unit/routers/test_oauth_clients_duplicate_guard.py \
    tests/unit/routers/test_service_token_clients.py \
    tests/unit/services/test_oauth_client_name_lookup.py \
    tests/unit/routers/test_oauth_provider_router.py \
    tests/unit/routers/test_oauth_userinfo_audience.py --no-cov -q
  → 103 passed

python -m pytest tests/unit/routers/ tests/unit/services/ --no-cov -q
  → 2382 passed, 91 skipped, 0 failed  (6m15s)

python -m ruff check app/routers/v1/oauth_clients.py \
    tests/unit/routers/test_oauth_clients_register_consumer_edge.py
  → 1 pre-existing F401 (unused `OAuthClientResponse` import, present on main,
    untouched here); no new findings
```

`black --check` reports this router as needing reformatting **on `origin/main`
as well** — the file was never black-clean, and `.github/workflows/tests.yml`
runs `black --check . || true` / `ruff check . || true` (non-blocking). Left
unformatted deliberately rather than adding unrelated churn to an auth file.

One note surfaced by the tests, not fixed here: the seed list's
`legal:client-profile` scope is **not registrable over HTTP** — the schema's
scope regex `^[a-z][a-z0-9_]*:[a-z][a-z0-9_]*$` rejects the hyphen, so that
scope is reachable only through the DB seed path. A pre-existing divergence
between the two provisioning paths, out of scope for this change.

## OPERATOR

- **Promote via the normal janua flow, then run the in-pod drift-check.** Janua's
  promote runs no migrations; per the standing ecosystem rule, verify schema
  state in-pod after promote even though this PR needs no migration.
- Nothing to apply before or with promote — this is code-only.
- After promote, the four consumer-edge clients above can be registered
  normally; each `POST .../register` with a **new name** returns 201 and a
  `jns_` secret **once**. Store each in Vault/Enclii and mount it into the
  calling service. Re-running a registration is safe and returns 200 with no
  secret.
- Existing production rows are untouched by this PR. If any audience currently
  holds a row that was *previously* hijacked (renamed away from its original
  consumer), that row's identity is now whatever name it last carried;
  re-registering the displaced consumer under its own name will mint it a fresh
  client rather than reclaiming the row. Worth a read of `oauth_clients` on
  `karafiel-api` and `yantra4d-api` before registering the new edges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
