### PR TITLE
feat(email): per-tenant BODY branding (CTM), MADFAM sender unchanged

### DIFF
--- a/apps/api/app/services/email_branding.py
+++ b/apps/api/app/services/email_branding.py
@@ -1,0 +1,161 @@
+"""Per-tenant BODY branding for transactional email.
+
+This is a Phase-1 *refinement*, not Phase 2. See `docs/EMAIL_SENDER_POLICY.md`.
+
+WHAT THIS DOES AND, JUST AS IMPORTANTLY, WHAT IT DOES NOT. Phase 1 keeps one
+sender for every message — `MADFAM <hola@madfam.io>` — because a bespoke client
+meets several MADFAM platforms over an engagement and a sender that changes per
+product reads as several vendors. That does not have to mean every BODY reads
+"MADFAM" as well: a client who signs into their own workspace should see their
+own name at the top of the sign-in mail, with MADFAM credited underneath. This
+module resolves the header name and header palette that vary per tenant, and
+NOTHING it returns is ever used to build the From line. `resolve_sender` in
+`email_service.py` stays the single, deliberately-unused Phase-2 seam.
+
+    From line   -> ALWAYS MADFAM (resolve_sender, untouched)
+    Body header -> the tenant's name and palette (this module)
+    Body footer -> "Con tecnología de <platform>" — the platform credited, and
+                   for a client tenant the platform IS MADFAM, so the footer
+                   reads "Con tecnología de MADFAM" (es) / "Powered by MADFAM".
+
+WHY THE SIGNAL IS THE REDIRECT HOST, NOT A DB LOOKUP. The auth mailer runs
+inside FastAPI BackgroundTasks, which hold no DB session — `EmailService()` is
+instantiated per task with neither Redis nor a DB handle. The tenant signal
+that IS available at send time is the same one `resolve_sender` was built to
+read: the magic-link `redirect_url`, whose host names the product the recipient
+is being sent back to. That is why branding is keyed on host here rather than on
+`WhiteLabelConfiguration` (which exists, is keyed by `organization_id`, and is
+the right home once a send path carries a session — a caller that already knows
+the org id can pass it via `org_id` and it is honored first).
+
+WHY THIS IS NOT "A GIANT HOST MAP". It is one tenant. The registry is CTM's
+canonical org id plus the two hosts CTM users actually sign in through
+(crea-map, kalya). A second client is a second entry, added the day their
+branding is agreed — not a config surface for every product.
+"""
+
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+# --------------------------------------------------------------------------
+# The MADFAM default. Byte-for-byte the header base.html rendered before this
+# module existed: the blue gradient, white text, the "MADFAM" wordmark. Every
+# caller that resolves to no tenant gets exactly this, so an unknown or absent
+# signal is a no-op — the regression tests pin that the default render is
+# identical to today's.
+# --------------------------------------------------------------------------
+MADFAM_BRANDING: Dict[str, str] = {
+    # `header_name` drives the wordmark in base.html's header. `platform_name`
+    # / `platform_url` drive the "Con tecnología de" footer, and default to
+    # Janua exactly as base.html did before (the footer credits the platform;
+    # for a MADFAM-branded message the platform underneath is Janua).
+    "header_name": "MADFAM",
+    "header_bg": "linear-gradient(135deg, #3b82f6 0%, #2563eb 100%)",
+    "header_fg": "#ffffff",
+    "platform_name": "Janua",
+    "platform_url": "https://janua.dev",
+}
+
+# --------------------------------------------------------------------------
+# Crea Tu Mundo Autismo (CTM). Its canonical Janua org and the hosts its users
+# sign in through. Header reads the client's name in the client's palette;
+# footer credits MADFAM (the platform underneath a client tenant IS MADFAM,
+# so `platform_name` is MADFAM here, not Janua).
+#
+# CTM palette: deep royal indigo on a warm cream ground. Kept typographic on
+# purpose — no hotlinked logo (blocked by most clients) and no CID/inline
+# image (fiddly through Resend); a name in brand colors reads correctly
+# everywhere, including with images off.
+# --------------------------------------------------------------------------
+CTM_ORG_ID = "e6cbd51d-8329-4c4e-8c74-aba643ab4575"
+
+CTM_BRANDING: Dict[str, str] = {
+    "header_name": "Crea Tu Mundo",
+    # Deep royal indigo, flat (no gradient) — reads as the brand, not as a
+    # second MADFAM. `header_fg` is the warm-cream text on that indigo ground.
+    "header_bg": "#1a2a8f",
+    "header_fg": "#fdf6e3",
+    # The footer credits the platform, which for a client tenant is MADFAM.
+    "platform_name": "MADFAM",
+    "platform_url": "https://madfam.io",
+}
+
+# Hosts whose sign-in redirect identifies a CTM user. Matched on exact host or
+# a subdomain suffix, so both `crea-map.madfam.io` and a bare `kalya.app`
+# resolve. NOT a catch-all: `madfam.io` itself is deliberately absent — it is
+# MADFAM's own host and must keep MADFAM branding.
+CTM_HOSTS: tuple = (
+    "crea-map.madfam.io",
+    "ensayo-map.madfam.io",
+    "kalya.app",
+)
+
+
+def _host_matches(host: str, pattern: str) -> bool:
+    """True when `host` is `pattern` or a subdomain of it.
+
+    Suffix match on a dot boundary so `kalya.app` matches `kalya.app` and
+    `app.kalya.app` but never `evilkalya.app`.
+    """
+    host = host.lower().strip()
+    pattern = pattern.lower().strip()
+    return host == pattern or host.endswith("." + pattern)
+
+
+def _tenant_for_host(host: Optional[str]) -> Optional[str]:
+    """Map a redirect host to a tenant key, or None for MADFAM default."""
+    if not host:
+        return None
+    for pattern in CTM_HOSTS:
+        if _host_matches(host, pattern):
+            return "ctm"
+    return None
+
+
+def _tenant_for_org_id(org_id: Optional[str]) -> Optional[str]:
+    """Map an organization id to a tenant key, or None for MADFAM default."""
+    if not org_id:
+        return None
+    if str(org_id).strip().lower() == CTM_ORG_ID:
+        return "ctm"
+    return None
+
+
+_TENANT_BRANDING: Dict[str, Dict[str, str]] = {
+    "ctm": CTM_BRANDING,
+}
+
+
+def resolve_branding(
+    redirect_url: Optional[str] = None,
+    org_id: Optional[Any] = None,
+) -> Dict[str, str]:
+    """The BODY branding context for one message.
+
+    Returns a plain dict merged into the template context: `header_name`,
+    `header_bg`, `header_fg` (the header wordmark and palette) plus
+    `platform_name` / `platform_url` (the "Con tecnología de" footer). Always a
+    complete set — a template never has to guard for a missing key.
+
+    Resolution order, highest precedence first:
+
+      1. `org_id` — a caller that already knows the tenant (a send path with a
+         session, or the template endpoint if a caller passes one) is
+         authoritative. This is where `WhiteLabelConfiguration` would be read
+         from once a mailer carries a DB session; today it is the static
+         registry.
+      2. `redirect_url` host — the signal the auth mailer actually has at send
+         time, the same host `resolve_sender` reads.
+      3. Neither, or an unrecognized value -> MADFAM. Unknown tenants get
+         today's exact MADFAM frame; this is a no-op for every existing caller.
+
+    NEVER used to build the From line. Body branding only. See module docstring
+    and `docs/EMAIL_SENDER_POLICY.md`.
+    """
+    tenant = _tenant_for_org_id(org_id)
+    if tenant is None and redirect_url:
+        host = urlparse(redirect_url).hostname
+        tenant = _tenant_for_host(host)
+    if tenant is None:
+        return dict(MADFAM_BRANDING)
+    return {**MADFAM_BRANDING, **_TENANT_BRANDING[tenant]}

--- a/apps/api/app/services/email_service.py
+++ b/apps/api/app/services/email_service.py
@@ -18,6 +18,7 @@ import redis.asyncio as redis
 import structlog
 
 from app.config import settings
+from app.services.email_branding import resolve_branding
 from app.services.email_i18n import (
     FALLBACK_LOCALE,
     FORMALITY_TU,
@@ -524,6 +525,12 @@ class EmailService:
             "base_url": settings.BASE_URL,
             "company_name": "Janua",
             "support_email": settings.SUPPORT_EMAIL or "support@janua.dev",
+            # BODY branding (header wordmark + palette, footer credit) resolved
+            # from the redirect host — the tenant the link sends the person back
+            # TO. Defaults to MADFAM, so an unknown or absent host renders
+            # exactly today's frame. The From line is unaffected: `resolve_sender`
+            # below still returns MADFAM. See app/services/email_branding.py.
+            **resolve_branding(redirect_url=redirect_url),
         }
 
         subject = subject_for("magic_link", recipient_locale, recipient_formality)

--- a/apps/api/app/templates/email/base.html
+++ b/apps/api/app/templates/email/base.html
@@ -99,7 +99,15 @@
 <body>
     <div class="container">
         <div class="email-wrapper">
-            <div class="header">
+            <!-- The header wordmark and palette are the ONE part of the frame
+                 that varies per tenant (BODY branding, Phase-1 refinement — the
+                 From line stays MADFAM; see docs/EMAIL_SENDER_POLICY.md and
+                 app/services/email_branding.py). `header_*` default to the
+                 MADFAM values so every existing caller renders byte-identically;
+                 a client tenant (CTM) passes its own name and colors, and the
+                 footer below credits MADFAM via "Con tecnología de". -->
+            <div class="header" style="background: {{ header_bg | default('linear-gradient(135deg, #3b82f6 0%, #2563eb 100%)', true) }}; color: {{ header_fg | default('#ffffff', true) }};">
+                {% if (header_name | default('MADFAM', true)) == 'MADFAM' %}
                 <div class="logo">
                     <!-- INLINE PNG, not the SVG and not a remote URL.
                          Gmail strips <svg> entirely, and most clients block
@@ -113,13 +121,16 @@
                          width="60" height="60" alt="MADFAM"
                          style="display:block;margin:0 auto;border:0;outline:none;text-decoration:none;" />
                 </div>
-                <!-- MADFAM is the sender on EVERY message, whichever platform
-                     produced it. Bespoke clients meet several of our platforms
-                     over an engagement; a header that changes per product
-                     teaches them nothing and reads as several vendors. One
-                     consistent brand is what makes the NEXT email safe to
-                     open. The platform is credited in the footer instead. -->
-                <h1 style="margin: 0; font-size: 24px; font-weight: 600;">MADFAM</h1>
+                {% endif %}
+                <!-- The wordmark. MADFAM by default, on every platform's own
+                     message: bespoke clients meet several of our platforms over
+                     an engagement, and a header that changes per PRODUCT reads
+                     as several vendors. A client TENANT is different — a person
+                     signing into their own workspace should see their own name
+                     here, with MADFAM credited in the footer. `header_name`
+                     defaults to MADFAM so nothing changes for existing callers;
+                     the From line is MADFAM regardless. -->
+                <h1 style="margin: 0; font-size: 24px; font-weight: 600;">{{ header_name | default('MADFAM', true) }}</h1>
                 <p style="margin: 5px 0 0 0; opacity: 0.9; font-size: 14px;">{{ t('tagline') }}</p>
             </div>
             

--- a/apps/api/templates/emails/transactional_workspace-activated.html
+++ b/apps/api/templates/emails/transactional_workspace-activated.html
@@ -27,7 +27,7 @@
             <p>{{line_support}}</p>
         </div>
         <div class="footer">
-            <p>{{workspace_host}} · Con tecnología MADFAM</p>
+            <p>{{workspace_host}} · Con tecnología de MADFAM</p>
         </div>
     </div>
 </body>

--- a/apps/api/tests/unit/services/test_email_branding.py
+++ b/apps/api/tests/unit/services/test_email_branding.py
@@ -1,0 +1,218 @@
+"""Per-tenant BODY branding, and the invariants that keep it Phase-1 safe.
+
+Context: docs/EMAIL_SENDER_POLICY.md. Phase 1 keeps ONE sender —
+`MADFAM <hola@madfam.io>` — for every message from every platform. This suite
+pins a refinement of Phase 1: the BODY may carry a client tenant's name in the
+header and credit MADFAM in the footer, while the From line does not move.
+
+The load-bearing guarantees, each with a test that fails loudly if it breaks:
+
+  * a CTM-context send still comes FROM MADFAM (the policy line)
+  * a non-CTM / unknown / absent signal renders TODAY's MADFAM frame
+  * the footer reads "Con tecnología de" (es) / "Powered by" (en), never
+    "Impulsado por"
+  * a CTM context puts "Crea Tu Mundo" in the header and MADFAM in the footer
+
+Style follows tests/unit/services/test_email_delivery.py: render templates
+directly and patch the transport with an AsyncMock rather than standing up a
+live provider.
+"""
+
+from email.utils import formataddr
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services import email_service as email_module
+from app.services.email_branding import (
+    CTM_ORG_ID,
+    MADFAM_BRANDING,
+    resolve_branding,
+)
+from app.services.email_service import EmailService, resolve_sender
+
+CTM_REDIRECT = "https://crea-map.madfam.io/portal/verify?next=/"
+
+
+# --------------------------------------------------------------------------
+# The resolver
+# --------------------------------------------------------------------------
+class TestResolveBranding:
+    def test_no_signal_is_madfam(self):
+        assert resolve_branding() == MADFAM_BRANDING
+        assert resolve_branding()["header_name"] == "MADFAM"
+        assert resolve_branding()["platform_name"] == "Janua"
+
+    def test_unknown_host_is_madfam(self):
+        b = resolve_branding(redirect_url="https://example.test/go?token=abc")
+        assert b["header_name"] == "MADFAM"
+
+    def test_madfam_own_host_stays_madfam(self):
+        """madfam.io is MADFAM's own host and must NOT resolve to a tenant."""
+        b = resolve_branding(redirect_url="https://app.madfam.io/x")
+        assert b["header_name"] == "MADFAM"
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://crea-map.madfam.io/portal/verify",
+            "https://ensayo-map.madfam.io/x",
+            "https://kalya.app/verify?token=abc",
+            "https://app.kalya.app/verify",  # subdomain of an allowed host
+        ],
+    )
+    def test_ctm_hosts_resolve_to_ctm(self, url):
+        b = resolve_branding(redirect_url=url)
+        assert b["header_name"] == "Crea Tu Mundo"
+        # Footer credits MADFAM (the platform underneath a client tenant).
+        assert b["platform_name"] == "MADFAM"
+        assert b["header_bg"] == "#1a2a8f"
+
+    def test_lookalike_host_does_not_match(self):
+        """Suffix match is on a dot boundary; `evilkalya.app` is not kalya."""
+        b = resolve_branding(redirect_url="https://evilkalya.app/x")
+        assert b["header_name"] == "MADFAM"
+
+    def test_org_id_resolves_ctm(self):
+        b = resolve_branding(org_id=CTM_ORG_ID)
+        assert b["header_name"] == "Crea Tu Mundo"
+
+    def test_org_id_takes_precedence_over_host(self):
+        """A caller that knows the org id is authoritative over the host."""
+        b = resolve_branding(
+            redirect_url="https://example.test/go", org_id=CTM_ORG_ID
+        )
+        assert b["header_name"] == "Crea Tu Mundo"
+
+    def test_resolver_never_returns_a_from_address(self):
+        """Branding must not carry anything usable as a sender."""
+        b = resolve_branding(redirect_url=CTM_REDIRECT)
+        for key in b:
+            assert "from" not in key.lower()
+            assert "sender" not in key.lower()
+            assert "email" not in key.lower()
+
+
+# --------------------------------------------------------------------------
+# The From line — the policy invariant
+# --------------------------------------------------------------------------
+class TestSenderNeverChanges:
+    def test_resolve_sender_is_madfam_for_ctm_redirect(self):
+        """resolve_sender ignores the redirect and returns MADFAM — always."""
+        name, address = resolve_sender(CTM_REDIRECT)
+        assert (name, address) == ("MADFAM", "hola@madfam.io")
+
+    @pytest.mark.asyncio
+    async def test_ctm_magic_link_still_sends_from_madfam(self):
+        """A CTM-branded magic link comes FROM MADFAM, not from CTM.
+
+        This is the policy line (EMAIL_SENDER_POLICY.md): BODY branding is
+        per-tenant, the sender is not. We drive the real send path and read the
+        From header off the Resend payload.
+        """
+        captured = {}
+
+        async def fake_post(url, headers=None, json=None):
+            captured["from"] = json["from"]
+
+            class _Resp:
+                status_code = 200
+                text = ""
+
+            return _Resp()
+
+        service = EmailService()
+        with patch.object(email_module.settings, "EMAIL_PROVIDER", "resend"), patch.object(
+            email_module.settings, "RESEND_API_KEY", "re_test_key"
+        ), patch("app.services.email_service.httpx.AsyncClient") as client_cls:
+            client = client_cls.return_value.__aenter__.return_value
+            client.post = AsyncMock(side_effect=fake_post)
+            sent = await service.send_magic_link_email(
+                "ana@creatumundo.mx",
+                "tok123",
+                redirect_url=CTM_REDIRECT,
+                locale="es",
+            )
+        assert sent is True
+        # From is MADFAM regardless of the CTM redirect.
+        assert captured["from"] == formataddr(("MADFAM", "hola@madfam.io"))
+
+    @pytest.mark.asyncio
+    async def test_ctm_body_is_branded_but_from_is_not(self):
+        """Same send: the HTML body carries CTM, the From carries MADFAM."""
+        captured = {}
+
+        async def fake_post(url, headers=None, json=None):
+            captured.update(json)
+
+            class _Resp:
+                status_code = 200
+                text = ""
+
+            return _Resp()
+
+        service = EmailService()
+        with patch.object(email_module.settings, "EMAIL_PROVIDER", "resend"), patch.object(
+            email_module.settings, "RESEND_API_KEY", "re_test_key"
+        ), patch("app.services.email_service.httpx.AsyncClient") as client_cls:
+            client = client_cls.return_value.__aenter__.return_value
+            client.post = AsyncMock(side_effect=fake_post)
+            await service.send_magic_link_email(
+                "ana@creatumundo.mx", "tok123", redirect_url=CTM_REDIRECT, locale="es"
+            )
+        assert captured["from"] == formataddr(("MADFAM", "hola@madfam.io"))
+        assert "Crea Tu Mundo" in captured["html"]
+        assert "Con tecnología de" in captured["html"]
+        assert "Impulsado por" not in captured["html"]
+
+
+# --------------------------------------------------------------------------
+# The rendered frame
+# --------------------------------------------------------------------------
+class TestRenderedFrame:
+    def _render(self, locale=None, branding_url=None):
+        service = EmailService()
+        ctx = {"magic_link": "https://x.test/a"}
+        if branding_url is not None:
+            ctx.update(resolve_branding(redirect_url=branding_url))
+        return service._render_template("magic_link.html", ctx, locale=locale)
+
+    def test_default_render_is_madfam_frame(self):
+        """No branding signal -> today's MADFAM header, byte-for-byte."""
+        html = self._render(locale="en")
+        assert (
+            '<h1 style="margin: 0; font-size: 24px; font-weight: 600;">MADFAM</h1>'
+            in html
+        )
+        assert "linear-gradient(135deg, #3b82f6 0%, #2563eb 100%)" in html
+        assert "#1a2a8f" not in html
+        # The MADFAM logo block is present for the MADFAM header.
+        assert 'alt="MADFAM"' in html
+
+    def test_default_es_footer_is_con_tecnologia_de_not_impulsado(self):
+        html = self._render(locale="es")
+        assert "Con tecnología de" in html
+        assert "Impulsado por" not in html
+
+    def test_ctm_header_reads_crea_tu_mundo(self):
+        html = self._render(locale="es", branding_url=CTM_REDIRECT)
+        assert "Crea Tu Mundo" in html
+        assert "#1a2a8f" in html
+
+    def test_ctm_header_drops_madfam_logo(self):
+        """CTM header is typographic — no MADFAM logo in the header segment."""
+        html = self._render(locale="es", branding_url=CTM_REDIRECT)
+        header_seg = html.split('class="content"')[0]
+        assert 'alt="MADFAM"' not in header_seg
+
+    def test_ctm_es_footer_credits_madfam_with_con_tecnologia_de(self):
+        html = self._render(locale="es", branding_url=CTM_REDIRECT)
+        assert "Con tecnología de" in html
+        assert "Impulsado por" not in html
+        # The credited platform is MADFAM (madfam.io link in the footer).
+        assert "madfam.io" in html
+
+    def test_ctm_en_footer_says_powered_by(self):
+        html = self._render(locale="en", branding_url=CTM_REDIRECT)
+        assert "Powered by" in html
+        assert "Impulsado" not in html

--- a/docs/EMAIL_SENDER_POLICY.md
+++ b/docs/EMAIL_SENDER_POLICY.md
@@ -63,6 +63,40 @@ Footer:  Con tecnología de MADFAM
 needs DNS records published — exactly what managing their web presence gives
 us. Without it, mail from their domain is spam-foldered or rejected.
 
+## Phase 1, refined — MADFAM sends, the BODY is the tenant's
+
+**2026-08-29.** The sender line above is untouched. What changed is the BODY:
+the header wordmark and palette may now read as the client's, with MADFAM
+credited underneath. A person signing into their own workspace sees their own
+name at the top of the sign-in mail; the envelope is still MADFAM's.
+
+```
+From:    MADFAM <hola@madfam.io>            (UNCHANGED — Phase 1)
+Header:  the tenant's name and palette      (e.g. "Crea Tu Mundo", indigo)
+Footer:  Con tecnología de MADFAM           ("Powered by MADFAM" in en)
+```
+
+This is a refinement of Phase 1, not the start of Phase 2. Phase 2 — the
+client's DOMAIN on the From line — remains gated on that domain being verified
+in Resend, exactly as below. Only the parts of the message that do not affect
+deliverability were made per-tenant.
+
+The resolver is `app/services/email_branding.py::resolve_branding()`. It keys on
+the magic-link `redirect_url` host (crea-map / kalya → CTM) or an explicit
+`org_id`, and returns the header name, header palette, and footer credit;
+everything else defaults to the MADFAM frame, so an unknown or absent signal
+renders exactly what it rendered before. It is deliberately kept separate from
+`resolve_sender`, and nothing it returns is ever used to build the From line —
+`tests/unit/services/test_email_branding.py` pins that a CTM-context send still
+comes from `MADFAM <hola@madfam.io>`.
+
+Why keyed on the redirect host rather than `WhiteLabelConfiguration`: the auth
+mailer runs in FastAPI BackgroundTasks with no DB session, so the org-branding
+table (keyed by `organization_id`) is not reachable at send time. The redirect
+host is the tenant signal that IS available — the same one Phase 2 will read.
+When a send path carries a session, `resolve_branding(org_id=…)` is the seam to
+hang the DB-backed config on.
+
 ## The seam that makes Phase 2 cheap
 
 `app/services/email_service.py::resolve_sender()` accepts `redirect_url` and


### PR DESCRIPTION
## What

Emails to a **Crea Tu Mundo (CTM)** tenant now read as **"Crea Tu Mundo"** in the body header (deep indigo `#1a2a8f` on cream, no MADFAM logo) and credit MADFAM in the footer via **"Con tecnología de MADFAM"** (es-MX) / "Powered by MADFAM" (en). Every other product/tenant keeps today's MADFAM frame, byte-identical.

This is a **refinement of Phase 1** of `docs/EMAIL_SENDER_POLICY.md`, **not Phase 2**.

## The invariant that matters: the From line does not move

The sender stays `MADFAM <hola@madfam.io>` for **every** message, CTM included. `resolve_sender()` is untouched, and **nothing the branding resolver returns is ever used to build the From line**. `tests/unit/services/test_email_branding.py::TestSenderNeverChanges::test_ctm_magic_link_still_sends_from_madfam` drives the real send path and asserts the Resend payload `from` is MADFAM even for a CTM redirect.

Footer uses **"Con tecnología de"** (es) / "Powered by" (en) — never "Impulsado por" (policy rule, EMAIL_SENDER_POLICY.md:81-83), pinned by tests.

## Resolution seam (per mailer)

- **Auth mailer (magic-link)** — new `app/services/email_branding.py::resolve_branding()` keys on the magic-link `redirect_url` host (`crea-map.madfam.io` / `ensayo-map.madfam.io` / `kalya.app` → CTM) or an explicit `org_id` (CTM org `e6cbd51d-…`). The auth mailer runs in FastAPI BackgroundTasks with **no DB session**, so the redirect host is the tenant signal available at send time — the same host `resolve_sender` was built to read. `org_id` is the precedence-1 seam for the DB-backed `WhiteLabelConfiguration` once a send path carries a session. `email_service.py::send_magic_link_email` merges the resolved branding into the template context.
- **`base.html`** — header wordmark and palette parametrized via `header_name` / `header_bg` / `header_fg`, all defaulting to the MADFAM values, so an unknown or absent signal renders exactly today's frame. The MADFAM logo block is shown only for the MADFAM header.
- **Template mailer (`/email/send-template`)** — From is settings-based (MADFAM); the client-facing `transactional_workspace-activated.html` footer normalized to "Con tecnología de MADFAM" (was missing "de"). These nauta templates are already fully caller-composed, so a CTM heading flows through the caller's variables without shared-template default changes.

## What varies for CTM vs stays MADFAM

| | CTM context | Everyone else / unknown |
|---|---|---|
| From line | `MADFAM <hola@madfam.io>` | `MADFAM <hola@madfam.io>` |
| Header wordmark | "Crea Tu Mundo" | "MADFAM" (+ logo) |
| Header palette | indigo `#1a2a8f` / cream | blue gradient / white |
| Footer credit | Con tecnología de **MADFAM** | Con tecnología de **Janua** (default) |

## Tests

`tests/unit/services/test_email_branding.py` — 20 cases: resolver (host/org-id/precedence/lookalike-host rejection/madfam.io-not-a-tenant), From-unchanged (2), rendered frame (MADFAM default no-regression, CTM header, footer phrase, en/es). All green. Full email suite (422) and email/magic scope (498) green; ran with `apps/api/.venv-test/bin/python -m pytest`.

## Flagged
- The DB-backed `WhiteLabelConfiguration` (keyed by `organization_id`) already exists but is **not reachable from the auth mailer** (BackgroundTasks, no DB session). This PR therefore keys branding on the redirect host + a static CTM registry, and leaves `org_id` as the documented seam to hang the DB config on once a send path carries a session. No new DB fields added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)