### PR TITLE
fix(ci): retry cosign keyless signing against transient OIDC failures

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -128,12 +128,34 @@ jobs:
           provenance: false
           sbom: false
 
+      # Retry: 2026-08-26 crea-frontend run 33010085743 lost a deploy when
+      # GitHub's OIDC endpoint returned non-JSON ("invalid character 'u'") and
+      # cosign died. Image was pushed, digest never pinned, ArgoCD never rolled.
       - name: Sign image with cosign
         if: steps.build.outcome == 'success'
         env:
           COSIGN_EXPERIMENTAL: "true"
+          IMAGE_REF: ${{ env.IMAGE_PREFIX }}/janua-api@${{ steps.build.outputs.digest }}
         run: |
-          cosign sign --yes ${{ env.IMAGE_PREFIX }}/janua-api@${{ steps.build.outputs.digest }}
+          set -euo pipefail
+          signed=0
+          for wait in 0 20 60; do
+            if [ "$wait" -gt 0 ]; then
+              echo "::warning::cosign sign failed for ${IMAGE_REF} (transient OIDC/Fulcio/Rekor?); retrying in ${wait}s..."
+              sleep "$wait"
+            fi
+            if cosign sign --yes "${IMAGE_REF}"; then
+              signed=1
+              break
+            fi
+          done
+          if [ "$signed" -ne 1 ]; then
+            echo "::error::cosign sign failed 3 times for ${IMAGE_REF}."
+            echo "::error::The image was BUILT AND PUSHED but is NOT signed, so it will not be"
+            echo "::error::pinned and ArgoCD will not roll it: the live host is still serving the"
+            echo "::error::PREVIOUS build even though this commit is on main. Rerun the failed jobs."
+            exit 1
+          fi
 
   build-admin:
     name: Build Admin
@@ -178,12 +200,34 @@ jobs:
           provenance: false
           sbom: false
 
+      # Retry: 2026-08-26 crea-frontend run 33010085743 lost a deploy when
+      # GitHub's OIDC endpoint returned non-JSON ("invalid character 'u'") and
+      # cosign died. Image was pushed, digest never pinned, ArgoCD never rolled.
       - name: Sign image with cosign
         if: steps.build.outcome == 'success'
         env:
           COSIGN_EXPERIMENTAL: "true"
+          IMAGE_REF: ${{ env.IMAGE_PREFIX }}/janua-admin@${{ steps.build.outputs.digest }}
         run: |
-          cosign sign --yes ${{ env.IMAGE_PREFIX }}/janua-admin@${{ steps.build.outputs.digest }}
+          set -euo pipefail
+          signed=0
+          for wait in 0 20 60; do
+            if [ "$wait" -gt 0 ]; then
+              echo "::warning::cosign sign failed for ${IMAGE_REF} (transient OIDC/Fulcio/Rekor?); retrying in ${wait}s..."
+              sleep "$wait"
+            fi
+            if cosign sign --yes "${IMAGE_REF}"; then
+              signed=1
+              break
+            fi
+          done
+          if [ "$signed" -ne 1 ]; then
+            echo "::error::cosign sign failed 3 times for ${IMAGE_REF}."
+            echo "::error::The image was BUILT AND PUSHED but is NOT signed, so it will not be"
+            echo "::error::pinned and ArgoCD will not roll it: the live host is still serving the"
+            echo "::error::PREVIOUS build even though this commit is on main. Rerun the failed jobs."
+            exit 1
+          fi
 
   build-dashboard:
     name: Build Dashboard
@@ -229,12 +273,34 @@ jobs:
           provenance: false
           sbom: false
 
+      # Retry: 2026-08-26 crea-frontend run 33010085743 lost a deploy when
+      # GitHub's OIDC endpoint returned non-JSON ("invalid character 'u'") and
+      # cosign died. Image was pushed, digest never pinned, ArgoCD never rolled.
       - name: Sign image with cosign
         if: steps.build.outcome == 'success'
         env:
           COSIGN_EXPERIMENTAL: "true"
+          IMAGE_REF: ${{ env.IMAGE_PREFIX }}/janua-dashboard@${{ steps.build.outputs.digest }}
         run: |
-          cosign sign --yes ${{ env.IMAGE_PREFIX }}/janua-dashboard@${{ steps.build.outputs.digest }}
+          set -euo pipefail
+          signed=0
+          for wait in 0 20 60; do
+            if [ "$wait" -gt 0 ]; then
+              echo "::warning::cosign sign failed for ${IMAGE_REF} (transient OIDC/Fulcio/Rekor?); retrying in ${wait}s..."
+              sleep "$wait"
+            fi
+            if cosign sign --yes "${IMAGE_REF}"; then
+              signed=1
+              break
+            fi
+          done
+          if [ "$signed" -ne 1 ]; then
+            echo "::error::cosign sign failed 3 times for ${IMAGE_REF}."
+            echo "::error::The image was BUILT AND PUSHED but is NOT signed, so it will not be"
+            echo "::error::pinned and ArgoCD will not roll it: the live host is still serving the"
+            echo "::error::PREVIOUS build even though this commit is on main. Rerun the failed jobs."
+            exit 1
+          fi
 
   build-docs:
     name: Build Docs
@@ -278,12 +344,34 @@ jobs:
           provenance: false
           sbom: false
 
+      # Retry: 2026-08-26 crea-frontend run 33010085743 lost a deploy when
+      # GitHub's OIDC endpoint returned non-JSON ("invalid character 'u'") and
+      # cosign died. Image was pushed, digest never pinned, ArgoCD never rolled.
       - name: Sign image with cosign
         if: steps.build.outcome == 'success'
         env:
           COSIGN_EXPERIMENTAL: "true"
+          IMAGE_REF: ${{ env.IMAGE_PREFIX }}/janua-docs@${{ steps.build.outputs.digest }}
         run: |
-          cosign sign --yes ${{ env.IMAGE_PREFIX }}/janua-docs@${{ steps.build.outputs.digest }}
+          set -euo pipefail
+          signed=0
+          for wait in 0 20 60; do
+            if [ "$wait" -gt 0 ]; then
+              echo "::warning::cosign sign failed for ${IMAGE_REF} (transient OIDC/Fulcio/Rekor?); retrying in ${wait}s..."
+              sleep "$wait"
+            fi
+            if cosign sign --yes "${IMAGE_REF}"; then
+              signed=1
+              break
+            fi
+          done
+          if [ "$signed" -ne 1 ]; then
+            echo "::error::cosign sign failed 3 times for ${IMAGE_REF}."
+            echo "::error::The image was BUILT AND PUSHED but is NOT signed, so it will not be"
+            echo "::error::pinned and ArgoCD will not roll it: the live host is still serving the"
+            echo "::error::PREVIOUS build even though this commit is on main. Rerun the failed jobs."
+            exit 1
+          fi
 
   build-website:
     name: Build Website
@@ -329,12 +417,34 @@ jobs:
           provenance: false
           sbom: false
 
+      # Retry: 2026-08-26 crea-frontend run 33010085743 lost a deploy when
+      # GitHub's OIDC endpoint returned non-JSON ("invalid character 'u'") and
+      # cosign died. Image was pushed, digest never pinned, ArgoCD never rolled.
       - name: Sign image with cosign
         if: steps.build.outcome == 'success'
         env:
           COSIGN_EXPERIMENTAL: "true"
+          IMAGE_REF: ${{ env.IMAGE_PREFIX }}/janua-website@${{ steps.build.outputs.digest }}
         run: |
-          cosign sign --yes ${{ env.IMAGE_PREFIX }}/janua-website@${{ steps.build.outputs.digest }}
+          set -euo pipefail
+          signed=0
+          for wait in 0 20 60; do
+            if [ "$wait" -gt 0 ]; then
+              echo "::warning::cosign sign failed for ${IMAGE_REF} (transient OIDC/Fulcio/Rekor?); retrying in ${wait}s..."
+              sleep "$wait"
+            fi
+            if cosign sign --yes "${IMAGE_REF}"; then
+              signed=1
+              break
+            fi
+          done
+          if [ "$signed" -ne 1 ]; then
+            echo "::error::cosign sign failed 3 times for ${IMAGE_REF}."
+            echo "::error::The image was BUILT AND PUSHED but is NOT signed, so it will not be"
+            echo "::error::pinned and ArgoCD will not roll it: the live host is still serving the"
+            echo "::error::PREVIOUS build even though this commit is on main. Rerun the failed jobs."
+            exit 1
+          fi
 
   commit-digests:
     name: Commit Digests to Staging Kustomization
@@ -422,6 +532,30 @@ jobs:
             sleep $((ATTEMPT * 2))
           done
           echo "ERROR: Failed to push after 3 attempts"
+          exit 1
+
+      # Loud-stale guard. "Update digests" skips any service whose build job did
+      # not end in `success`, and this job runs `if: always()` — so a build that
+      # pushed its image and then died at the sign step is silently dropped from
+      # the pin while this job goes green. That is the 2026-08-26 crea-frontend
+      # failure mode exactly: green on main, previous build still live.
+      - name: Guard — fail loudly if a built image was not pinned
+        if: >-
+          always() &&
+          (needs.build-api.result == 'failure' ||
+           needs.build-admin.result == 'failure' ||
+           needs.build-dashboard.result == 'failure' ||
+           needs.build-docs.result == 'failure' ||
+           needs.build-website.result == 'failure')
+        run: |
+          echo "::error title=Image pushed but NOT pinned/deployed::A build job failed after its"
+          echo "::error::image may already have been pushed to GHCR (api=${{ needs.build-api.result }},"
+          echo "::error::admin=${{ needs.build-admin.result }}, dashboard=${{ needs.build-dashboard.result }},"
+          echo "::error::docs=${{ needs.build-docs.result }}, website=${{ needs.build-website.result }})."
+          echo "::error::Its digest was SKIPPED by the pin step above, so ArgoCD was never handed a new"
+          echo "::error::digest and THE LIVE HOST IS STILL SERVING THE PREVIOUS BUILD even though this"
+          echo "::error::commit is green on main. Rerun the failed jobs:"
+          echo "::error::  gh run rerun ${{ github.run_id }} --failed"
           exit 1
 
   report-lifecycle:


### PR DESCRIPTION
## Why

On 2026-08-26, `madfam-org/crea-frontend` run 33010085743 failed at 20:22:40Z in **Sign image (keyless, Fulcio/Rekor)**:

```
getting key from Fulcio: fetching ambient OIDC credentials:
invalid character 'u' looking for beginning of value
```

GitHub's OIDC token endpoint transiently returned non-JSON. The image had **already been built and pushed**, but the chain stopped *before* the digest-pin step — so ArgoCD was never handed a new digest. `main` showed a green squash while the deployed host silently kept serving the previous build. It was caught only by an external census deploy-gate. `gh run rerun --failed` succeeded on the first try, confirming the failure was purely transient.

That is a **silent-stale-deploy** class hazard: a one-shot network call sits between "image is public" and "cluster is told about it", and a blip there strands the deploy without turning anything red that a human is watching.

## What changed

**1. Retry the `cosign sign` call (every sign step in this repo).**
Only the `cosign sign` invocation is retried — never the build or push. 3 attempts, 0s / 20s / 60s backoff, inline bash, no new marketplace action. The image ref moves into a step-level `env:` var so the loop body stays clean. On final failure the step says exactly what is wrong: the image is pushed but unsigned, so it will not be pinned and the live host is still on the previous build.

**2. The loud-stale guard (where the workflow can go green without deploying).**
An `if: always()` guard step that fails with an explicit "Image pushed but NOT pinned/deployed" error, naming the rerun command.

Existing step names, `if:` conditions, and `env:` keys are preserved. Workflow-YAML only.

### Per-file

| File | Change 1 (sign retry) | Change 2 (loud-stale guard) |
|---|---|---|
| `.github/workflows/docker-publish.yml` | yes — all 5 sign steps (api, admin, dashboard, docs, website) | **yes** |

**Why this workflow needed the guard.** `commit-digests` runs `if: always()`, and its `Update digests` step pins a service only when `needs.build-<svc>.result == 'success'`. A build job that pushed its image and then died at the sign step is therefore *silently skipped* by the pin while `commit-digests` itself goes green — the crea-frontend failure mode exactly. The new guard step fails the job and names the affected services and the rerun command.


## Validation

`python3 -c "import yaml; yaml.safe_load(open(...))"` passes on every touched file. actionlint 1.7.7 passes clean (exit 0, no output).

Held for review — not auto-merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
