### PR TITLE
feat(admin): create an organization owned by a specified user

### DIFF
--- a/apps/api/app/routers/v1/admin.py
+++ b/apps/api/app/routers/v1/admin.py
@@ -16,6 +16,7 @@ from sqlalchemy.orm import Session
 from app.config import settings
 from app.database import get_db
 from app.routers.v1.auth import get_current_user
+from app.routers.v1.organizations.dependencies import validate_unique_slug
 from app.services.account_lockout_service import AccountLockoutService
 from app.services.audit_logger import AuditEventType, AuditLogger
 from app.services.auth_service import AuthService
@@ -133,6 +134,31 @@ class AdminUserUpdateRequest(BaseModel):
 # User.is_admin flag. Keeping the two disjoint is the no-privilege-escalation
 # boundary — an org "admin" must never confer platform admin, and vice-versa.
 _ALLOWED_ORG_ROLES = {"member", "admin", "owner"}
+
+
+class AdminOrganizationCreateRequest(BaseModel):
+    """Admin: create an organization owned by a SPECIFIED existing user.
+
+    The self-service `POST /organizations/` always sets owner = the caller, and
+    janua exposes no ownership-transfer endpoint. That makes it impossible for an
+    operator to stand up a CUSTOMER's canonical org (owned by the customer's
+    master user, not the operator) — which is exactly what onboarding a tenant
+    like a client account requires. This admin endpoint fills that gap: the owner
+    is named explicitly and must already exist.
+    """
+
+    name: str = Field(..., min_length=1, max_length=200)
+    slug: str = Field(..., min_length=1, max_length=100, pattern="^[a-z0-9-]+$")
+    # The owner is an EXISTING user, addressed by email (the human-meaningful key
+    # an operator has) or by id. Exactly one must be provided.
+    owner_email: Optional[EmailStr] = Field(
+        None, description="Email of the existing user to own the org."
+    )
+    owner_id: Optional[str] = Field(
+        None, description="UUID of the existing user to own the org (alternative to owner_email)."
+    )
+    description: Optional[str] = Field(None, max_length=1000)
+    billing_email: Optional[EmailStr] = None
 
 
 class AdminUserCreateRequest(BaseModel):
@@ -729,6 +755,97 @@ async def get_user_lockout_status(
         raise HTTPException(status_code=404, detail=status["error"])
 
     return status
+
+
+@router.post("/organizations", response_model=OrganizationAdminResponse, status_code=201)
+async def create_organization_admin(
+    request: AdminOrganizationCreateRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Create an organization owned by a SPECIFIED existing user (admin only).
+
+    WHY THIS EXISTS. `POST /organizations/` sets owner = the caller, and there is
+    no ownership-transfer endpoint (the members/roles sub-routers are not
+    mounted). So an operator could not create a customer's canonical org owned by
+    the CUSTOMER's master user — the org would be owned by the operator. Tenant
+    onboarding (e.g. standing up one canonical org that provisions a client
+    across every product slice) needs exactly this. The owner is named
+    explicitly, must already exist, and is added as an `owner`-role member.
+
+    Idempotent-friendly: a duplicate slug returns 400 (via validate_unique_slug),
+    so re-running after the org exists fails cleanly rather than creating a
+    second org — the caller then reads the existing org via GET /organizations.
+
+    Privilege model: gated by check_admin_permission (platform admins only).
+    Naming an owner here does NOT grant that user platform admin — org-scoped
+    ownership and the platform `is_admin` flag stay disjoint.
+    """
+    check_admin_permission(current_user)
+
+    if (request.owner_email is None) == (request.owner_id is None):
+        raise HTTPException(
+            status_code=422,
+            detail="Provide exactly one of owner_email or owner_id.",
+        )
+
+    # Resolve the owner FIRST — a bad owner must fail before any write, never
+    # orphan a half-created org.
+    if request.owner_id is not None:
+        try:
+            owner_uuid = uuid.UUID(request.owner_id)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid owner_id")
+        owner_result = await db.execute(select(User).where(User.id == owner_uuid))
+    else:
+        owner_result = await db.execute(select(User).where(User.email == request.owner_email))
+    owner = owner_result.scalar_one_or_none()
+    if not owner:
+        raise HTTPException(status_code=404, detail="Owner user not found")
+
+    # Unique slug (raises 400 if taken) — this is also the idempotency guard.
+    await validate_unique_slug(db, request.slug)
+
+    org = Organization(
+        name=request.name,
+        slug=request.slug,
+        description=request.description,
+        owner_id=owner.id,
+        billing_email=request.billing_email or owner.email,
+        billing_plan="free",
+        settings={},
+        org_metadata={},
+    )
+    db.add(org)
+    await db.flush()  # assign org.id without ending the transaction
+
+    # Add the owner as an owner-role member (mirrors create_organization, which
+    # adds the creator; here the OWNER is the member, not the calling admin).
+    db.add(
+        OrganizationMember(
+            organization_id=org.id,
+            user_id=owner.id,
+            role="owner",
+            status="active",
+            joined_at=datetime.utcnow(),
+        )
+    )
+
+    await db.commit()
+    await db.refresh(org)
+
+    return OrganizationAdminResponse(
+        id=str(org.id),
+        name=org.name,
+        slug=org.slug,
+        owner_id=str(org.owner_id),
+        owner_email=owner.email,
+        billing_plan=org.billing_plan,
+        billing_email=org.billing_email,
+        members_count=1,
+        created_at=org.created_at,
+        updated_at=org.updated_at,
+    )
 
 
 @router.get("/organizations", response_model=List[OrganizationAdminResponse])

--- a/apps/api/tests/unit/routers/test_admin_create_organization.py
+++ b/apps/api/tests/unit/routers/test_admin_create_organization.py
@@ -1,0 +1,213 @@
+"""Admin create-organization endpoint (POST /api/v1/admin/organizations).
+
+The self-service `POST /organizations/` always sets owner = the caller, and janua
+exposes no ownership-transfer endpoint (the members/roles sub-routers are not
+mounted). So an operator could not stand up a CUSTOMER's canonical org owned by
+the customer's master user — it would be owned by the operator. This admin
+endpoint fills that gap. These tests pin the security-critical behaviours:
+
+  * happy path            -> org created owned by the NAMED existing user (not
+                             the calling admin), owner added as an `owner` member
+  * owner addressed by id  -> resolves by UUID too
+  * non-admin caller       -> 403 (gate runs before any write)
+  * unknown owner          -> 404 (fail before any write)
+  * owner XOR              -> exactly one of owner_email/owner_id required (422)
+  * no privilege escalation-> naming an owner does not set platform is_admin
+
+Style follows tests/unit/routers/test_admin_create_user.py: call the endpoint
+coroutine directly with an AsyncMock session and intercept db.add().
+"""
+
+import uuid
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.routers.v1.admin import (
+    AdminOrganizationCreateRequest,
+    create_organization_admin,
+)
+from app.models import Organization, OrganizationMember, User
+
+pytestmark = pytest.mark.asyncio
+
+
+def _admin_user() -> User:
+    return User(id=uuid.uuid4(), email="admin@madfam.io", password_hash="hashed", is_admin=True)
+
+
+def _non_admin_user() -> User:
+    return User(id=uuid.uuid4(), email="mallory@example.com", password_hash="hashed", is_admin=False)
+
+
+def _owner_user(email="creatumundoautismo@hotmail.com") -> User:
+    return User(id=uuid.uuid4(), email=email, password_hash=None, is_admin=False)
+
+
+def _db(owner=None, existing_org_for_slug=None):
+    """AsyncMock session.
+
+    db.execute is called for: owner lookup, then validate_unique_slug's lookup.
+    scalar_one_or_none yields, in order: [owner, slug-collision-or-None].
+    """
+    results = [owner, existing_org_for_slug]
+    call = {"i": 0}
+
+    def _make_result():
+        idx = call["i"]
+        call["i"] += 1
+        value = results[idx] if idx < len(results) else None
+        r = MagicMock()
+        r.scalar_one_or_none = MagicMock(return_value=value)
+        return r
+
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=lambda *a, **k: _make_result())
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+
+    async def refresh(obj, *args, **kwargs):
+        for column, default in (
+            ("id", uuid.uuid4()),
+            ("created_at", datetime.utcnow()),
+            ("updated_at", datetime.utcnow()),
+        ):
+            if getattr(obj, column, None) is None:
+                setattr(obj, column, default)
+
+    db.refresh = AsyncMock(side_effect=refresh)
+    return db
+
+
+def _added(db, cls):
+    return [c.args[0] for c in db.add.call_args_list if c.args and isinstance(c.args[0], cls)]
+
+
+async def _create(request, caller, db):
+    return await create_organization_admin(request=request, current_user=caller, db=db)
+
+
+class TestHappyPath:
+    async def test_creates_org_owned_by_named_user_not_the_admin(self):
+        owner = _owner_user()
+        admin = _admin_user()
+        db = _db(owner=owner)
+        resp = await _create(
+            AdminOrganizationCreateRequest(
+                name="Crea Tu Mundo Autismo",
+                slug="crea",
+                owner_email=owner.email,
+            ),
+            admin,
+            db,
+        )
+
+        orgs = _added(db, Organization)
+        assert len(orgs) == 1
+        created = orgs[0]
+        # The OWNER is the named user, NOT the calling admin.
+        assert created.owner_id == owner.id
+        assert created.owner_id != admin.id
+        assert created.slug == "crea"
+        assert created.billing_email == owner.email  # defaults to owner's email
+
+        # Owner is added as an owner-role member.
+        members = _added(db, OrganizationMember)
+        assert len(members) == 1
+        assert members[0].user_id == owner.id
+        assert members[0].role == "owner"
+
+        assert resp.owner_email == owner.email
+        assert resp.members_count == 1
+
+    async def test_owner_addressed_by_id(self):
+        owner = _owner_user()
+        db = _db(owner=owner)
+        resp = await _create(
+            AdminOrganizationCreateRequest(
+                name="Crea Tu Mundo Autismo", slug="crea", owner_id=str(owner.id)
+            ),
+            _admin_user(),
+            db,
+        )
+        assert _added(db, Organization)[0].owner_id == owner.id
+        assert resp.owner_id == str(owner.id)
+
+    async def test_naming_owner_does_not_grant_platform_admin(self):
+        owner = _owner_user()
+        db = _db(owner=owner)
+        await _create(
+            AdminOrganizationCreateRequest(name="X", slug="crea", owner_email=owner.email),
+            _admin_user(),
+            db,
+        )
+        # The owner user object is untouched w.r.t. platform admin.
+        assert owner.is_admin is False
+        # Membership is org-scoped 'owner', never a platform flag.
+        assert _added(db, OrganizationMember)[0].role == "owner"
+
+
+class TestGuards:
+    async def test_non_admin_caller_forbidden_before_any_write(self):
+        db = _db(owner=_owner_user())
+        with pytest.raises(HTTPException) as exc:
+            await _create(
+                AdminOrganizationCreateRequest(name="X", slug="crea", owner_email="o@x.com"),
+                _non_admin_user(),
+                db,
+            )
+        assert exc.value.status_code == 403
+        assert db.add.call_args_list == []
+
+    async def test_unknown_owner_404_before_any_write(self):
+        db = _db(owner=None)  # owner lookup yields nothing
+        with pytest.raises(HTTPException) as exc:
+            await _create(
+                AdminOrganizationCreateRequest(
+                    name="X", slug="crea", owner_email="ghost@example.com"
+                ),
+                _admin_user(),
+                db,
+            )
+        assert exc.value.status_code == 404
+        assert _added(db, Organization) == []
+
+    async def test_requires_exactly_one_owner_identifier(self):
+        db = _db(owner=_owner_user())
+        # Neither provided.
+        with pytest.raises(HTTPException) as exc_none:
+            await _create(
+                AdminOrganizationCreateRequest(name="X", slug="crea"),
+                _admin_user(),
+                db,
+            )
+        assert exc_none.value.status_code == 422
+
+        # Both provided.
+        db2 = _db(owner=_owner_user())
+        with pytest.raises(HTTPException) as exc_both:
+            await _create(
+                AdminOrganizationCreateRequest(
+                    name="X", slug="crea", owner_email="o@x.com", owner_id=str(uuid.uuid4())
+                ),
+                _admin_user(),
+                db2,
+            )
+        assert exc_both.value.status_code == 422
+
+    async def test_duplicate_slug_rejected(self):
+        owner = _owner_user()
+        collision = Organization(id=uuid.uuid4(), slug="crea", name="Existing", owner_id=owner.id)
+        db = _db(owner=owner, existing_org_for_slug=collision)
+        with pytest.raises(HTTPException) as exc:
+            await _create(
+                AdminOrganizationCreateRequest(name="X", slug="crea", owner_email=owner.email),
+                _admin_user(),
+                db,
+            )
+        # validate_unique_slug raises 400 on a taken slug.
+        assert exc.value.status_code == 400
+        assert _added(db, Organization) == []


### PR DESCRIPTION
Adds POST /api/v1/admin/organizations (admin-gated) to create an org owned by a specified existing user (by email or id), added as an owner-role member. Fills the gap that self-service POST /organizations/ forces owner=caller and janua has no ownership transfer. Resolves owner before any write (404 on unknown); reuses validate_unique_slug (400 on taken slug). 7 unit tests passing; no migration; reuses Organization + OrganizationMember. See commit body for full rationale.