### PR TITLE
feat(email): add Crea + MADFAM logos to CTM auth emails

### DIFF
--- a/apps/api/app/services/email_branding.py
+++ b/apps/api/app/services/email_branding.py
@@ -54,18 +54,37 @@ MADFAM_BRANDING: Dict[str, str] = {
     "header_fg": "#ffffff",
     "platform_name": "Janua",
     "platform_url": "https://janua.dev",
+    # `header_logo_url` / `footer_logo_url` are the hotlinked brand marks. EMPTY
+    # for the MADFAM default: a MADFAM-branded message keeps its INLINE base64
+    # wordmark (base.html, gated on header_name == 'MADFAM') and needs no footer
+    # mark — the header already carries the brand. A client tenant sets these to
+    # the client's header mark and MADFAM's footer mark. Empty string, not a
+    # missing key, so the template's `if` is a plain truthiness test.
+    "header_logo_url": "",
+    "footer_logo_url": "",
 }
 
 # --------------------------------------------------------------------------
 # Crea Tu Mundo Autismo (CTM). Its canonical Janua org and the hosts its users
-# sign in through. Header reads the client's name in the client's palette;
-# footer credits MADFAM (the platform underneath a client tenant IS MADFAM,
-# so `platform_name` is MADFAM here, not Janua).
+# sign in through. Header reads the client's name in the client's palette and
+# carries the client's LOGO; footer credits MADFAM with the MADFAM mark (the
+# platform underneath a client tenant IS MADFAM, so `platform_name` is MADFAM
+# here, not Janua).
 #
-# CTM palette: deep royal indigo on a warm cream ground. Kept typographic on
-# purpose — no hotlinked logo (blocked by most clients) and no CID/inline
-# image (fiddly through Resend); a name in brand colors reads correctly
-# everywhere, including with images off.
+# CTM palette: deep royal indigo on a warm cream ground. The header logo is
+# the gold Crea mark with the indigo header ground BAKED IN (flat RGB PNG, no
+# alpha), the same asset the kalya booking emails carry and which is verified
+# to render in real inboxes (Proton, 2026-08-29). The client's own name in
+# brand colors remains the `<img>` alt text, so with images OFF the header
+# still reads "Crea Tu Mundo" — the logo is an enhancement over the
+# typographic frame, not a replacement for it.
+#
+# WHY HOTLINKED, NOT INLINE. The MADFAM default header ships an inline base64
+# PNG (blocked-image-proof). CTM's marks are hotlinked from crea-map.madfam.io
+# instead, deliberately: they are ALREADY LIVE and public there, they are the
+# byte-identical assets the kalya emails use (one source of truth for the CTM
+# brand across both mailers), and they proved to render in Proton. Keeping the
+# alt text as the brand name preserves the images-off case.
 # --------------------------------------------------------------------------
 CTM_ORG_ID = "e6cbd51d-8329-4c4e-8c74-aba643ab4575"
 
@@ -78,6 +97,11 @@ CTM_BRANDING: Dict[str, str] = {
     # The footer credits the platform, which for a client tenant is MADFAM.
     "platform_name": "MADFAM",
     "platform_url": "https://madfam.io",
+    # The gold Crea mark on the indigo header ground (60px, flat RGB, ~10KB),
+    # and the MADFAM mark for the "Con tecnología de MADFAM" footer (28px).
+    # Same public assets as the kalya booking emails (crea-map origin).
+    "header_logo_url": "https://crea-map.madfam.io/crea-logo-email.png",
+    "footer_logo_url": "https://crea-map.madfam.io/madfam-logo.png",
 }
 
 # Hosts whose sign-in redirect identifies a CTM user. Matched on exact host or

--- a/apps/api/app/templates/email/base.html
+++ b/apps/api/app/templates/email/base.html
@@ -122,6 +122,21 @@
                          style="display:block;margin:0 auto;border:0;outline:none;text-decoration:none;" />
                 </div>
                 {% endif %}
+                {% if header_logo_url | default('', true) %}
+                <!-- A client TENANT's own header mark (CTM's gold Crea logo on
+                     the indigo ground). HOTLINKED from crea-map.madfam.io — the
+                     same public asset the kalya booking emails carry, verified
+                     to render in real inboxes. The `alt` is the tenant name, so
+                     with images OFF this degrades to exactly the typographic
+                     wordmark below rather than to nothing. Only set for a
+                     client tenant (email_branding.py); the MADFAM default keeps
+                     its inline base64 mark above and leaves this empty. -->
+                <div class="logo">
+                    <img src="{{ header_logo_url }}"
+                         width="60" height="60" alt="{{ header_name | default('MADFAM', true) }}"
+                         style="display:block;margin:0 auto;border:0;outline:none;text-decoration:none;" />
+                </div>
+                {% endif %}
                 <!-- The wordmark. MADFAM by default, on every platform's own
                      message: bespoke clients meet several of our platforms over
                      an engagement, and a header that changes per PRODUCT reads
@@ -146,8 +161,17 @@
                 <!-- "Powered by" credits the platform without competing with the
                      MADFAM brand above. `platform_name`/`platform_url` default
                      to Janua so every existing caller renders correctly; a
-                     platform that passes its own gets its own. -->
+                     platform that passes its own gets its own. For a client
+                     tenant, `footer_logo_url` sets the MADFAM mark that sits
+                     beside the credit — the same 28px mark the kalya booking
+                     emails use; its `alt` carries the name for images-off. The
+                     MADFAM default leaves it empty (the header already carries
+                     the MADFAM brand, so a footer mark would be redundant). -->
                 <p style="margin: 0 0 10px 0; font-size: 12px; opacity: 0.75;">
+                    {% if footer_logo_url | default('', true) %}
+                    <img src="{{ footer_logo_url }}" width="28" height="28" alt="{{ platform_name | default('Janua', true) }}"
+                         style="display:inline-block;border:0;vertical-align:middle;margin-right:6px;" />
+                    {% endif %}
                     {{ t('powered_by') }}
                     <a href="{{ platform_url | default('https://janua.dev', true) }}">{{ platform_name | default('Janua', true) }}</a>
                 </p>

--- a/apps/api/tests/unit/services/test_email_branding.py
+++ b/apps/api/tests/unit/services/test_email_branding.py
@@ -67,6 +67,17 @@ class TestResolveBranding:
         # Footer credits MADFAM (the platform underneath a client tenant).
         assert b["platform_name"] == "MADFAM"
         assert b["header_bg"] == "#1a2a8f"
+        # CTM carries the client's header mark and MADFAM's footer mark (the
+        # same public crea-map assets the kalya booking emails use).
+        assert b["header_logo_url"] == "https://crea-map.madfam.io/crea-logo-email.png"
+        assert b["footer_logo_url"] == "https://crea-map.madfam.io/madfam-logo.png"
+
+    def test_madfam_default_has_no_hotlinked_logos(self):
+        """The MADFAM default keeps its INLINE mark; the hotlinked slots are
+        empty so nothing changes for existing callers."""
+        b = resolve_branding()
+        assert b["header_logo_url"] == ""
+        assert b["footer_logo_url"] == ""
 
     def test_lookalike_host_does_not_match(self):
         """Suffix match is on a dot boundary; `evilkalya.app` is not kalya."""
@@ -200,10 +211,30 @@ class TestRenderedFrame:
         assert "#1a2a8f" in html
 
     def test_ctm_header_drops_madfam_logo(self):
-        """CTM header is typographic — no MADFAM logo in the header segment."""
+        """CTM header carries the CREA mark, never the MADFAM one. The MADFAM
+        inline logo (alt="MADFAM") must not appear in the header segment; the
+        Crea mark (alt="Crea Tu Mundo") is what's there instead."""
         html = self._render(locale="es", branding_url=CTM_REDIRECT)
         header_seg = html.split('class="content"')[0]
         assert 'alt="MADFAM"' not in header_seg
+        # The CTM header carries the Crea mark (hotlinked, alt = the brand name).
+        assert "crea-logo-email.png" in header_seg
+        assert 'alt="Crea Tu Mundo"' in header_seg
+
+    def test_ctm_footer_carries_madfam_mark(self):
+        """The CTM footer credits MADFAM WITH the MADFAM mark, in the footer
+        segment (below the content), so the header-segment assertions above are
+        unaffected."""
+        html = self._render(locale="es", branding_url=CTM_REDIRECT)
+        footer_seg = html.split('class="content"')[-1]
+        assert "madfam-logo.png" in footer_seg
+
+    def test_default_render_has_no_hotlinked_logos(self):
+        """No branding signal -> the inline MADFAM mark only; neither hotlinked
+        CTM asset appears."""
+        html = self._render(locale="en")
+        assert "crea-logo-email.png" not in html
+        assert "madfam-logo.png" not in html
 
     def test_ctm_es_footer_credits_madfam_with_con_tecnologia_de(self):
         html = self._render(locale="es", branding_url=CTM_REDIRECT)


### PR DESCRIPTION
## What

The magic-link **login** email (and every janua auth email that resolves to a CTM redirect host) already carried CTM per-tenant **BODY branding** from #577 — header reads "Crea Tu Mundo" in the CTM indigo palette, footer credits "Con tecnología de MADFAM", and the From line stays `MADFAM <hola@madfam.io>`. But it was **typographic-only**: no logo images.

Meanwhile the **kalya booking** emails now render both the gold Crea header mark and the MADFAM footer mark in real inboxes (verified in Proton, 2026-08-29). The standing agreement is that **all Crea Tu Mundo emails carry the corresponding logos**, so the two mailers should match.

## Change

Adds the **same public assets kalya uses** — one source of truth for the CTM brand across both mailers, already live and public on `crea-map.madfam.io`:

| Slot | CTM value | MADFAM default |
|------|-----------|----------------|
| `header_logo_url` | `crea-logo-email.png` (gold Crea mark on indigo, flat RGB, 60px, ~10KB) | `""` (keeps inline base64 wordmark) |
| `footer_logo_url` | `madfam-logo.png` (MADFAM mark beside the credit, 28px) | `""` (header already carries MADFAM brand) |

Both are resolved by `email_branding.resolve_branding` and rendered in `base.html` behind a truthiness guard, with the brand name as the `<img>` `alt` so an **images-off** client degrades to exactly the existing typographic frame.

## Invariants preserved (and pinned by tests)

- ✅ MADFAM default renders **byte-identically** — inline base64 wordmark, blue gradient, no hotlinked assets. No change for any existing caller.
- ✅ CTM header carries the **Crea** mark, never the MADFAM one (`test_ctm_header_drops_madfam_logo` still holds — the MADFAM footer mark lives in the footer segment, out of the header split).
- ✅ **From line unaffected** — branding never builds the sender (`resolve_sender` stays MADFAM).
- ✅ Footer stays "Con tecnología de" / "Powered by", never "Impulsado por".

## Verification

- Rendered the **actual HTML** for both the CTM and MADFAM cases and inspected header + footer segments directly (per the hard-won lesson: view real HTML, don't theorize about the client).
- Both assets confirmed live: `curl` → `200 image/png` (10453 / 3800 bytes), byte-identical to the local files, same URLs proven to render in this Proton inbox via kalya.
- `tests/unit/services/test_email_branding.py` extended with logo assertions — **23 passed**.

## Policy

Consistent with `docs/EMAIL_SENDER_POLICY.md` Phase 1: sender stays MADFAM, body carries the client tenant's identity, MADFAM credited underneath. This is a body-branding refinement, not Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)