### PR TITLE
fix(enclii): remove the domain block that took identity down

### DIFF
--- a/enclii.yaml
+++ b/enclii.yaml
@@ -47,20 +47,17 @@ spec:
     port: 8080
     replicas: 1
     healthCheck: /api/v1/health/ready
-  domains:
-    - name: api.janua.dev
-      environment: production
-    - name: app.janua.dev
-      environment: production
-    - name: admin.janua.dev
-      environment: production
-    - name: auth.madfam.io
-      environment: production
-    - name: janua.dev
-      environment: production
-    - name: www.janua.dev
-      environment: production
-    - name: madfam.io
-      environment: production
-    - name: www.madfam.io
-      environment: production
+  # domains: intentionally NOT declared here — REMOVED 2026-08-27.
+  #
+  # This file is a legacy single Service doc named `janua`, but no cluster
+  # Service named `janua` exists (the real ones are janua-api / janua-admin /
+  # janua-dashboard / janua-website, each on port 80). On 2026-08-27 the
+  # platform's domain reconciler captured the 8 domains that used to be listed
+  # here onto that nonexistent backend and rewrote the tunnel's working ingress
+  # rules to `janua.janua.svc:8080`, taking down auth.madfam.io, madfam.io and
+  # janua.dev — the full identity outage. Until enclii supports per-domain
+  # service targets (or this manifest is split into truthful per-surface
+  # Service docs), the domain→service bindings live in the switchyard registry
+  # ONLY: auth.madfam.io + api.janua.dev → janua-api · admin.janua.dev →
+  # janua-admin · app.janua.dev → janua-dashboard · janua.dev + www → 
+  # janua-website · madfam.io + www belong to the madfam-site project, not here.


### PR DESCRIPTION
Root-cause fix for the 2026-08-27 outage (auth.madfam.io + 7 hostnames, 502 since 16:23Z): this legacy single-doc manifest declares all 8 domains under service name `janua`, which exists in the registry but NOT as a cluster Service — the platform's domain reconciler captured the block and faithfully rewrote the tunnel's working ingress rules to `janua.janua.svc:8080`, a dead backend. Removing the block stops every future capture pass from re-poisoning; the correct per-surface bindings (janua-api/-admin/-dashboard/-website, madfam.io → madfam-site) are documented in-place and live in the registry. Companion PRs: madfam-site (same disease), enclii tunnel-route guards (resolve-before-write + canary + revert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)